### PR TITLE
Remove subject ID from CSV extractors, use MRN instead

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,3 +1,3 @@
-mrn,subjectId,conditionId,diseaseStatus,dateOfObservation
-pat-mrn-1,subjectId-1,cond-1,responding,12/2/19
-pat-mrn-2,subjectId-2,cond-2,responding,12/2/19
+mrn,conditionId,diseaseStatus,dateOfObservation
+pat-mrn-1,cond-1,responding,12/2/19
+pat-mrn-2,cond-2,responding,12/2/19

--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,patientId,family,given,gender
-pat-mrn-1,pat-id-1,last,first,female
-pat-mrn-2,pat-id-2,final,preceding,male
+mrn,family,given,gender
+pat-mrn-1,last,first,female
+pat-mrn-2,final,preceding,male

--- a/docs/treatment-plan-change.csv
+++ b/docs/treatment-plan-change.csv
@@ -1,3 +1,3 @@
-mrn,subjectId,reasonCode,changed,dateOfCarePlan
-mrn-1,subjectId-1,281647001,true,04/15/2020
-mrn-2,subjectId-2,281647001,true,03/30/2020
+mrn,reasonCode,changed,dateOfCarePlan
+mrn-1,281647001,true,04/15/2020
+mrn-2,281647001,true,03/30/2020

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -9,8 +9,8 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
   // No join needed - just reformatting for template
   // Check the shape of the data
   arrOfDiseaseStatusData.forEach((record) => {
-    if (!(record.mrn && record.subjectId && record.conditionId && record.diseaseStatus && record.dateOfObservation)) {
-      throw new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.');
+    if (!(record.mrn && record.conditionId && record.diseaseStatus && record.dateOfObservation)) {
+      throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.');
     }
   });
   return arrOfDiseaseStatusData.map((record) => ({
@@ -22,7 +22,7 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
       display: record.diseaseStatus,
     },
     subject: {
-      id: record.subjectId,
+      id: record.mrn,
     },
     condition: {
       id: record.conditionId,

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -7,12 +7,10 @@ const logger = require('../helpers/logger');
 function joinAndReformatData(patientData) {
   logger.info('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
-  const {
-    mrn, patientId, family, given, gender,
-  } = patientData;
+  const { mrn, family, given, gender } = patientData;
 
   return {
-    id: patientId,
+    id: mrn,
     mrn,
     family,
     given,

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -7,9 +7,9 @@ const logger = require('../helpers/logger');
 // Formats data to be passed into template-friendly format
 function formatData(tpcData) {
   return tpcData.map((data) => {
-    const { dateOfCarePlan, changed, reasonCode, subjectId } = data;
-    if (!dateOfCarePlan || !changed || !reasonCode || !subjectId) {
-      throw new Error('Treatment Plan Change Data missing an expected property: dateOfCarePlan, subjectId, reasonCode, changed are required');
+    const { mrn, dateOfCarePlan, changed, reasonCode } = data;
+    if (!mrn || !dateOfCarePlan || !changed || !reasonCode) {
+      throw new Error('Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required');
     }
 
     return {
@@ -22,7 +22,7 @@ function formatData(tpcData) {
         },
       },
       subject: {
-        id: subjectId,
+        id: mrn,
       },
     };
   });

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -34,35 +34,28 @@ test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
   // Test all required properties are
   delete localData[0].mrn;
   expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.'),
+    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
   );
   localData[0].mrn = exampleCSVDiseaseStatusModuleResponse[0].mrn;
   expect(joinAndReformatData(localData)).toEqual(expect.anything());
 
-  delete localData[0].subjectId;
-  expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.'),
-  );
-  localData[0].subjectId = exampleCSVDiseaseStatusModuleResponse[0].subjectId;
-  expect(joinAndReformatData(localData)).toEqual(expect.anything());
-
   delete localData[0].conditionId;
   expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.'),
+    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
   );
   localData[0].conditionId = exampleCSVDiseaseStatusModuleResponse[0].conditionId;
   expect(joinAndReformatData(localData)).toEqual(expect.anything());
 
   delete localData[0].diseaseStatus;
   expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.'),
+    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
   );
   localData[0].diseaseStatus = exampleCSVDiseaseStatusModuleResponse[0].diseaseStatus;
   expect(joinAndReformatData(localData)).toEqual(expect.anything());
 
   delete localData[0].dateOfObservation;
   expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, subjectId, conditionId, diseaseStatus and dateOfObservation are required.'),
+    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
   );
   localData[0].dateOfObservation = exampleCSVDiseaseStatusModuleResponse[0].dateOfObservation;
   expect(joinAndReformatData(localData)).toEqual(expect.anything());

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -21,13 +21,13 @@ csvModuleSpy
 const formatData = rewire('../../src/extractors/CSVTreatmentPlanChangeExtractor.js').__get__('formatData');
 
 test('format data from CSV', () => {
-  const expectedErrorString = 'Treatment Plan Change Data missing an expected property: dateOfCarePlan, subjectId, reasonCode, changed are required';
+  const expectedErrorString = 'Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required';
   const exampleData = [
     {
       dateOfCarePlan: '04/15/2020',
       changed: true,
       reasonCode: 'exampleCode',
-      subjectId: 'id',
+      mrn: 'id',
     },
   ];
 

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:c0782423117bcafaa74fd5e1aef1d5525a0479c6427cd23387ff1c16105db13b",
+      "fullUrl": "urn:uuid:b7e26f3bb795a02703c2619fb7ed9155e011572c4c05434e6fd3cfe32bb0d1cd",
       "resource": {
         "resourceType": "Observation",
-        "id": "c0782423117bcafaa74fd5e1aef1d5525a0479c6427cd23387ff1c16105db13b",
+        "id": "b7e26f3bb795a02703c2619fb7ed9155e011572c4c05434e6fd3cfe32bb0d1cd",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/onco-core-CancerDiseaseStatus"
@@ -39,7 +39,7 @@
           }
         ],
         "subject": {
-          "reference": "Patient/subjectId-1"
+          "reference": "Patient/pat-mrn-1"
         },
         "effectiveDateTime": "12/2/19",
         "valueCodeableConcept": {

--- a/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
@@ -1,7 +1,6 @@
 [
   {
     "mrn": "pat-mrn-1",
-    "subjectId": "subjectId-1",
     "conditionId": "cond-1",
     "diseaseStatus": "responding",
     "dateOfObservation": "12/2/19"

--- a/test/extractors/fixtures/csv-patient-bundle.json
+++ b/test/extractors/fixtures/csv-patient-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:any-unique-id",
+      "fullUrl": "urn:uuid:119147111821125",
       "resource": {
         "resourceType": "Patient",
-        "id": "any-unique-id",
+        "id": "119147111821125",
         "identifier": [
           {
             "type": {

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -1,7 +1,6 @@
 [
   {
     "mrn": "119147111821125",
-    "patientId": "any-unique-id",
     "family": "Marshall",
     "given": "Archy",
     "gender": "male"

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:4af65d96ed5787f612d58396d081551c95c6883f359d3505fe0faee7fefc7f85",
+      "fullUrl": "urn:uuid:f45018cdf3bfc70b281462c980a15d3876bb1428fd223d66d9895bd03d5d2ae2",
       "resource": {
         "resourceType": "CarePlan",
-        "id": "4af65d96ed5787f612d58396d081551c95c6883f359d3505fe0faee7fefc7f85",
+        "id": "f45018cdf3bfc70b281462c980a15d3876bb1428fd223d66d9895bd03d5d2ae2",
         "meta": {
           "profile": [
             "http://standardhealthrecord.org/guides/icare/StructureDefinition-icare-CarePlanWithReview.html"
@@ -33,7 +33,7 @@
             ]
           }
         ],
-        "subject": { "reference": "Patient/subjectId-1" },
+        "subject": { "reference": "Patient/mrn-1" },
         "status": "draft",
         "intent": "proposal",
         "created": "04/15/2020",

--- a/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
@@ -1,7 +1,6 @@
 [
   {
     "mrn": "mrn-1",
-    "subjectId": "subjectId-1",
     "dateOfCarePlan": "04/15/2020",
     "reasonCode": "281647001",
     "changed": "true"


### PR DESCRIPTION
# Summary

This PR implements changes to remove the `subjectId` column from the TreatmentPlanChange and CancerDiseaseStatus extractors, and remove the `patientId` column from the Patient extractor. No changes are made to other extractors.

## New behavior

The new changes cause the subject ID field for each relevant template to use the MRN instead of the subject's ID itself. No other apparent changes should be noticeable.

## Code changes

The `.csv` files for TreatmentPlanChange, CancerDiseaseStatus, and Patient have their `subjectID` and `patientID` columns removed. The related extractors have the requirement for the `subjectID` and `patientID` columns removed, and use the `mrn` field wherever the removed fields were previously used. All test files requiring changes have been updated accordingly.

# Testing guidance

Run the `icare-extraction-client` CLI using these changes, and ensure that it's using the CSV client and an appropriate config.

Make sure to run the tests.

As for any other testing guidance, at this point, you all know more than me!

*Needs only one reviewer.*