### PR TITLE
Format dates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4505,11 +4505,9 @@
       }
     },
     "moment": {
-      "version": "2.25.3",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.3.tgz",
-      "integrity": "sha512-PuYv0PHxZvzc15Sp8ybUCoQ+xpyPWvjOuK72a5ovzp2LI32rJXOiIfyoFoYvG3s6EwwrdkMyWuRiEHSZRLJNdg==",
-      "dev": true,
-      "optional": true
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "fhir-crud-client": "^1.2.1",
     "fhirpath": "^2.1.5",
     "lodash": "^4.17.15",
+    "moment": "^2.26.0",
     "sha.js": "^2.4.9",
     "winston": "^3.2.1"
   },

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { CSVModule } = require('../modules');
 const { getDiseaseStatusCode } = require('../helpers/diseaseStatusUtils');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
+const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(arrOfDiseaseStatusData) {
@@ -27,7 +28,7 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
     condition: {
       id: record.conditionId,
     },
-    effectiveDateTime: record.dateOfObservation,
+    effectiveDateTime: formatDateTime(record.dateOfObservation),
   }));
 }
 

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -2,6 +2,7 @@ const path = require('path');
 const { Extractor } = require('./Extractor');
 const { CSVModule } = require('../modules');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
+const { formatDate, formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
 
 // Formats data to be passed into template-friendly format
@@ -13,8 +14,8 @@ function formatData(tpcData) {
     }
 
     return {
-      effectiveDate: dateOfCarePlan,
-      effectiveDateTime: dateOfCarePlan,
+      effectiveDate: formatDate(dateOfCarePlan),
+      effectiveDateTime: formatDateTime(dateOfCarePlan),
       treatmentPlanChange: {
         hasChanged: changed,
         reason: {

--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -1,0 +1,34 @@
+const moment = require('moment');
+const logger = require('./logger');
+
+moment.suppressDeprecationWarnings = true; // We handle invalid date formats
+const dateFormat = 'YYYY-MM-DD';
+const dateTimeFormat = 'YYYY-MM-DDThh:mm:ssZ';
+
+function formatDate(date) {
+  const parsedDate = moment(date);
+  if (!parsedDate.isValid()) {
+    logger.error(`Invalid date provided: ${date}`);
+    return date; // Use the provided date rather than 'Invalid date'
+  }
+
+  return parsedDate.format(dateFormat);
+}
+
+function formatDateTime(date) {
+  const parsedDate = moment(date);
+  if (!parsedDate.isValid()) {
+    logger.error(`Invalid date provided: ${date}`);
+    return date; // Use the provided date rather than 'Invalid date'
+  }
+
+  if (parsedDate.hour()) {
+    return parsedDate.format(dateTimeFormat);
+  }
+  return parsedDate.format(dateFormat);
+}
+
+module.exports = {
+  formatDate,
+  formatDateTime,
+};

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const {
 const { generateMcodeResources } = require('./helpers/ejsUtils');
 const { isConditionPrimary, isConditionSecondary, getICD10Code } = require('./helpers/conditionUtils');
 const { getDiseaseStatusCode } = require('./helpers/diseaseStatusUtils');
+const { formatDate, formatDateTime } = require('./helpers/dateUtils');
 
 module.exports = {
   BaseFHIRExtractor,
@@ -53,6 +54,8 @@ module.exports = {
   allResourcesInBundle,
   firstEntryInBundle,
   firstResourceInBundle,
+  formatDate,
+  formatDateTime,
   generateMcodeResources,
   getBundleResourcesByType,
   getDiseaseStatusCode,

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:b7e26f3bb795a02703c2619fb7ed9155e011572c4c05434e6fd3cfe32bb0d1cd",
+      "fullUrl": "urn:uuid:ca18e669dec6d735f840c8b787c8f00cda949085fcbc18e21a52c409afcf3587",
       "resource": {
         "resourceType": "Observation",
-        "id": "b7e26f3bb795a02703c2619fb7ed9155e011572c4c05434e6fd3cfe32bb0d1cd",
+        "id": "ca18e669dec6d735f840c8b787c8f00cda949085fcbc18e21a52c409afcf3587",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
@@ -41,7 +41,7 @@
         "subject": {
           "reference": "Patient/pat-mrn-1"
         },
-        "effectiveDateTime": "12/2/19",
+        "effectiveDateTime": "2019-12-02",
         "valueCodeableConcept": {
           "coding": [
             {

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:f45018cdf3bfc70b281462c980a15d3876bb1428fd223d66d9895bd03d5d2ae2",
+      "fullUrl": "urn:uuid:077b177c9f25c32768459bf2062422811d6a5809d87ed9908a737d7bb9be5c9c",
       "resource": {
         "resourceType": "CarePlan",
-        "id": "f45018cdf3bfc70b281462c980a15d3876bb1428fd223d66d9895bd03d5d2ae2",
+        "id": "077b177c9f25c32768459bf2062422811d6a5809d87ed9908a737d7bb9be5c9c",
         "meta": {
           "profile": [
             "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-with-review"
@@ -28,7 +28,7 @@
                   ]
                 }
               },
-              { "url": "ReviewDate", "valueDate": "04/15/2020" },
+              { "url": "ReviewDate", "valueDate": "2020-04-15" },
               { "url": "ChangedFlag", "valueBoolean": true }
             ]
           }
@@ -36,7 +36,7 @@
         "subject": { "reference": "Patient/mrn-1" },
         "status": "draft",
         "intent": "proposal",
-        "created": "04/15/2020",
+        "created": "2020-04-15",
         "category": [
           {
             "coding": [


### PR DESCRIPTION
# Summary
Ensure dates in CSV files are valid FHIR date format

## New behavior
Use util functions to reformat dates received in CSV files. If an invalid date format is provided, we log an error and just use the date given in the CSV. I figured we could also use `undefined` or something in this case, but either way, it is incorrect information, so figured I'd mess as little as possible with the data provided.

## Code changes
Added date util functions and used them to reformat all dates we receive from CSVs.

# Testing guidance
If you run the CSV client but provide dates in the format of `06/09/2020` in your CSV files, they should be reformatted in the resulting bundles as `2020-06-09`. The changes in the tests here reflect the same test case because the data passed into the tests are in the first date format.

One question: Should I use the date format functions in the web service framework repo? I wasn't sure if I should be manipulating the format of data returned from web services. If we don't want to do that, I can probably remove the export of the new functions.
