### PR TITLE
Update tests and code to us codes in lieu of text

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,3 +1,3 @@
 mrn,conditionId,diseaseStatus,dateOfObservation
-pat-mrn-1,cond-1,responding,12/2/19
-pat-mrn-2,cond-2,responding,12/2/19
+pat-mrn-1,cond-1,268910001,12/2/19
+pat-mrn-2,cond-2,268910001,12/2/19

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -1,13 +1,12 @@
 const path = require('path');
 const { CSVModule } = require('../modules');
-const { getDiseaseStatusCode } = require('../helpers/diseaseStatusUtils');
+const { getDiseaseStatusDisplay } = require('../helpers/diseaseStatusUtils');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(arrOfDiseaseStatusData) {
   logger.info('Reformatting disease status data from CSV into template format');
-  // No join needed - just reformatting for template
   // Check the shape of the data
   arrOfDiseaseStatusData.forEach((record) => {
     if (!(record.mrn && record.conditionId && record.diseaseStatus && record.dateOfObservation)) {
@@ -18,9 +17,9 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
     // We have no note to base our ObservationStatus off of; default to 'final'
     status: 'final',
     value: {
-      code: getDiseaseStatusCode(record.diseaseStatus),
+      code: record.diseaseStatus,
       system: 'http://snomed.info/sct',
-      display: record.diseaseStatus,
+      display: getDiseaseStatusDisplay(record.diseaseStatus),
     },
     subject: {
       id: record.mrn,

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -7,6 +7,17 @@ const diseaseStatusTextToCodeLookup = {
   'not evaluated': 709137006,
 };
 
+function invert(obj) {
+  return Object.entries(obj).reduce((ret, entry) => {
+    const [key, value] = entry;
+    // eslint-disable-next-line no-param-reassign
+    ret[value] = key;
+    return ret;
+  }, {});
+}
+
+const diseaseStatusCodeToTextLookup = invert(diseaseStatusTextToCodeLookup);
+
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
  * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
@@ -16,6 +27,16 @@ function getDiseaseStatusCode(text) {
   return diseaseStatusTextToCodeLookup[text];
 }
 
+/**
+ * Converts code in mCODE's ConditionStatusTrendVS to Text Value
+ * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ */
+function getDiseaseStatusDisplay(code) {
+  return diseaseStatusCodeToTextLookup[code];
+}
+
 module.exports = {
   getDiseaseStatusCode,
+  getDiseaseStatusDisplay,
 };

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:ca18e669dec6d735f840c8b787c8f00cda949085fcbc18e21a52c409afcf3587",
+      "fullUrl": "urn:uuid:e7125282081c74589baca75d56c783a79e3a8f7cb95c979a45012b4e55765227",
       "resource": {
         "resourceType": "Observation",
-        "id": "ca18e669dec6d735f840c8b787c8f00cda949085fcbc18e21a52c409afcf3587",
+        "id": "e7125282081c74589baca75d56c783a79e3a8f7cb95c979a45012b4e55765227",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"

--- a/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
@@ -2,7 +2,7 @@
   {
     "mrn": "pat-mrn-1",
     "conditionId": "cond-1",
-    "diseaseStatus": "responding",
+    "diseaseStatus": "268910001",
     "dateOfObservation": "12/2/19"
   }
 ]


### PR DESCRIPTION
# Summary
Update CSV format for CDS (not clinical-decision-support) to use codes instead of display text for CDS response values.

## New behavior
None

## Code changes
- Update example fixtures to use new format
- New CDS util for mapping codes to display text
- Update CSVCDSExtractor to assume `record.diseaseStatus` is a code not a display string

# Testing guidance
- Ensure tests pass

_only needs one reviewer_