### PR TITLE
Changed templates to use generic reference ids

### DIFF
--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -50,13 +50,13 @@
   },
   "focus" : [
     {
-      "reference": "Condition/<%- condition.id %>"<% if (condition.name) { %>,
+      "reference": "urn:uuid:<%- condition.id %>"<% if (condition.name) { %>,
       "display": "<%- condition.name %>"
       <% } %>
     }
   ],
   "subject" : {
-    "reference": "Patient/<%- subject.id %>"<% if (subject.name) { %>,
+    "reference": "urn:uuid:<%- subject.id %>"<% if (subject.name) { %>,
     "display": "<%- subject.name %>"
     <% } %>
   },

--- a/src/templates/CarePlanWithReview.ejs
+++ b/src/templates/CarePlanWithReview.ejs
@@ -65,7 +65,7 @@
     }
   ],
   "subject" : {
-    "reference": "Patient/<%- subject.id %>" <% if (subject.name) { %>,
+    "reference": "urn:uuid:<%- subject.id %>" <% if (subject.name) { %>,
     "display": "<%- subject.name %>"
     <% } %>
   },

--- a/src/templates/Condition.ejs
+++ b/src/templates/Condition.ejs
@@ -19,7 +19,7 @@
   "resourceType": "Condition",
   "id": "<%- id %>",
   "subject" : {
-    "reference": "Patient/<%- subject.id %>"<% if (subject.name) { %>,
+    "reference": "urn:uuid:<%- subject.id %>"<% if (subject.name) { %>,
     "display": "<%- subject.name %>"
     <% } %>
   },

--- a/src/templates/ResearchSubject.ejs
+++ b/src/templates/ResearchSubject.ejs
@@ -25,6 +25,6 @@
       "reference": "ResearchStudy/<%- trialResearchID %>"
   },
   "individual": {
-      "reference": "Patient/<%- patientId %>"
+      "reference": "urn:uuid:<%- patientId %>"
   }
 }

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -35,11 +35,11 @@
         },
         "focus": [
           {
-            "reference": "Condition/cond-1"
+            "reference": "urn:uuid:cond-1"
           }
         ],
         "subject": {
-          "reference": "Patient/pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1"
         },
         "effectiveDateTime": "2019-12-02",
         "valueCodeableConcept": {

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -16,7 +16,7 @@
         ],
         "status": "example-enrollment-status",
         "study": { "reference": "ResearchStudy/example-researchId" },
-        "individual": { "reference": "Patient/EXAMPLE-MRN" }
+        "individual": { "reference": "urn:uuid:EXAMPLE-MRN" }
       }
     },
     {

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -7,7 +7,7 @@
       "resource": {
         "resourceType": "Condition",
         "id": "conditionId-1",
-        "subject": { "reference": "Patient/mrn-1" },
+        "subject": { "reference": "urn:uuid:mrn-1" },
         "code": {
           "coding": [
             { "system": "example-code-system", "code": "example-code" }

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -33,7 +33,7 @@
             ]
           }
         ],
-        "subject": { "reference": "Patient/mrn-1" },
+        "subject": { "reference": "urn:uuid:mrn-1" },
         "status": "draft",
         "intent": "proposal",
         "created": "2020-04-15",

--- a/test/templates/fixtures/careplan-resource.json
+++ b/test/templates/fixtures/careplan-resource.json
@@ -39,7 +39,7 @@
     }
   ],
   "subject": {
-    "reference": "Patient/abc-def",
+    "reference": "urn:uuid:abc-def",
     "display": "Sample Text"
   },
   "status": "draft",

--- a/test/templates/fixtures/condition-resource.json
+++ b/test/templates/fixtures/condition-resource.json
@@ -2,7 +2,7 @@
   "resourceType": "Condition",
   "id": "example-id",
   "subject" : {
-    "reference": "Patient/example-subject-id"
+    "reference": "urn:uuid:example-subject-id"
   },
   "code": {
     "coding": [

--- a/test/templates/fixtures/disease-status-resource.json
+++ b/test/templates/fixtures/disease-status-resource.json
@@ -29,12 +29,12 @@
   },
   "focus" : [
     {
-      "reference": "Condition/123-Walking-Corpse-Syndrome",
+      "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
       "display": "Walking Corpse Syndrome"
     }
   ],
   "subject": {
-    "reference": "Patient/123-example-patient",
+    "reference": "urn:uuid:123-example-patient",
     "display": "Mr. Patient Example"
   },
   "effectiveDateTime" : "1994-12-09T09:07:00Z",

--- a/test/templates/fixtures/research-subject-resource.json
+++ b/test/templates/fixtures/research-subject-resource.json
@@ -15,6 +15,6 @@
     "reference": "ResearchStudy/rs1"
   },
   "individual": {
-    "reference": "Patient/mCODEPatient1"
+    "reference": "urn:uuid:mCODEPatient1"
   }
 }


### PR DESCRIPTION
# Summary
Changed templates to use generic reference ids
## New behavior/Code changes
- Updated templates and test fixtures to use `urn:uuid` as prefix for reference ids instead of `Patient/` or `Condition/`.
# Testing guidance
Ensure tests are good and other repos work fine with these changes.