### PR TITLE
Cds evidence csv

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,3 +1,5 @@
-mrn,conditionId,diseaseStatus,dateOfObservation
-pat-mrn-1,cond-1,268910001,12/2/19
-pat-mrn-2,cond-2,268910001,12/2/19
+mrn,conditionId,evidence,diseaseStatus,dateOfObservation
+pat-mrn-1,cond-1,363679005|252416005,268910001,12/2/19
+pat-mrn-2,cond-2,363679005,268910001,12/3/19
+pat-mrn-3,cond-3,,260415000,12/4/19
+pat-mrn-4,cond-4,271299001,268910001,12/5/19

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -54,7 +54,8 @@ class CSVCancerDiseaseStatusExtractor {
     const packagedDiseaseStatusData = joinAndReformatData(diseaseStatusData);
 
     // 3. Generate FHIR Resources
-    return generateMcodeResources('CancerDiseaseStatus', packagedDiseaseStatusData);
+    const resources = generateMcodeResources('CancerDiseaseStatus', packagedDiseaseStatusData);
+    return resources;
   }
 }
 

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const { CSVModule } = require('../modules');
-const { getDiseaseStatusDisplay } = require('../helpers/diseaseStatusUtils');
+const { getDiseaseStatusDisplay, getDiseaseStatusEvidenceDisplay } = require('../helpers/diseaseStatusUtils');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
@@ -13,6 +13,7 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
       throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.');
     }
   });
+  const evidenceDelimiter = '|';
   return arrOfDiseaseStatusData.map((record) => ({
     // We have no note to base our ObservationStatus off of; default to 'final'
     status: 'final',
@@ -28,6 +29,10 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
       id: record.conditionId,
     },
     effectiveDateTime: formatDateTime(record.dateOfObservation),
+    evidence: !record.evidence ? null : record.evidence.split(evidenceDelimiter).map((evidenceCode) => ({
+      code: evidenceCode,
+      display: getDiseaseStatusEvidenceDisplay(evidenceCode),
+    })),
   }));
 }
 

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -1,12 +1,4 @@
-// Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
-const diseaseStatusTextToCodeLookup = {
-  'no evidence of disease': 260415000,
-  responding: 268910001,
-  stable: 359746009,
-  progressing: 271299001,
-  'not evaluated': 709137006,
-};
-
+// Helper function for inverting a object's keys and values s.t. (k->v) becomes (v->k)
 function invert(obj) {
   return Object.entries(obj).reduce((ret, entry) => {
     const [key, value] = entry;
@@ -16,7 +8,24 @@ function invert(obj) {
   }, {});
 }
 
+// Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
+const diseaseStatusTextToCodeLookup = {
+  'no evidence of disease': 260415000,
+  responding: 268910001,
+  stable: 359746009,
+  progressing: 271299001,
+  'not evaluated': 709137006,
+};
 const diseaseStatusCodeToTextLookup = invert(diseaseStatusTextToCodeLookup);
+
+const evidenceTextToCodeLookup = {
+  Imaging: 363679005,
+  'Histopathology test': 252416005,
+  'Assessment of symptom control': 711015009,
+  'Physical examination procedure': 5880005,
+  'Laboratory data interpretation': 386344002,
+};
+const evidenceCodeToTextLookup = invert(evidenceTextToCodeLookup);
 
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
@@ -36,7 +45,27 @@ function getDiseaseStatusDisplay(code) {
   return diseaseStatusCodeToTextLookup[code];
 }
 
+/**
+ * Converts Text Value to code in mCODE's ConditionStatusTrendVS
+ * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ */
+function getDiseaseStatusEvidenceCode(text) {
+  return evidenceTextToCodeLookup[text];
+}
+
+/**
+ * Converts code in mCODE's ConditionStatusTrendVS to Text Value
+ * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ */
+function getDiseaseStatusEvidenceDisplay(code) {
+  return evidenceCodeToTextLookup[code];
+}
+
 module.exports = {
   getDiseaseStatusCode,
   getDiseaseStatusDisplay,
+  getDiseaseStatusEvidenceCode,
+  getDiseaseStatusEvidenceDisplay,
 };

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -18,6 +18,7 @@ const diseaseStatusTextToCodeLookup = {
 };
 const diseaseStatusCodeToTextLookup = invert(diseaseStatusTextToCodeLookup);
 
+// Code mapping is based on http://hl7.org/fhir/us/mcode/ValueSet-mcode-cancer-disease-status-evidence-type-vs.html
 const evidenceTextToCodeLookup = {
   Imaging: 363679005,
   'Histopathology test': 252416005,
@@ -46,18 +47,18 @@ function getDiseaseStatusDisplay(code) {
 }
 
 /**
- * Converts Text Value to code in mCODE's ConditionStatusTrendVS
+ * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
  * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
- * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceCode(text) {
   return evidenceTextToCodeLookup[text];
 }
 
 /**
- * Converts code in mCODE's ConditionStatusTrendVS to Text Value
+ * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
  * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
- * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceDisplay(code) {
   return evidenceCodeToTextLookup[code];

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -25,7 +25,8 @@ function generateResourceId(data) {
 
 function renderTemplate(template, data) {
   // Ensure that spread operator on data is last, so any data.id takes precedence
-  return JSON.parse(ejs.render(template, { id: generateResourceId(data), ...data }));
+  const render = ejs.render(template, { id: generateResourceId(data), ...data });
+  return JSON.parse(render);
 }
 
 function generateMcodeResources(mcodeProfileID, data) {

--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -74,20 +74,19 @@
       }
     ]
   }<% if (evidence) { %>,
-  "extension" : [
-    <% evidence.forEach(e => { %>
+  "extension" : [<% evidence.forEach((e, i) => { %>
     {
       "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
       "valueCodeableConcept" : {
         "coding" : [
           {
             "system" : "http://snomed.info/sct",
-            "display": <%- e.display %>
-            "code" : <%- e.code %>
+            "display": "<%- e.display %>",
+            "code": "<%- e.code %>"
           }
         ]
       }
-    }<% }) %>
+    }<% if (i + 1 < evidence.length) { %>,<% }%><% }) %>
   ]<% } %>
 }
 

--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -17,6 +17,10 @@
     code: String,
     display: String,
   },
+  evidence: [{
+    code: String,
+    display: String,
+  }]
 }
 <% */ %>
 {
@@ -69,6 +73,21 @@
         "display": "<%- value.display %>"
       }
     ]
-  }
+  }<% if (evidence) { %>,
+  "extension" : [
+    <% evidence.forEach(e => { %>
+    {
+      "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
+      "valueCodeableConcept" : {
+        "coding" : [
+          {
+            "system" : "http://snomed.info/sct",
+            "display": <%- e.display %>
+            "code" : <%- e.code %>
+          }
+        ]
+      }
+    }<% }) %>
+  ]<% } %>
 }
 

--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -73,7 +73,7 @@
         "display": "<%- value.display %>"
       }
     ]
-  }<% if (evidence) { %>,
+  }<% if (evidence && evidence.length > 0) { %>,
   "extension" : [<% evidence.forEach((e, i) => { %>
     {
       "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
@@ -81,8 +81,8 @@
         "coding" : [
           {
             "system" : "http://snomed.info/sct",
-            "display": "<%- e.display %>",
-            "code": "<%- e.code %>"
+            "code": "<%- e.code %>"<% if (e.display) { %>,
+            "display": "<%- e.display %>"<% } %>
           }
         ]
       }

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:e7125282081c74589baca75d56c783a79e3a8f7cb95c979a45012b4e55765227",
+      "fullUrl": "urn:uuid:3953511e92b90d115c8234f8bccef8cbe152f436aa01894cdcde3d665f30b4db",
       "resource": {
         "resourceType": "Observation",
-        "id": "e7125282081c74589baca75d56c783a79e3a8f7cb95c979a45012b4e55765227",
+        "id": "3953511e92b90d115c8234f8bccef8cbe152f436aa01894cdcde3d665f30b4db",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:3953511e92b90d115c8234f8bccef8cbe152f436aa01894cdcde3d665f30b4db",
+      "fullUrl": "urn:uuid:2f26785071c04af0b4f649cf9aed2a31298c2194b331e2117874586dd6493d28",
       "resource": {
         "resourceType": "Observation",
-        "id": "3953511e92b90d115c8234f8bccef8cbe152f436aa01894cdcde3d665f30b4db",
+        "id": "2f26785071c04af0b4f649cf9aed2a31298c2194b331e2117874586dd6493d28",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
@@ -50,7 +50,33 @@
               "display": "responding"
             }
           ]
-        }
+        },
+        "extension" : [
+          {
+            "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "system" : "http://snomed.info/sct",
+                  "display": "Imaging",
+                  "code": "363679005"
+                }
+              ]
+            }
+          },
+          {
+            "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
+            "valueCodeableConcept" : {
+              "coding" : [
+                {
+                  "system" : "http://snomed.info/sct",
+                  "display": "Histopathology test",
+                  "code": "252416005"
+                }
+              ]
+            }
+          }
+        ]
       }
     }
   ]

--- a/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
@@ -3,6 +3,7 @@
     "mrn": "pat-mrn-1",
     "conditionId": "cond-1",
     "diseaseStatus": "268910001",
-    "dateOfObservation": "12/2/19"
+    "dateOfObservation": "12/2/19",
+    "evidence": "363679005|252416005"
   }
 ]

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -1,0 +1,45 @@
+const diseaseStatusUtils = require('../../src/helpers/diseaseStatusUtils.js');
+
+// Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
+const diseaseStatusTextToCodeLookup = {
+  'no evidence of disease': 260415000,
+  responding: 268910001,
+  stable: 359746009,
+  progressing: 271299001,
+  'not evaluated': 709137006,
+};
+// Code mapping is based on http://hl7.org/fhir/us/mcode/ValueSet-mcode-cancer-disease-status-evidence-type-vs.html
+const evidenceTextToCodeLookup = {
+  Imaging: 363679005,
+  'Histopathology test': 252416005,
+  'Assessment of symptom control': 711015009,
+  'Physical examination procedure': 5880005,
+  'Laboratory data interpretation': 386344002,
+};
+
+describe('diseaseStatusUtils', () => {
+  test('getDiseaseStatusCode,', () => {
+    Object.keys(diseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = diseaseStatusTextToCodeLookup[dsText];
+      expect(diseaseStatusUtils.getDiseaseStatusCode(dsText)).toEqual(dsCode);
+    });
+  });
+  test('getDiseaseStatusDisplay,', () => {
+    Object.keys(diseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = diseaseStatusTextToCodeLookup[dsText];
+      expect(diseaseStatusUtils.getDiseaseStatusDisplay(dsCode)).toEqual(dsText);
+    });
+  });
+  test('getDiseaseStatusEvidenceCode,', () => {
+    Object.keys(evidenceTextToCodeLookup).forEach((evidenceText) => {
+      const evidenceCode = evidenceTextToCodeLookup[evidenceText];
+      expect(diseaseStatusUtils.getDiseaseStatusEvidenceCode(evidenceText)).toEqual(evidenceCode);
+    });
+  });
+  test('getDiseaseStatusEvidenceDisplay,', () => {
+    Object.keys(evidenceTextToCodeLookup).forEach((evidenceText) => {
+      const evidenceCode = evidenceTextToCodeLookup[evidenceText];
+      expect(diseaseStatusUtils.getDiseaseStatusEvidenceDisplay(evidenceCode)).toEqual(evidenceText);
+    });
+  });
+});

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -19,6 +19,7 @@ const VALID_DATA = {
     name: 'Walking Corpse Syndrome',
   },
   effectiveDateTime: '1994-12-09T09:07:00Z',
+  evidence: null,
 };
 
 const INVALID_DATA = {
@@ -37,6 +38,7 @@ const INVALID_DATA = {
     name: 'Walking Corpse Syndrome',
   },
   effectiveDateTime: '1994-12-09T09:07:00Z',
+  evidence: null,
 };
 
 const DISEASE_STATUS_TEMPLATE = fs.readFileSync(path.join(__dirname, '../../src/templates/CancerDiseaseStatus.ejs'), 'utf8');

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -4,6 +4,7 @@ const validCancerDiseaseStatus = require('./fixtures/disease-status-resource.jso
 const { renderTemplate } = require('../../src/helpers/ejsUtils');
 
 const VALID_DATA = {
+  id: 'CancerDiseaseStatus-fixture',
   status: 'final',
   value: {
     code: '385633008',
@@ -19,10 +20,19 @@ const VALID_DATA = {
     name: 'Walking Corpse Syndrome',
   },
   effectiveDateTime: '1994-12-09T09:07:00Z',
-  evidence: null,
+  evidence: [
+    {
+      code: '09870987',
+      display: 'Evidence display text',
+    },
+    {
+      code: '12341234',
+    },
+  ],
 };
 
 const INVALID_DATA = {
+  id: 'CancerDiseaseStatus-fixture',
   // Omitting 'status' field which is required
   value: {
     code: '385633008',
@@ -51,10 +61,7 @@ describe('test CancerDiseaseStatus template', () => {
     );
 
     // Relevant fields should match the valid FHIR
-    expect(generatedDiseaseStatus.valueCodeableConcept)
-      .toEqual(validCancerDiseaseStatus.valueCodeableConcept);
-    expect(generatedDiseaseStatus.status).toEqual(validCancerDiseaseStatus.status);
-    expect(generatedDiseaseStatus.subject).toEqual(validCancerDiseaseStatus.subject);
+    expect(generatedDiseaseStatus).toEqual(validCancerDiseaseStatus);
   });
 
   test('invalid data should throw an error', () => {

--- a/test/templates/fixtures/disease-status-resource.json
+++ b/test/templates/fixtures/disease-status-resource.json
@@ -46,5 +46,30 @@
         "display": "Improving"
       }
     ]
-  }
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "09870987",
+            "display": "Evidence display text"
+          }
+        ]
+      }
+    },
+    {
+      "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
+      "valueCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "12341234"
+          }
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# Summary
Adds evidence as a new required parameter of the CDS template and augments the CSV-CDS extractor to parse the evidence appropriately  

## New behavior
CSV files containing CDS data must now have an evidence column, and a value that contains a pipe-delimited list of codes associated with evidences coming from the following value set: http://hl7.org/fhir/us/mcode/ValueSet-mcode-cancer-disease-status-evidence-type-vs.html

## Code changes
Update tests to supply this newly required piece of data; augment the EJS template to handle the iteration over a list of evidences and add them to the rendered template accordingly; adding a evidence-type code lookup akin to the disease-status code lookup

# Testing guidance
Ensure test pass, linting passes, and that the ICARE-extraction-client's sibling branch works as expected. 

Probably want two sets of eyes on this since it's a pretty critical new piece of functionality