### PR TITLE
Support filtering by fromDate and toDate in CSV module

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,5 +1,5 @@
-mrn,conditionId,evidence,diseaseStatus,dateOfObservation
-pat-mrn-1,cond-1,363679005|252416005,268910001,12/2/19
-pat-mrn-2,cond-2,363679005,268910001,12/3/19
-pat-mrn-3,cond-3,,260415000,12/4/19
-pat-mrn-4,cond-4,271299001,268910001,12/5/19
+mrn,conditionId,evidence,diseaseStatus,dateOfObservation,dateRecorded
+pat-mrn-1,cond-1,363679005|252416005,268910001,12/2/19,2020-01-10
+pat-mrn-2,cond-2,363679005,268910001,12/3/19,2020-01-10
+pat-mrn-3,cond-3,,260415000,12/4/19,2020-01-10
+pat-mrn-4,cond-4,271299001,268910001,12/5/19,,2020-05-10

--- a/docs/treatment-plan-change.csv
+++ b/docs/treatment-plan-change.csv
@@ -1,3 +1,3 @@
-mrn,reasonCode,changed,dateOfCarePlan
-mrn-1,281647001,true,04/15/2020
-mrn-2,281647001,true,03/30/2020
+mrn,reasonCode,changed,dateOfCarePlan,dateRecorded
+mrn-1,281647001,true,04/15/2020,2020-05-01
+mrn-2,281647001,true,03/30/2020,2020-05-01

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -1,8 +1,9 @@
 const path = require('path');
 const { CSVModule } = require('../modules');
+const { formatDateTime } = require('../helpers/dateUtils');
 const { getDiseaseStatusDisplay, getDiseaseStatusEvidenceDisplay } = require('../helpers/diseaseStatusUtils');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
-const { formatDateTime } = require('../helpers/dateUtils');
+const { getEmptyBundle } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(arrOfDiseaseStatusData) {
@@ -51,11 +52,7 @@ class CSVCancerDiseaseStatusExtractor {
     const diseaseStatusData = await this.getDiseaseStatusData(mrn, fromDate, toDate);
     if (diseaseStatusData.length === 0) {
       logger.warn('No disease status data found for patient');
-      return {
-        resourceType: 'Bundle',
-        type: 'collection',
-        entry: [],
-      };
+      return getEmptyBundle();
     }
 
     // 2. Format data for research study and research subject

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -41,14 +41,23 @@ class CSVCancerDiseaseStatusExtractor {
     this.csvModule = new CSVModule(path.resolve(filePath));
   }
 
-  async getDiseaseStatusData(mrn) {
+  async getDiseaseStatusData(mrn, fromDate) {
     logger.info('Getting disease status data');
-    return this.csvModule.get('mrn', mrn);
+    return this.csvModule.get('mrn', mrn, fromDate);
   }
 
-  async get({ mrn }) {
+  async get({ mrn, fromDate }) {
     // 1. Get all relevant data and do necessary post-processing
-    const diseaseStatusData = await this.getDiseaseStatusData(mrn);
+    const diseaseStatusData = await this.getDiseaseStatusData(mrn, fromDate);
+    if (diseaseStatusData.length === 0) {
+      logger.warn('No disease status data found for patient');
+      return {
+        resourceType: 'Bundle',
+        type: 'collection',
+        total: 0,
+        entry: [],
+      };
+    }
 
     // 2. Format data for research study and research subject
     const packagedDiseaseStatusData = joinAndReformatData(diseaseStatusData);

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -54,7 +54,6 @@ class CSVCancerDiseaseStatusExtractor {
       return {
         resourceType: 'Bundle',
         type: 'collection',
-        total: 0,
         entry: [],
       };
     }

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -41,14 +41,14 @@ class CSVCancerDiseaseStatusExtractor {
     this.csvModule = new CSVModule(path.resolve(filePath));
   }
 
-  async getDiseaseStatusData(mrn, fromDate) {
+  async getDiseaseStatusData(mrn, fromDate, toDate) {
     logger.info('Getting disease status data');
-    return this.csvModule.get('mrn', mrn, fromDate);
+    return this.csvModule.get('mrn', mrn, fromDate, toDate);
   }
 
-  async get({ mrn, fromDate }) {
+  async get({ mrn, fromDate, toDate }) {
     // 1. Get all relevant data and do necessary post-processing
-    const diseaseStatusData = await this.getDiseaseStatusData(mrn, fromDate);
+    const diseaseStatusData = await this.getDiseaseStatusData(mrn, fromDate, toDate);
     if (diseaseStatusData.length === 0) {
       logger.warn('No disease status data found for patient');
       return {

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -35,13 +35,23 @@ class CSVTreatmentPlanChangeExtractor extends Extractor {
     this.csvModule = new CSVModule(path.resolve(filePath));
   }
 
-  async getTPCData(mrn) {
+  async getTPCData(mrn, fromDate) {
     logger.info('Getting Treatment Plan Change Data');
-    return this.csvModule.get('mrn', mrn);
+    return this.csvModule.get('mrn', mrn, fromDate);
   }
 
-  async get({ mrn }) {
-    const tpcData = await this.getTPCData(mrn);
+  async get({ mrn, fromDate }) {
+    const tpcData = await this.getTPCData(mrn, fromDate);
+    if (tpcData.length === 0) {
+      logger.warn('No disease status data found for patient');
+      return {
+        resourceType: 'Bundle',
+        type: 'collection',
+        total: 0,
+        entry: [],
+      };
+    }
+
     const formattedData = formatData(tpcData);
 
     return generateMcodeResources('CarePlanWithReview', formattedData);

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -47,7 +47,6 @@ class CSVTreatmentPlanChangeExtractor extends Extractor {
       return {
         resourceType: 'Bundle',
         type: 'collection',
-        total: 0,
         entry: [],
       };
     }

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -35,13 +35,13 @@ class CSVTreatmentPlanChangeExtractor extends Extractor {
     this.csvModule = new CSVModule(path.resolve(filePath));
   }
 
-  async getTPCData(mrn, fromDate) {
+  async getTPCData(mrn, fromDate, toDate) {
     logger.info('Getting Treatment Plan Change Data');
-    return this.csvModule.get('mrn', mrn, fromDate);
+    return this.csvModule.get('mrn', mrn, fromDate, toDate);
   }
 
-  async get({ mrn, fromDate }) {
-    const tpcData = await this.getTPCData(mrn, fromDate);
+  async get({ mrn, fromDate, toDate }) {
+    const tpcData = await this.getTPCData(mrn, fromDate, toDate);
     if (tpcData.length === 0) {
       logger.warn('No disease status data found for patient');
       return {

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -1,8 +1,9 @@
 const path = require('path');
 const { Extractor } = require('./Extractor');
 const { CSVModule } = require('../modules');
-const { generateMcodeResources } = require('../helpers/ejsUtils');
 const { formatDate, formatDateTime } = require('../helpers/dateUtils');
+const { generateMcodeResources } = require('../helpers/ejsUtils');
+const { getEmptyBundle } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 // Formats data to be passed into template-friendly format
@@ -44,11 +45,7 @@ class CSVTreatmentPlanChangeExtractor extends Extractor {
     const tpcData = await this.getTPCData(mrn, fromDate, toDate);
     if (tpcData.length === 0) {
       logger.warn('No disease status data found for patient');
-      return {
-        resourceType: 'Bundle',
-        type: 'collection',
-        entry: [],
-      };
+      return getEmptyBundle();
     }
 
     const formattedData = formatData(tpcData);

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -16,6 +16,14 @@ function allResourcesInBundle(bundle) {
   return bundle.entry.map((e) => e.resource);
 }
 
+function getEmptyBundle() {
+  return {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [],
+  };
+}
+
 function determineVersion(fhirBundle) {
   // TODO: Actual determination of versions
   if (fhirBundle) {
@@ -54,6 +62,7 @@ module.exports = {
   firstEntryInBundle,
   firstResourceInBundle,
   getBundleResourcesByType,
+  getEmptyBundle,
   isBundleEmpty,
   mapFHIRVersions,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ const {
   firstEntryInBundle,
   firstResourceInBundle,
   getBundleResourcesByType,
+  getEmptyBundle,
   isBundleEmpty,
 } = require('./helpers/fhirUtils');
 const { generateMcodeResources } = require('./helpers/ejsUtils');
@@ -56,6 +57,7 @@ module.exports = {
   firstResourceInBundle,
   formatDate,
   formatDateTime,
+  getEmptyBundle,
   generateMcodeResources,
   getBundleResourcesByType,
   getDiseaseStatusCode,

--- a/src/modules/CSVModule.js
+++ b/src/modules/CSVModule.js
@@ -18,7 +18,7 @@ class CSVModule {
     // If fromDate and toDate is provided, filter out all results that fall outside that timespan
     if (fromDate && moment(fromDate).isValid()) result = result.filter((r) => !(r.dateRecorded && moment(fromDate).isAfter(r.dateRecorded)));
     if (toDate && moment(toDate).isValid()) result = result.filter((r) => !(r.dateRecorded && moment(toDate).isBefore(r.dateRecorded)));
-    if (result.length === 0) logger.warn('No data for patient after specified fromDate');
+    if (result.length === 0) logger.warn('No data for patient within specified time range');
     return result;
   }
 }

--- a/src/modules/CSVModule.js
+++ b/src/modules/CSVModule.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const moment = require('moment');
 const parse = require('csv-parse/lib/sync');
 const logger = require('../helpers/logger');
 
@@ -7,12 +8,16 @@ class CSVModule {
     this.data = parse(fs.readFileSync(csvFilePath), { columns: true });
   }
 
-  async get(key, value) {
+  async get(key, value, fromDate) {
     logger.info(`Get csvModule info by key '${key}'`);
     // return all rows if key and value aren't provided
     if (!key && !value) return this.data;
-    const result = this.data.filter((d) => d[key] === value);
+    let result = this.data.filter((d) => d[key] === value);
     if (result.length === 0) throw new ReferenceError(`CSV Record with provided key '${key}' and value was not found`);
+
+    // If fromDate is provided, filter out all results that were recorded before fromDate
+    if (fromDate) result = result.filter((r) => !(r.dateRecorded && moment(fromDate).isAfter(r.dateRecorded)));
+    if (result.length === 0) logger.warn('No data for patient after specified fromDate');
     return result;
   }
 }

--- a/src/modules/CSVModule.js
+++ b/src/modules/CSVModule.js
@@ -8,15 +8,16 @@ class CSVModule {
     this.data = parse(fs.readFileSync(csvFilePath), { columns: true });
   }
 
-  async get(key, value, fromDate) {
+  async get(key, value, fromDate, toDate) {
     logger.info(`Get csvModule info by key '${key}'`);
     // return all rows if key and value aren't provided
     if (!key && !value) return this.data;
     let result = this.data.filter((d) => d[key] === value);
     if (result.length === 0) throw new ReferenceError(`CSV Record with provided key '${key}' and value was not found`);
 
-    // If fromDate is provided, filter out all results that were recorded before fromDate
-    if (fromDate) result = result.filter((r) => !(r.dateRecorded && moment(fromDate).isAfter(r.dateRecorded)));
+    // If fromDate and toDate is provided, filter out all results that fall outside that timespan
+    if (fromDate && moment(fromDate).isValid()) result = result.filter((r) => !(r.dateRecorded && moment(fromDate).isAfter(r.dateRecorded)));
+    if (toDate && moment(toDate).isValid()) result = result.filter((r) => !(r.dateRecorded && moment(toDate).isBefore(r.dateRecorded)));
     if (result.length === 0) logger.warn('No data for patient after specified fromDate');
     return result;
   }

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -53,7 +53,6 @@ test('CSVCancerDiseaseStatusExtractor returns empty bundle when no data availabl
   const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');
-  expect(data.total).toEqual(0);
   expect(data.entry).toBeDefined();
   expect(data.entry.length).toEqual(0);
 });

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -22,8 +22,6 @@ const { csvModule } = csvCancerDiseaseStatusExtractor;
 
 // Spy on csvModule
 const csvModuleSpy = jest.spyOn(csvModule, 'get');
-csvModuleSpy
-  .mockReturnValue(exampleCSVDiseaseStatusModuleResponse);
 
 const joinAndReformatData = CSVCancerDiseaseStatusExtractorRewired.__get__('joinAndReformatData');
 test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
@@ -61,11 +59,22 @@ test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
   expect(joinAndReformatData(localData)).toEqual(expect.anything());
 });
 
-test('CSVCancerDiseaseStatusExtractor', async () => {
+test('CSVCancerDiseaseStatusExtractor returns bundle with Observation', async () => {
+  csvModuleSpy.mockImplementation(() => exampleCSVDiseaseStatusModuleResponse);
   const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');
   expect(data.entry).toBeDefined();
   expect(data.entry.length).toEqual(1);
   expect(data.entry).toEqual(exampleCSVDiseaseStatusBundle.entry);
+});
+
+test('CSVCancerDiseaseStatusExtractor returns empty bundle when no data available from module', async () => {
+  csvModuleSpy.mockImplementation(() => []);
+  const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
+  expect(data.resourceType).toEqual('Bundle');
+  expect(data.type).toEqual('collection');
+  expect(data.total).toEqual(0);
+  expect(data.entry).toBeDefined();
+  expect(data.entry.length).toEqual(0);
 });

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -34,6 +34,7 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
 
       // Test all required properties are
+      delete localData[0].evidence; // Evidence is not required and will not throw an error
       Object.keys(localData[0]).forEach((key) => {
         const clonedData = _.cloneDeep(localData);
         delete clonedData[0][key];

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -24,35 +24,42 @@ const { csvModule } = csvCancerDiseaseStatusExtractor;
 const csvModuleSpy = jest.spyOn(csvModule, 'get');
 
 const joinAndReformatData = CSVCancerDiseaseStatusExtractorRewired.__get__('joinAndReformatData');
-test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
-  const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.';
-  const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
-  // Test that valid data works fine
-  expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
 
-  // Test all required properties are
-  Object.keys(localData[0]).forEach((key) => {
-    const clonedData = _.cloneDeep(localData);
-    delete clonedData[0][key];
-    expect(() => joinAndReformatData(clonedData)).toThrow(new Error(expectedErrorString));
+describe('CSVCancerDiseaseStatusExtractor', () => {
+  describe('joinAndReformatData', () => {
+    test('should join data appropriately and throw errors when missing required properties', () => {
+      const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.';
+      const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
+      // Test that valid data works fine
+      expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
+
+      // Test all required properties are
+      Object.keys(localData[0]).forEach((key) => {
+        const clonedData = _.cloneDeep(localData);
+        delete clonedData[0][key];
+        expect(() => joinAndReformatData(clonedData)).toThrow(new Error(expectedErrorString));
+      });
+    });
   });
-});
 
-test('CSVCancerDiseaseStatusExtractor returns bundle with Observation', async () => {
-  csvModuleSpy.mockReturnValue(exampleCSVDiseaseStatusModuleResponse);
-  const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
-  expect(data.resourceType).toEqual('Bundle');
-  expect(data.type).toEqual('collection');
-  expect(data.entry).toBeDefined();
-  expect(data.entry.length).toEqual(1);
-  expect(data.entry).toEqual(exampleCSVDiseaseStatusBundle.entry);
-});
+  describe('get', () => {
+    test('should return bundle with Observation', async () => {
+      csvModuleSpy.mockReturnValue(exampleCSVDiseaseStatusModuleResponse);
+      const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry).toBeDefined();
+      expect(data.entry.length).toEqual(1);
+      expect(data.entry).toEqual(exampleCSVDiseaseStatusBundle.entry);
+    });
 
-test('CSVCancerDiseaseStatusExtractor returns empty bundle when no data available from module', async () => {
-  csvModuleSpy.mockReturnValue([]);
-  const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
-  expect(data.resourceType).toEqual('Bundle');
-  expect(data.type).toEqual('collection');
-  expect(data.entry).toBeDefined();
-  expect(data.entry.length).toEqual(0);
+    test('should return empty bundle when no data available from module', async () => {
+      csvModuleSpy.mockReturnValue([]);
+      const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry).toBeDefined();
+      expect(data.entry.length).toEqual(0);
+    });
+  });
 });

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -25,38 +25,17 @@ const csvModuleSpy = jest.spyOn(csvModule, 'get');
 
 const joinAndReformatData = CSVCancerDiseaseStatusExtractorRewired.__get__('joinAndReformatData');
 test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
+  const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.';
   const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
   // Test that valid data works fine
   expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
 
   // Test all required properties are
-  delete localData[0].mrn;
-  expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
-  );
-  localData[0].mrn = exampleCSVDiseaseStatusModuleResponse[0].mrn;
-  expect(joinAndReformatData(localData)).toEqual(expect.anything());
-
-  delete localData[0].conditionId;
-  expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
-  );
-  localData[0].conditionId = exampleCSVDiseaseStatusModuleResponse[0].conditionId;
-  expect(joinAndReformatData(localData)).toEqual(expect.anything());
-
-  delete localData[0].diseaseStatus;
-  expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
-  );
-  localData[0].diseaseStatus = exampleCSVDiseaseStatusModuleResponse[0].diseaseStatus;
-  expect(joinAndReformatData(localData)).toEqual(expect.anything());
-
-  delete localData[0].dateOfObservation;
-  expect(() => joinAndReformatData(localData)).toThrow(
-    new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.'),
-  );
-  localData[0].dateOfObservation = exampleCSVDiseaseStatusModuleResponse[0].dateOfObservation;
-  expect(joinAndReformatData(localData)).toEqual(expect.anything());
+  Object.keys(localData[0]).forEach((key) => {
+    const clonedData = _.cloneDeep(localData);
+    delete clonedData[0][key];
+    expect(() => joinAndReformatData(clonedData)).toThrow(new Error(expectedErrorString));
+  });
 });
 
 test('CSVCancerDiseaseStatusExtractor returns bundle with Observation', async () => {

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -39,7 +39,7 @@ test('CSVCancerDiseaseStatusExtractor -> joinAndReformatData', () => {
 });
 
 test('CSVCancerDiseaseStatusExtractor returns bundle with Observation', async () => {
-  csvModuleSpy.mockImplementation(() => exampleCSVDiseaseStatusModuleResponse);
+  csvModuleSpy.mockReturnValue(exampleCSVDiseaseStatusModuleResponse);
   const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');
@@ -49,7 +49,7 @@ test('CSVCancerDiseaseStatusExtractor returns bundle with Observation', async ()
 });
 
 test('CSVCancerDiseaseStatusExtractor returns empty bundle when no data available from module', async () => {
-  csvModuleSpy.mockImplementation(() => []);
+  csvModuleSpy.mockReturnValue([]);
   const data = await csvCancerDiseaseStatusExtractor.get({ mrn: MOCK_PATIENT_MRN });
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -28,7 +28,7 @@ const getPatientId = rewire('../../src/extractors/CSVClinicalTrialInformationExt
 
 describe('CSVClinicalTrialInformationExtractor', () => {
   describe('joinClinicalTrialData', () => {
-    test('should join clinical trial data appropriately', () => {
+    test('should join clinical trial data appropriately and throw errors when missing required properties', () => {
       const firstClinicalTrialInfoResponse = exampleClinicalTrialInformationResponse[0]; // Each patient will only have one entry per clinical trial
       const expectedErrorString = 'Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.';
 

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -15,8 +15,6 @@ const { csvModule } = csvTPCExtractor;
 
 // Spy on csvModule
 const csvModuleSpy = jest.spyOn(csvModule, 'get');
-csvModuleSpy
-  .mockReturnValue(exampleCSVTPCModuleResponse);
 
 const formatData = rewire('../../src/extractors/CSVTreatmentPlanChangeExtractor.js').__get__('formatData');
 
@@ -40,11 +38,22 @@ test('format data from CSV', () => {
   });
 });
 
-test('CSV Treatment Plan Change Extractor', async () => {
+test('CSV Treatment Plan Change Extractor returns bundle with CarePlan', async () => {
+  csvModuleSpy.mockReturnValue(exampleCSVTPCModuleResponse);
   const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
 
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');
   expect(data.entry.length).toEqual(1);
   expect(data).toEqual(exampleCSVTPCBundle);
+});
+
+test('CSV Treatment Plan Change Extractor returns empty bundle with no data available from module', async () => {
+  csvModuleSpy.mockReturnValue([]);
+  const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
+
+  expect(data.resourceType).toEqual('Bundle');
+  expect(data.type).toEqual('collection');
+  expect(data.total).toEqual(0);
+  expect(data.entry.length).toEqual(0);
 });

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -18,41 +18,47 @@ const csvModuleSpy = jest.spyOn(csvModule, 'get');
 
 const formatData = rewire('../../src/extractors/CSVTreatmentPlanChangeExtractor.js').__get__('formatData');
 
-test('format data from CSV', () => {
-  const expectedErrorString = 'Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required';
-  const exampleData = [
-    {
-      dateOfCarePlan: '04/15/2020',
-      changed: true,
-      reasonCode: 'exampleCode',
-      mrn: 'id',
-    },
-  ];
+describe('CSVTreatmentPlanChangeExtractor', () => {
+  describe('formatData', () => {
+    test('should join data appropriately and throw errors when missing required properties', () => {
+      const expectedErrorString = 'Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required';
+      const exampleData = [
+        {
+          dateOfCarePlan: '04/15/2020',
+          changed: true,
+          reasonCode: 'exampleCode',
+          mrn: 'id',
+        },
+      ];
 
-  // Test required properties throw error
-  Object.keys(exampleData[0]).forEach((key) => {
-    const clonedData = _.cloneDeep(exampleData);
-    expect(formatData(clonedData)).toEqual(expect.anything());
-    delete clonedData[0][key];
-    expect(() => formatData(clonedData)).toThrow(new Error(expectedErrorString));
+      // Test required properties throw error
+      Object.keys(exampleData[0]).forEach((key) => {
+        const clonedData = _.cloneDeep(exampleData);
+
+        delete clonedData[0][key];
+        expect(() => formatData(clonedData)).toThrow(new Error(expectedErrorString));
+      });
+    });
   });
-});
 
-test('CSV Treatment Plan Change Extractor returns bundle with CarePlan', async () => {
-  csvModuleSpy.mockReturnValue(exampleCSVTPCModuleResponse);
-  const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
+  describe('get', () => {
+    test('should return bundle with CarePlan', async () => {
+      csvModuleSpy.mockReturnValue(exampleCSVTPCModuleResponse);
+      const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
 
-  expect(data.resourceType).toEqual('Bundle');
-  expect(data.type).toEqual('collection');
-  expect(data.entry.length).toEqual(1);
-  expect(data).toEqual(exampleCSVTPCBundle);
-});
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry.length).toEqual(1);
+      expect(data).toEqual(exampleCSVTPCBundle);
+    });
 
-test('CSV Treatment Plan Change Extractor returns empty bundle with no data available from module', async () => {
-  csvModuleSpy.mockReturnValue([]);
-  const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
+    test('should return empty bundle with no data available from module', async () => {
+      csvModuleSpy.mockReturnValue([]);
+      const data = await csvTPCExtractor.get({ mrn: MOCK_MRN });
 
-  expect(data.resourceType).toEqual('Bundle');
-  expect(data.type).toEqual('collection');
-  expect(data.entry.length).toEqual(0);
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry.length).toEqual(0);
+    });
+  });
 });

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -54,6 +54,5 @@ test('CSV Treatment Plan Change Extractor returns empty bundle with no data avai
 
   expect(data.resourceType).toEqual('Bundle');
   expect(data.type).toEqual('collection');
-  expect(data.total).toEqual(0);
   expect(data.entry.length).toEqual(0);
 });

--- a/test/modules/CSVModule.test.js
+++ b/test/modules/CSVModule.test.js
@@ -21,6 +21,11 @@ test('Returns all rows when both key and value are undefined', async () => {
   expect(data).toEqual(csvModule.data);
 });
 
+test('Returns data with recordedDate after specified from date', async () => {
+  const data = await csvModule.get('mrn', 'example-mrn-2', '2020-05-01');
+  expect(data).toHaveLength(1);
+});
+
 test('Invalid MRN', async () => {
   try {
     await csvModule.get('mrn', INVALID_MRN);

--- a/test/modules/CSVModule.test.js
+++ b/test/modules/CSVModule.test.js
@@ -26,6 +26,11 @@ test('Returns data with recordedDate after specified from date', async () => {
   expect(data).toHaveLength(1);
 });
 
+test('Returns data with recordedDate before specified to date', async () => {
+  const data = await csvModule.get('mrn', 'example-mrn-2', null, '2020-05-01');
+  expect(data).toHaveLength(1);
+});
+
 test('Invalid MRN', async () => {
   try {
     await csvModule.get('mrn', INVALID_MRN);

--- a/test/modules/fixtures/csv-response.json
+++ b/test/modules/fixtures/csv-response.json
@@ -4,6 +4,7 @@
     "trialSubjectID": "subjectId-1",
     "enrollmentStatus": "status-1",
     "trialResearchID": "researchId-1",
-    "trialStatus": "trialStatus-1"
+    "trialStatus": "trialStatus-1",
+    "dateRecorded": "2020-01-10"
   }
 ]

--- a/test/modules/fixtures/example-csv.csv
+++ b/test/modules/fixtures/example-csv.csv
@@ -1,4 +1,4 @@
-mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus
-example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1
-example-mrn-2,subjectId-2,status-2,researchId-2,trialStatus-2
-example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3
+mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,dateRecorded
+example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1,2020-01-10
+example-mrn-2,subjectId-2,status-2,researchId-2,trialStatus-2,2020-01-10
+example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3,2020-06-10


### PR DESCRIPTION
# Summary
Adds support for filtering out CSV data based on a provided `fromDate` and `toDate`.

## New behavior
You can now run the client with a `--fromDate` and `--toDate` specified for CSV extraction. The fromDate (or one from the log file if not provided) and the toDate (if provided) are then used to filter out data in the CSV module `get`. If all data is filtered out, we return an empty collection bundle.

## Code changes
Added filtering to CSV Module `get` based on a `fromDate` and `toDate`, if provided and valid dates. Return an empty bundle if no patient information is returned from extractor's `get`. Added tests for both of those changes. I also updated the joinAndReformat test in the CancerDiseaseStatus tests to more closely mirror the ones in TreatmentPlanChange and ClinicalTrialInfo since it was functionally the same, but I can revert that if we prefer the old way.

# Testing guidance
You should be able to run the client and specify a `--fromDate` and `--toDate` and only have resources for data with a `dateRecorded` after the specified `--fromDate` and before the specified `--toDate`. Also, if you have successfully run the CSV client, it will pull the latest date to use as `fromDate` if it is not specified.