### PR TITLE
Condition CSV Extractor

### DIFF
--- a/docs/condition.csv
+++ b/docs/condition.csv
@@ -1,0 +1,3 @@
+mrn,conditionId,subjectId,codeSystem,code
+mrn-1,conditionId-1,subjectId-1,example-code-system,example-code
+mrn-2,conditionId-2,subjectId-2,example-code-system,example-code

--- a/docs/condition.csv
+++ b/docs/condition.csv
@@ -1,3 +1,3 @@
-mrn,conditionId,subjectId,codeSystem,code
-mrn-1,conditionId-1,subjectId-1,example-code-system,example-code
-mrn-2,conditionId-2,subjectId-2,example-code-system,example-code
+mrn,conditionId,codeSystem,code
+mrn-1,conditionId-1,example-code-system,example-code
+mrn-2,conditionId-2,example-code-system,example-code

--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -1,0 +1,45 @@
+const { CSVModule } = require('../modules');
+const { generateMcodeResources } = require('../helpers/ejsUtils');
+const { Extractor } = require('./Extractor');
+const logger = require('../helpers/logger');
+
+// Formats data to be passed into template-friendly format
+function formatData(conditionData) {
+  return conditionData.map((data) => {
+    const { conditionId, subjectId, codeSystem, code } = data;
+
+    return {
+      id: conditionId,
+      subject: {
+        id: subjectId,
+      },
+      code: {
+        code,
+        system: codeSystem,
+      },
+    };
+  });
+}
+
+class CSVConditionExtractor extends Extractor {
+  constructor(conditionCSVPath) {
+    super();
+    this.csvModule = new CSVModule(conditionCSVPath);
+  }
+
+  async getConditionData(mrn) {
+    logger.info('Getting Condition Data');
+    return this.csvModule.get('mrn', mrn);
+  }
+
+  async get({ mrn }) {
+    const conditionData = await this.getConditionData(mrn);
+    const formattedData = formatData(conditionData);
+
+    return generateMcodeResources('Condition', formattedData);
+  }
+}
+
+module.exports = {
+  CSVConditionExtractor,
+};

--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -6,12 +6,12 @@ const logger = require('../helpers/logger');
 // Formats data to be passed into template-friendly format
 function formatData(conditionData) {
   return conditionData.map((data) => {
-    const { conditionId, subjectId, codeSystem, code } = data;
+    const { mrn, conditionId, codeSystem, code } = data;
 
     return {
       id: conditionId,
       subject: {
-        id: subjectId,
+        id: mrn,
       },
       code: {
         code,

--- a/src/extractors/index.js
+++ b/src/extractors/index.js
@@ -1,6 +1,7 @@
 const { BaseFHIRExtractor } = require('./BaseFHIRExtractor');
 const { CSVCancerDiseaseStatusExtractor } = require('./CSVCancerDiseaseStatusExtractor');
 const { CSVClinicalTrialInformationExtractor } = require('./CSVClinicalTrialInformationExtractor');
+const { CSVConditionExtractor } = require('./CSVConditionExtractor');
 const { CSVPatientExtractor } = require('./CSVPatientExtractor');
 const { CSVTreatmentPlanChangeExtractor } = require('./CSVTreatmentPlanChangeExtractor');
 const { Extractor } = require('./Extractor');
@@ -8,8 +9,9 @@ const { Extractor } = require('./Extractor');
 module.exports = {
   BaseFHIRExtractor,
   CSVCancerDiseaseStatusExtractor,
-  CSVPatientExtractor,
   CSVClinicalTrialInformationExtractor,
+  CSVConditionExtractor,
+  CSVPatientExtractor,
   CSVTreatmentPlanChangeExtractor,
   Extractor,
 };

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -9,6 +9,7 @@ const logger = require('./logger');
 const fhirTemplateLookup = {
   CancerDiseaseStatus: fs.readFileSync(path.join(__dirname, '../templates/CancerDiseaseStatus.ejs'), 'utf8'),
   CarePlanWithReview: fs.readFileSync(path.join(__dirname, '../templates/CarePlanWithReview.ejs'), 'utf8'),
+  Condition: fs.readFileSync(path.join(__dirname, '../templates/Condition.ejs'), 'utf8'),
   Patient: fs.readFileSync(path.join(__dirname, '../templates/Patient.ejs'), 'utf8'),
   ResearchStudy: fs.readFileSync(path.join(__dirname, '../templates/ResearchStudy.ejs'), 'utf8'),
   ResearchSubject: fs.readFileSync(path.join(__dirname, '../templates/ResearchSubject.ejs'), 'utf8'),

--- a/src/templates/Condition.ejs
+++ b/src/templates/Condition.ejs
@@ -1,0 +1,52 @@
+<%# Condition Template %>
+<%# Based on https://mcodeinitiative.github.io/StructureDefinition-obf-Condition.html %>
+<%# Official url: http://hl7.org/fhir/us/mcode/StructureDefinition/obf-Condition %>
+<% /* %>
+{
+  id: String,
+  subject: {
+    id: String,
+    name: String,
+  },
+  code: {
+    system: String,
+    code: String,
+    display: String,
+  },
+}
+<% */ %>
+{
+  "resourceType": "Condition",
+  "id": "<%- id %>",
+  "subject" : {
+    "reference": "Patient/<%- subject.id %>"<% if (subject.name) { %>,
+    "display": "<%- subject.name %>"
+    <% } %>
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "<%- code.system %>",
+        "code": "<%- code.code %>"<% if (code.display) { %>,
+        "display": "<%- code.display %>"
+        <% } %>
+      }
+    ]
+  },
+  "category": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+        "code": "encounter-diagnosis"
+      }
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "code": "confirmed"
+      }
+    ]
+  }
+}

--- a/src/templates/Condition.ejs
+++ b/src/templates/Condition.ejs
@@ -37,7 +37,7 @@
     "coding": [
       {
         "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-        "code": "encounter-diagnosis"
+        "code": "problem-list-item"
       }
     ]
   },

--- a/src/templates/Condition.ejs
+++ b/src/templates/Condition.ejs
@@ -33,18 +33,20 @@
       }
     ]
   },
-  "category": {
-    "coding": [
-      {
-        "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-        "code": "problem-list-item"
-      }
-    ]
-  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "problem-list-item"
+        }
+      ]
+    }
+  ],
   "verificationStatus": {
     "coding": [
       {
-        "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
         "code": "confirmed"
       }
     ]

--- a/test/extractors/CSVConditionExtractor.test.js
+++ b/test/extractors/CSVConditionExtractor.test.js
@@ -4,7 +4,7 @@ const exampleConditionResponse = require('./fixtures/csv-condition-module-respon
 const exampleConditionBundle = require('./fixtures/csv-condition-bundle.json');
 
 // Constants for mock tests
-const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
+const MOCK_PATIENT_MRN = 'mrn-1';
 const MOCK_CSV_PATH = path.join(__dirname, 'fixtures/example.csv'); // need a valid path/csv here to avoid parse error
 const csvConditionExtractor = new CSVConditionExtractor(MOCK_CSV_PATH);
 

--- a/test/extractors/CSVConditionExtractor.test.js
+++ b/test/extractors/CSVConditionExtractor.test.js
@@ -1,0 +1,28 @@
+const path = require('path');
+const { CSVConditionExtractor } = require('../../src/extractors');
+const exampleConditionResponse = require('./fixtures/csv-condition-module-response.json');
+const exampleConditionBundle = require('./fixtures/csv-condition-bundle.json');
+
+// Constants for mock tests
+const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
+const MOCK_CSV_PATH = path.join(__dirname, 'fixtures/example.csv'); // need a valid path/csv here to avoid parse error
+const csvConditionExtractor = new CSVConditionExtractor(MOCK_CSV_PATH);
+
+const { csvModule } = csvConditionExtractor;
+
+// Spy on csvModule
+const csvModuleSpy = jest.spyOn(csvModule, 'get');
+csvModuleSpy
+  .mockReturnValue(exampleConditionResponse);
+
+describe('CSV Condition Extractor tests', () => {
+  test('get should return a fhir bundle when MRN is known', async () => {
+    const data = await csvConditionExtractor.get({ mrn: MOCK_PATIENT_MRN });
+
+    expect(data.resourceType).toEqual('Bundle');
+    expect(data.type).toEqual('collection');
+    expect(data.entry).toBeDefined();
+    expect(data.entry.length).toEqual(1);
+    expect(data).toEqual(exampleConditionBundle);
+  });
+});

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -13,18 +13,20 @@
             { "system": "example-code-system", "code": "example-code" }
           ]
         },
-        "category": {
-          "coding": [
-            {
-              "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-              "code": "problem-list-item"
-            }
-          ]
-        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "problem-list-item"
+              }
+            ]
+          }
+        ],
         "verificationStatus": {
           "coding": [
             {
-              "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
               "code": "confirmed"
             }
           ]

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -17,7 +17,7 @@
           "coding": [
             {
               "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-              "code": "encounter-diagnosis"
+              "code": "problem-list-item"
             }
           ]
         },

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -7,7 +7,7 @@
       "resource": {
         "resourceType": "Condition",
         "id": "conditionId-1",
-        "subject": { "reference": "Patient/subjectId-1" },
+        "subject": { "reference": "Patient/mrn-1" },
         "code": {
           "coding": [
             { "system": "example-code-system", "code": "example-code" }

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:conditionId-1",
+      "resource": {
+        "resourceType": "Condition",
+        "id": "conditionId-1",
+        "subject": { "reference": "Patient/subjectId-1" },
+        "code": {
+          "coding": [
+            { "system": "example-code-system", "code": "example-code" }
+          ]
+        },
+        "category": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+              "code": "encounter-diagnosis"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+              "code": "confirmed"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/test/extractors/fixtures/csv-condition-module-response.json
+++ b/test/extractors/fixtures/csv-condition-module-response.json
@@ -1,0 +1,9 @@
+[
+  {
+    "mrn": "mrn-1",
+    "conditionId": "conditionId-1",
+    "subjectId": "subjectId-1",
+    "codeSystem": "example-code-system",
+    "code": "example-code"
+  }
+]

--- a/test/extractors/fixtures/csv-condition-module-response.json
+++ b/test/extractors/fixtures/csv-condition-module-response.json
@@ -2,7 +2,6 @@
   {
     "mrn": "mrn-1",
     "conditionId": "conditionId-1",
-    "subjectId": "subjectId-1",
     "codeSystem": "example-code-system",
     "code": "example-code"
   }

--- a/test/templates/condition.test.js
+++ b/test/templates/condition.test.js
@@ -1,0 +1,42 @@
+const fs = require('fs');
+const path = require('path');
+const validExampleCondition = require('./fixtures/condition-resource.json');
+const { renderTemplate } = require('../../src/helpers/ejsUtils');
+
+const CONDITION_VALID_DATA = {
+  id: 'example-id',
+  subject: {
+    id: 'example-subject-id',
+  },
+  code: {
+    system: 'example-system',
+    code: 'example-code',
+  },
+};
+
+const CONDITION_INVALID_DATA = {
+  // Omitting 'subject' field which is required
+  id: 'example-id',
+  code: {
+    system: 'example-system',
+    code: 'example-code',
+  },
+};
+
+const CONDITION_TEMPLATE = fs.readFileSync(path.join(__dirname, '../../src/templates/Condition.ejs'), 'utf8');
+
+describe('test Condition template', () => {
+  test('valid data passed into template should generate FHIR resource', () => {
+    const generateCondition = renderTemplate(
+      CONDITION_TEMPLATE,
+      CONDITION_VALID_DATA,
+    );
+    expect(generateCondition.id).toEqual(validExampleCondition.id);
+    expect(generateCondition.code).toEqual(validExampleCondition.code);
+    expect(generateCondition.subject).toEqual(validExampleCondition.subject);
+  });
+
+  test('invalid data should throw an error', () => {
+    expect(() => renderTemplate(CONDITION_TEMPLATE, CONDITION_INVALID_DATA)).toThrow(ReferenceError);
+  });
+});

--- a/test/templates/condition.test.js
+++ b/test/templates/condition.test.js
@@ -31,9 +31,8 @@ describe('test Condition template', () => {
       CONDITION_TEMPLATE,
       CONDITION_VALID_DATA,
     );
-    expect(generateCondition.id).toEqual(validExampleCondition.id);
-    expect(generateCondition.code).toEqual(validExampleCondition.code);
-    expect(generateCondition.subject).toEqual(validExampleCondition.subject);
+
+    expect(generateCondition).toEqual(validExampleCondition);
   });
 
   test('invalid data should throw an error', () => {

--- a/test/templates/fixtures/condition-resource.json
+++ b/test/templates/fixtures/condition-resource.json
@@ -16,7 +16,7 @@
     "coding": [
       {
         "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-        "code": "encounter-diagnosis"
+        "code": "problem-list-item"
       }
     ]
   },

--- a/test/templates/fixtures/condition-resource.json
+++ b/test/templates/fixtures/condition-resource.json
@@ -1,0 +1,31 @@
+{
+  "resourceType": "Condition",
+  "id": "example-id",
+  "subject" : {
+    "reference": "Patient/example-subject-id"
+  },
+  "code": {
+    "coding": [
+      {
+        "system": "example-system",
+        "code": "example-code"
+      }
+    ]
+  },
+  "category": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
+        "code": "encounter-diagnosis"
+      }
+    ]
+  },
+  "verificationStatus": {
+    "coding": [
+      {
+        "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "code": "confirmed"
+      }
+    ]
+  }
+}

--- a/test/templates/fixtures/condition-resource.json
+++ b/test/templates/fixtures/condition-resource.json
@@ -12,18 +12,20 @@
       }
     ]
   },
-  "category": {
-    "coding": [
-      {
-        "system": "http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category",
-        "code": "problem-list-item"
-      }
-    ]
-  },
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+          "code": "problem-list-item"
+        }
+      ]
+    }
+  ],
   "verificationStatus": {
     "coding": [
       {
-        "system": "http://hl7.org/fhir/ValueSet/condition-ver-status",
+        "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
         "code": "confirmed"
       }
     ]


### PR DESCRIPTION
# Summary
Added CSV format for condition information and extractor to retrieve data.
## New behavior
New CSV extractor to extract condition data
## Code changes
- Added EJS template and test for Condition resource
    - `category` and `verificationStatus` were required fields. I gave them values of `encountered-diagnosis` and `confirmed` in the template. Did we want different values here? Did we want to include this in the CSV format?
- Added `CSVConditionExtractor`
# Testing guidance
- Review CSV format
    - I put `codeSystem` and `code` as separate values for easier parsing. Did we want to combine these into one value that we would parse (e.g. value would be `system: code`)?
    - Did we want to only allow codes from one system in which case we would only have a `code` value in the csv format?
- Ensure tests pass