### PR TITLE
ClinicalTrialInformation Extractor uses ClinicalSiteId

### DIFF
--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -20,14 +20,16 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
   constructor({ filePath, clinicalSiteID }) {
     super();
     this.csvModule = new CSVModule(path.resolve(filePath));
+    if (!clinicalSiteID) logger.warn(`${this.constructor.name} expects a value for clinicalSiteID but got ${clinicalSiteID}`);
     this.clinicalSiteID = clinicalSiteID;
   }
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
     const { trialSubjectID, enrollmentStatus, trialResearchID, trialStatus } = clinicalTrialData;
+    const { clinicalSiteID } = this;
 
-    if (!(patientId && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
-      throw new Error('Clinical trial missing an expected property: patientId, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.');
+    if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
+      throw new Error('Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.');
     }
 
     // Need separate data objects for ResearchSubject and ResearchStudy so that they get different resource ids
@@ -41,7 +43,7 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
       formattedDataStudy: {
         trialStatus,
         trialResearchID,
-        clinicalSiteID: this.clinicalSiteID,
+        clinicalSiteID,
       },
     };
   }

--- a/src/templates/ResearchStudy.ejs
+++ b/src/templates/ResearchStudy.ejs
@@ -4,20 +4,29 @@
 {
   id: String,
   trialStatus: String,
-  trialResearchID: String
+  trialResearchID: String,
+  clinicalSiteID: String
 }
 <% */ %>
 {
   "resourceType": "ResearchStudy",
   "id": "<%- id %>",
   "status": "<%- trialStatus %>",
+  "site": {
+    "type": "Location",
+    "display": "ID associated with Clinical Trial",
+    "identifier": {
+      "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
+      "value": "<%- clinicalSiteID %>"
+    }
+  },
   "identifier": [
-      {
-          "system": "http://example.com/clinicaltrialids",
-          "type": {
-              "text": "Clinical Trial Research ID"
-          },
-          "value": "<%- trialResearchID %>"
-      }
+    {
+      "system": "http://example.com/clinicaltrialids",
+      "type": {
+        "text": "Clinical Trial Research ID"
+      },
+      "value": "<%- trialResearchID %>"
+    }
   ]
 }

--- a/src/templates/ResearchStudy.ejs
+++ b/src/templates/ResearchStudy.ejs
@@ -12,14 +12,16 @@
   "resourceType": "ResearchStudy",
   "id": "<%- id %>",
   "status": "<%- trialStatus %>",
-  "site": {
-    "type": "Location",
-    "display": "ID associated with Clinical Trial",
-    "identifier": {
-      "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
-      "value": "<%- clinicalSiteID %>"
+  "site": [
+    {
+      "type": "Location",
+      "display": "ID associated with Clinical Trial",
+      "identifier": {
+        "system": "http://example.com/clinicalSiteIds",
+        "value": "<%- clinicalSiteID %>"
+      }
     }
-  },
+  ],
   "identifier": [
     {
       "system": "http://example.com/clinicaltrialids",

--- a/src/templates/ResearchStudy.ejs
+++ b/src/templates/ResearchStudy.ejs
@@ -14,7 +14,6 @@
   "status": "<%- trialStatus %>",
   "site": [
     {
-      "type": "Location",
       "display": "ID associated with Clinical Trial",
       "identifier": {
         "system": "http://example.com/clinicalSiteIds",

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -30,7 +30,7 @@ describe('CSVClinicalTrialInformationExtractor', () => {
   describe('joinClinicalTrialData', () => {
     test('should join clinical trial data appropriately', () => {
       const firstClinicalTrialInfoResponse = exampleClinicalTrialInformationResponse[0]; // Each patient will only have one entry per clinical trial
-      const expectedErrorString = 'Clinical trial missing an expected property: patientId, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.';
+      const expectedErrorString = 'Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.';
 
       // Test required properties in CSV throw error
       Object.keys(firstClinicalTrialInfoResponse).forEach((key) => {

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -7,12 +7,13 @@ const exampleClinicalTrialInformationBundle = require('./fixtures/csv-clinical-t
 
 // Constants for mock tests
 const MOCK_CSV_PATH = path.join(__dirname, 'fixtures/example.csv'); // need a valid path/csv here to avoid parse error
-
+const MOCK_CLINICAL_SITE_ID = 'EXAMPLE-CLINICAL-SITE-ID';
 const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
 
 // Instantiate module with mock parameters
 const csvClinicalTrialInformationExtractor = new CSVClinicalTrialInformationExtractor({
   filePath: MOCK_CSV_PATH,
+  clinicalSiteID: MOCK_CLINICAL_SITE_ID,
 });
 
 // Destructure all modules
@@ -23,73 +24,79 @@ const csvModuleSpy = jest.spyOn(csvModule, 'get');
 csvModuleSpy
   .mockReturnValue(exampleClinicalTrialInformationResponse);
 
-const joinClinicalTrialData = rewire('../../src/extractors/CSVClinicalTrialInformationExtractor.js').__get__('joinClinicalTrialData');
 const getPatientId = rewire('../../src/extractors/CSVClinicalTrialInformationExtractor.js').__get__('getPatientId');
 
 describe('CSVClinicalTrialInformationExtractor', () => {
-  test('should join clinical trial data appropriately', () => {
-    const firstClinicalTrialInfoResponse = exampleClinicalTrialInformationResponse[0]; // Each patient will only have one entry per clinical trial
-    const expectedErrorString = 'Clinical trial missing an expected property: patientId, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.';
+  describe('joinClinicalTrialData', () => {
+    test('should join clinical trial data appropriately', () => {
+      const firstClinicalTrialInfoResponse = exampleClinicalTrialInformationResponse[0]; // Each patient will only have one entry per clinical trial
+      const expectedErrorString = 'Clinical trial missing an expected property: patientId, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.';
 
-    // Test required properties in CSV throw error
-    Object.keys(firstClinicalTrialInfoResponse).forEach((key) => {
-      const clonedData = _.cloneDeep(firstClinicalTrialInfoResponse);
-      expect(joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toEqual(expect.anything());
-      if (key === 'mrn') return; // MRN is not required from CSV
-      delete clonedData[key];
-      expect(() => joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toThrow(new Error(expectedErrorString));
-    });
+      // Test required properties in CSV throw error
+      Object.keys(firstClinicalTrialInfoResponse).forEach((key) => {
+        const clonedData = _.cloneDeep(firstClinicalTrialInfoResponse);
+        expect(csvClinicalTrialInformationExtractor.joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toEqual(expect.anything());
+        if (key === 'mrn') return; // MRN is not required from CSV
+        delete clonedData[key];
+        expect(() => csvClinicalTrialInformationExtractor.joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toThrow(new Error(expectedErrorString));
+      });
 
-    // patientId is required to be passed in
-    expect(() => joinClinicalTrialData(undefined, firstClinicalTrialInfoResponse)).toThrow(new Error(expectedErrorString));
+      // patientId is required to be passed in
+      expect(() => csvClinicalTrialInformationExtractor.joinClinicalTrialData(undefined, firstClinicalTrialInfoResponse)).toThrow(new Error(expectedErrorString));
 
-    // joinClinicalTrialData should return correct format
-    expect(joinClinicalTrialData(MOCK_PATIENT_MRN, firstClinicalTrialInfoResponse)).toEqual({
-      formattedDataSubject: {
-        enrollmentStatus: firstClinicalTrialInfoResponse.enrollmentStatus,
-        trialSubjectID: firstClinicalTrialInfoResponse.trialSubjectID,
-        trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
-        patientId: MOCK_PATIENT_MRN,
-      },
-      formattedDataStudy: {
-        trialStatus: firstClinicalTrialInfoResponse.trialStatus,
-        trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
-      },
-    });
-  });
-
-  test('should return patient id when patient resource in context', () => {
-    const contextPatient = {
-      resourceType: 'Patient',
-      id: 'context-patient-id',
-    };
-    const contextBundle = {
-      resourceType: 'Bundle',
-      type: 'collection',
-      entry: [
-        {
-          fullUrl: 'context-url',
-          resource: contextPatient,
+      // joinClinicalTrialData should return correct format
+      expect(csvClinicalTrialInformationExtractor.joinClinicalTrialData(MOCK_PATIENT_MRN, firstClinicalTrialInfoResponse)).toEqual({
+        formattedDataSubject: {
+          enrollmentStatus: firstClinicalTrialInfoResponse.enrollmentStatus,
+          trialSubjectID: firstClinicalTrialInfoResponse.trialSubjectID,
+          trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
+          patientId: MOCK_PATIENT_MRN,
         },
-      ],
-    };
-
-    const patientId = getPatientId(contextBundle);
-    expect(patientId).toEqual(contextPatient.id);
+        formattedDataStudy: {
+          trialStatus: firstClinicalTrialInfoResponse.trialStatus,
+          trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
+          clinicalSiteID: MOCK_CLINICAL_SITE_ID,
+        },
+      });
+    });
   });
 
-  test('getPatientId should return undefined when no patient resource in context', () => {
-    const patientId = getPatientId({});
-    expect(patientId).toBeUndefined();
+  describe('getPatientId', () => {
+    test('should return patient id when patient resource in context', () => {
+      const contextPatient = {
+        resourceType: 'Patient',
+        id: 'context-patient-id',
+      };
+      const contextBundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'context-url',
+            resource: contextPatient,
+          },
+        ],
+      };
+
+      const patientId = getPatientId(contextBundle);
+      expect(patientId).toEqual(contextPatient.id);
+    });
+
+    test('getPatientId should return undefined when no patient resource in context', () => {
+      const patientId = getPatientId({});
+      expect(patientId).toBeUndefined();
+    });
   });
 
-  test('should return a bundle with the correct resources', async () => {
-    const data = await csvClinicalTrialInformationExtractor.get({ mrn: MOCK_PATIENT_MRN });
+  describe('get', () => {
+    test('should return a bundle with the correct resources', async () => {
+      const data = await csvClinicalTrialInformationExtractor.get({ mrn: MOCK_PATIENT_MRN });
 
-    expect(data.resourceType).toEqual('Bundle');
-    expect(data.type).toEqual('collection');
-    expect(data.entry).toBeDefined();
-    expect(data.entry.length).toEqual(2);
-    expect(data.entry).toEqual(exampleClinicalTrialInformationBundle.entry);
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry).toBeDefined();
+      expect(data.entry.length).toEqual(2);
+      expect(data.entry).toEqual(exampleClinicalTrialInformationBundle.entry);
+    });
   });
 });

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -20,11 +20,19 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:37a4e7de00084e541b81c6ddbb1ee0ab50b7a5e58d10a2695301487ec094e6ab",
+      "fullUrl": "urn:uuid:1b04fc751b08fd0e0b89293a0ccb61e931e6eeed87d88100fb0c3b15d0cf7fbb",
       "resource": {
         "resourceType": "ResearchStudy",
-        "id": "37a4e7de00084e541b81c6ddbb1ee0ab50b7a5e58d10a2695301487ec094e6ab",
+        "id": "1b04fc751b08fd0e0b89293a0ccb61e931e6eeed87d88100fb0c3b15d0cf7fbb",
         "status": "example-trialStatus",
+        "site": {
+          "display": "ID associated with Clinical Trial",
+          "identifier": {
+            "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
+            "value": "EXAMPLE-CLINICAL-SITE-ID"
+          },
+          "type": "Location"
+        },
         "identifier": [
           {
             "system": "http://example.com/clinicaltrialids",

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -25,14 +25,16 @@
         "resourceType": "ResearchStudy",
         "id": "1b04fc751b08fd0e0b89293a0ccb61e931e6eeed87d88100fb0c3b15d0cf7fbb",
         "status": "example-trialStatus",
-        "site": {
-          "display": "ID associated with Clinical Trial",
-          "identifier": {
-            "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
-            "value": "EXAMPLE-CLINICAL-SITE-ID"
-          },
-          "type": "Location"
-        },
+        "site": [
+          {
+            "display": "ID associated with Clinical Trial",
+            "identifier": {
+              "system": "http://example.com/clinicalSiteIds",
+              "value": "EXAMPLE-CLINICAL-SITE-ID"
+            },
+            "type": "Location"
+          }
+        ],
         "identifier": [
           {
             "system": "http://example.com/clinicaltrialids",

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -31,8 +31,7 @@
             "identifier": {
               "system": "http://example.com/clinicalSiteIds",
               "value": "EXAMPLE-CLINICAL-SITE-ID"
-            },
-            "type": "Location"
+            }
           }
         ],
         "identifier": [

--- a/test/templates/condition.test.js
+++ b/test/templates/condition.test.js
@@ -27,12 +27,12 @@ const CONDITION_TEMPLATE = fs.readFileSync(path.join(__dirname, '../../src/templ
 
 describe('test Condition template', () => {
   test('valid data passed into template should generate FHIR resource', () => {
-    const generateCondition = renderTemplate(
+    const generatedCondition = renderTemplate(
       CONDITION_TEMPLATE,
       CONDITION_VALID_DATA,
     );
 
-    expect(generateCondition).toEqual(validExampleCondition);
+    expect(generatedCondition).toEqual(validExampleCondition);
   });
 
   test('invalid data should throw an error', () => {

--- a/test/templates/fixtures/research-study-resource.json
+++ b/test/templates/fixtures/research-study-resource.json
@@ -1,10 +1,22 @@
 {
-    "resourceType": "ResearchStudy",
-    "id": "fd1a39e3cb43961b5f44ace008930c88e38a705d687f23920a45038cfb8d9482",
-    "status": "active",
-    "identifier": [
-        {
-            "value": "AFT1235"
-        }
-    ]
+  "resourceType": "ResearchStudy",
+  "id": "4419c8c6cf32a3647dff187f301906d26e9435c1f009ebb59b88a0b233ba4ab5",
+  "status": "active",
+  "site": {
+    "display": "ID associated with Clinical Trial",
+    "identifier": {
+      "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
+      "value": "EXAMPLE_SITE_ID"
+    },
+    "type": "Location"
+  },
+  "identifier": [
+    {
+      "value": "AFT1235",
+      "system": "http://example.com/clinicaltrialids",
+      "type":  {
+        "text": "Clinical Trial Research ID"
+      }
+    }
+  ]
 }

--- a/test/templates/fixtures/research-study-resource.json
+++ b/test/templates/fixtures/research-study-resource.json
@@ -8,8 +8,7 @@
       "identifier": {
         "system": "http://example.com/clinicalSiteIds",
         "value": "EXAMPLE_SITE_ID"
-      },
-      "type": "Location"
+      }
     }
   ],
   "identifier": [

--- a/test/templates/fixtures/research-study-resource.json
+++ b/test/templates/fixtures/research-study-resource.json
@@ -2,14 +2,16 @@
   "resourceType": "ResearchStudy",
   "id": "4419c8c6cf32a3647dff187f301906d26e9435c1f009ebb59b88a0b233ba4ab5",
   "status": "active",
-  "site": {
-    "display": "ID associated with Clinical Trial",
-    "identifier": {
-      "system": "NOTE: Not sure what to use here, but presumably we want some code system of all trial IDs",
-      "value": "EXAMPLE_SITE_ID"
-    },
-    "type": "Location"
-  },
+  "site": [
+      {
+      "display": "ID associated with Clinical Trial",
+      "identifier": {
+        "system": "http://example.com/clinicalSiteIds",
+        "value": "EXAMPLE_SITE_ID"
+      },
+      "type": "Location"
+    }
+  ],
   "identifier": [
     {
       "value": "AFT1235",

--- a/test/templates/researchStudy.test.js
+++ b/test/templates/researchStudy.test.js
@@ -6,6 +6,7 @@ const { renderTemplate } = require('../../src/helpers/ejsUtils');
 const VALID_DATA = {
   trialStatus: 'active',
   trialResearchID: 'AFT1235',
+  clinicalSiteID: 'EXAMPLE_SITE_ID',
 };
 
 const INVALID_DATA = {
@@ -22,9 +23,7 @@ describe('test ResearchStudy template', () => {
       VALID_DATA,
     );
     // Relevant fields should match the valid FHIR
-    expect(generatedResearchStudy.id).toEqual(validResearchStudy.id);
-    expect(generatedResearchStudy.trialStatus).toEqual(validResearchStudy.trialStatus);
-    expect(generatedResearchStudy.trialResearchID).toEqual(validResearchStudy.trialResearchID);
+    expect(generatedResearchStudy).toEqual(validResearchStudy);
   });
 
   test('invalid data should throw an error', () => {


### PR DESCRIPTION
# Summary
Update the CSVClinicalTrialInformationExtractor to accept a ClinicalSiteId as a constructor argument, and update the templates to use that constructor argument.

## New behavior
See above

## Addl. Code changes
Updates to tests (also added describes where appropriate); changes to class to support new features. 

# Testing guidance
- Ensure these local tests pass;
- Ensure that the local `mcode-extraction-framework/test/templates/fixtures/research-study-resource.json` validates against R4;
- Looking at the #site-id PR on ICARE-ext-client, ensure that things fail and messages are logged appropriately when information is missing from the configuration file; 
- When the configuration file is updated to provide the ClinicalSiteId as a constructor arg for ClinicalTrialInformationExtractors, ensure that running the client doesn't fail for that. 

_Probably only needs one reviewer_