### PR TITLE
Require `reasonCode` only when `changed` is true

### DIFF
--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -10,23 +10,34 @@ const logger = require('../helpers/logger');
 function formatData(tpcData) {
   return tpcData.map((data) => {
     const { mrn, dateOfCarePlan, changed, reasonCode } = data;
-    if (!mrn || !dateOfCarePlan || !changed || !reasonCode) {
-      throw new Error('Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required');
+    if (!mrn || !dateOfCarePlan || !changed) {
+      throw new Error('Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, changed are required');
     }
 
-    return {
+    // reasonCode is required if changed flag is true
+    if (changed === 'true' && !reasonCode) {
+      throw new Error('reasonCode is required when changed flag is true');
+    }
+
+    const formattedData = {
       effectiveDate: formatDate(dateOfCarePlan),
       effectiveDateTime: formatDateTime(dateOfCarePlan),
       treatmentPlanChange: {
         hasChanged: changed,
-        reason: {
-          code: reasonCode,
-        },
       },
       subject: {
         id: mrn,
       },
     };
+
+    // Add reasonCode to formattedData if available
+    if (reasonCode) {
+      formattedData.treatmentPlanChange.reason = {
+        code: reasonCode,
+      };
+    }
+
+    return formattedData;
   });
 }
 

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -20,16 +20,19 @@ const formatData = rewire('../../src/extractors/CSVTreatmentPlanChangeExtractor.
 
 describe('CSVTreatmentPlanChangeExtractor', () => {
   describe('formatData', () => {
+    const exampleData = [
+      {
+        dateOfCarePlan: '04/15/2020',
+        changed: 'false',
+        mrn: 'id',
+      },
+    ];
+
     test('should join data appropriately and throw errors when missing required properties', () => {
-      const expectedErrorString = 'Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, reasonCode, changed are required';
-      const exampleData = [
-        {
-          dateOfCarePlan: '04/15/2020',
-          changed: true,
-          reasonCode: 'exampleCode',
-          mrn: 'id',
-        },
-      ];
+      const expectedErrorString = 'Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, changed are required';
+
+      // formatData on example data should not throw error when changed is false
+      expect(() => formatData(exampleData)).not.toThrowError();
 
       // Test required properties throw error
       Object.keys(exampleData[0]).forEach((key) => {
@@ -38,6 +41,18 @@ describe('CSVTreatmentPlanChangeExtractor', () => {
         delete clonedData[0][key];
         expect(() => formatData(clonedData)).toThrow(new Error(expectedErrorString));
       });
+    });
+
+    test('should throw error if reasonCode is missing when changed flag is true.', () => {
+      const expectedErrorString = 'reasonCode is required when changed flag is true';
+
+      // error should get throw when changed flag is true and there is no reasonCode provided
+      exampleData[0].changed = 'true';
+      expect(() => formatData(exampleData)).toThrow(new Error(expectedErrorString));
+
+      // No error should be throw when reasonCode is provided
+      exampleData[0].reasonCode = 'example code';
+      expect(() => formatData(exampleData)).not.toThrowError();
     });
   });
 

--- a/test/templates/carePlanWithReview.test.js
+++ b/test/templates/carePlanWithReview.test.js
@@ -7,7 +7,7 @@ const VALID_DATA = {
   effectiveDateTime: '2020-01-23T09:07:00Z',
   effectiveDate: '2020-01-23',
   treatmentPlanChange: {
-    hasChanged: true,
+    hasChanged: 'true',
     reason: {
       code: '281647001',
       displayText: 'Adverse reaction (disorder)',


### PR DESCRIPTION
Small change to check for `reasonCode` only when `changed` is `'true'`

# Testing guidance
Ensure tests pass and changes make sense
Run with client to ensure everything still works

One reviewer on this should be fine.