### PR TITLE
Context Aware Extractors

### DIFF
--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -3,7 +3,6 @@ const { BaseFHIRModule } = require('../modules');
 const { determineVersion, mapFHIRVersions, isBundleEmpty, getBundleResourcesByType } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
-// eslint-disable-next-line no-unused-vars
 function parseContextForPatientId(context) {
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   return patientInContext ? patientInContext.id : undefined;

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -1,12 +1,12 @@
 const { Extractor } = require('./Extractor');
 const { BaseFHIRModule } = require('../modules');
-const { determineVersion, mapFHIRVersions, isBundleEmpty } = require('../helpers/fhirUtils');
+const { determineVersion, mapFHIRVersions, isBundleEmpty, getBundleResourcesByType } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 // eslint-disable-next-line no-unused-vars
 function parseContextForPatientId(context) {
-  // TODO: Sync with Dan
-  return undefined;
+  const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
+  return patientInContext ? patientInContext.id : undefined;
 }
 
 class BaseFHIRExtractor extends Extractor {

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -29,7 +29,13 @@ function joinClinicalTrialData(patientId, clinicalTrialData) {
 
 function getPatientId(context) {
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
-  return patientInContext ? patientInContext.id : undefined;
+  if (patientInContext) {
+    logger.info('Patient resource found in context.');
+    return patientInContext.id;
+  }
+
+  logger.info('No patient resource found in context.');
+  return undefined;
 }
 
 class CSVClinicalTrialInformationExtractor extends Extractor {

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const { Extractor } = require('./Extractor');
 const { CSVModule } = require('../modules');
-const { firstEntryInBundle } = require('../helpers/fhirUtils');
+const { firstEntryInBundle, getBundleResourcesByType } = require('../helpers/fhirUtils');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
 const logger = require('../helpers/logger');
 
@@ -27,12 +27,9 @@ function joinClinicalTrialData(patientId, clinicalTrialData) {
   };
 }
 
-// eslint-disable-next-line no-unused-vars
-function getPatientId(contextBundle) {
-  // When context enabled:
-  // Use FHIR path to get patient resource off bundle (and remove eslint-disable)
-  // If patient, get id off of that, return id;
-  // If no patient, return;
+function getPatientId(context) {
+  const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
+  return patientInContext ? patientInContext.id : undefined;
 }
 
 class CSVClinicalTrialInformationExtractor extends Extractor {
@@ -48,8 +45,8 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
     return data[0];
   }
 
-  async get({ mrn, contextBundle }) {
-    const patientId = getPatientId(contextBundle) || mrn;
+  async get({ mrn, context }) {
+    const patientId = getPatientId(context) || mrn;
     const clinicalTrialData = await this.getClinicalTrialData(mrn);
 
     // Format data for research study and research subject

--- a/src/helpers/conditionUtils.js
+++ b/src/helpers/conditionUtils.js
@@ -48,7 +48,7 @@ function isConditionSecondary(condition) {
 }
 
 module.exports = {
+  getICD10Code,
   isConditionPrimary,
   isConditionSecondary,
-  getICD10Code,
 };

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -43,6 +43,6 @@ function generateMcodeResources(mcodeProfileID, data) {
 }
 
 module.exports = {
-  renderTemplate,
   generateMcodeResources,
+  renderTemplate,
 };

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -49,11 +49,11 @@ const getBundleResourcesByType = (bundle, type, context = {}, first) => {
 };
 
 module.exports = {
-  isBundleEmpty,
-  firstEntryInBundle,
-  firstResourceInBundle,
   allResourcesInBundle,
   determineVersion,
-  mapFHIRVersions,
+  firstEntryInBundle,
+  firstResourceInBundle,
   getBundleResourcesByType,
+  isBundleEmpty,
+  mapFHIRVersions,
 };

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -1,3 +1,5 @@
+const fhirpath = require('fhirpath');
+
 function isBundleEmpty(bundle) {
   return bundle.total === 0;
 }
@@ -30,6 +32,22 @@ function mapFHIRVersions(resource, currentVersion, targetVersion) {
   return resource;
 }
 
+// Utility function to get the resources of a type from our bundle
+// Optionally get only the first resource of that type via 'first' parameter
+const getBundleResourcesByType = (bundle, type, context = {}, first) => {
+  const resources = fhirpath.evaluate(
+    bundle,
+    `Bundle.entry.where(resource.resourceType='${type}').resource`,
+    context,
+  );
+
+  if (resources.length > 0) {
+    return first ? resources[0] : resources;
+  }
+
+  return first ? null : [];
+};
+
 module.exports = {
   isBundleEmpty,
   firstEntryInBundle,
@@ -37,4 +55,5 @@ module.exports = {
   allResourcesInBundle,
   determineVersion,
   mapFHIRVersions,
+  getBundleResourcesByType,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,13 @@ const {
 } = require('./extractors');
 const { BaseFHIRModule, CSVModule } = require('./modules');
 const { getPatientName } = require('./helpers/patientUtils');
-const { allResourcesInBundle, firstEntryInBundle, firstResourceInBundle, isBundleEmpty } = require('./helpers/fhirUtils');
+const {
+  allResourcesInBundle,
+  firstEntryInBundle,
+  firstResourceInBundle,
+  getBundleResourcesByType,
+  isBundleEmpty,
+} = require('./helpers/fhirUtils');
 const { generateMcodeResources } = require('./helpers/ejsUtils');
 const { isConditionPrimary, isConditionSecondary, getICD10Code } = require('./helpers/conditionUtils');
 const { getDiseaseStatusCode } = require('./helpers/diseaseStatusUtils');
@@ -47,6 +53,7 @@ module.exports = {
   firstResourceInBundle,
   getDiseaseStatusCode,
   generateMcodeResources,
+  getBundleResourcesByType,
   getICD10Code,
   getPatientName,
   isBundleEmpty,

--- a/src/index.js
+++ b/src/index.js
@@ -31,11 +31,11 @@ const { getDiseaseStatusCode } = require('./helpers/diseaseStatusUtils');
 
 module.exports = {
   BaseFHIRExtractor,
-  CSVModule,
   BaseFHIRModule,
   CSVCancerDiseaseStatusExtractor,
   CSVClinicalTrialInformationExtractor,
   CSVConditionExtractor,
+  CSVModule,
   CSVPatientExtractor,
   CSVTreatmentPlanChangeExtractor,
   Extractor,
@@ -51,9 +51,9 @@ module.exports = {
   allResourcesInBundle,
   firstEntryInBundle,
   firstResourceInBundle,
-  getDiseaseStatusCode,
   generateMcodeResources,
   getBundleResourcesByType,
+  getDiseaseStatusCode,
   getICD10Code,
   getPatientName,
   isBundleEmpty,

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -24,6 +24,7 @@ csvModuleSpy
   .mockReturnValue(exampleClinicalTrialInformationResponse);
 
 const joinClinicalTrialData = rewire('../../src/extractors/CSVClinicalTrialInformationExtractor.js').__get__('joinClinicalTrialData');
+const getPatientId = rewire('../../src/extractors/CSVClinicalTrialInformationExtractor.js').__get__('getPatientId');
 
 describe('CSVClinicalTrialInformationExtractor', () => {
   test('should join clinical trial data appropriately', () => {
@@ -55,6 +56,31 @@ describe('CSVClinicalTrialInformationExtractor', () => {
         trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
       },
     });
+  });
+
+  test('should return patient id when patient resource in context', () => {
+    const contextPatient = {
+      resourceType: 'Patient',
+      id: 'context-patient-id',
+    };
+    const contextBundle = {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: [
+        {
+          fullUrl: 'context-url',
+          resource: contextPatient,
+        },
+      ],
+    };
+
+    const patientId = getPatientId(contextBundle);
+    expect(patientId).toEqual(contextPatient.id);
+  });
+
+  test('getPatientId should return undefined when no patient resource in context', () => {
+    const patientId = getPatientId({});
+    expect(patientId).toBeUndefined();
   });
 
   test('should return a bundle with the correct resources', async () => {


### PR DESCRIPTION
# Summary
Extractors now parse context bundle for resources

## New behavior
- Added helper function in `fhirUtils` to use `fhirpath` to search for resources in bundle
- Added logic to parse context bundle in `BaseFHIRExtractor` and `CSVClinicalTrialInformationExtractor`
- Added tests to make sure resources are being retrieved from context instead of from fhir module.
# Testing guidance
- Ensure tests pass
- Ensure quality of the code
- Run the CSV Client
   - Make sure to update the `package.json` to point to the `context-aware` branch.
   - In the log statements when the `CSVClinicalTrialInformationExtractor` is running, it should log that patient resource is found in context.
   - The resulting bundle generated by the client should use the patient id for the research subject instead of the mrn.
