### PR TITLE
Update to debug statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ const cancerDiseaseStatusExtractor = new CSVCancerDiseaseStatusExtractor('path-t
 (async () => {
   logger.info('Extracting primary disease status data');
   const primaryDiseaseStatusBundle = await cancerDiseaseStatusExtractor.get({ mrn: 'some-mrn' });
-  logger.info(JSON.stringify(primaryDiseaseStatusBundle));
 })();
 ```
 

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -25,7 +25,7 @@ class BaseFHIRExtractor extends Extractor {
     const idFromContext = parseContextForPatientId(context);
     if (idFromContext) return { patient: idFromContext };
 
-    logger.info('No patient ID in context; fetching with baseFHIRModule');
+    logger.debug('No patient ID in context; fetching with baseFHIRModule');
     const patientResponseBundle = await this.baseFHIRModule.search('Patient', { identifier: `MRN|${mrn}` });
     if (!patientResponseBundle || !patientResponseBundle.entry || !patientResponseBundle.entry[0] || !patientResponseBundle.entry[0].resource) {
       logger.error(`Could not get a patient ID to cross-reference for ${this.resourceType}`);
@@ -38,18 +38,18 @@ class BaseFHIRExtractor extends Extractor {
   // arguments differently, all pass to this function which interfaces with the baseFHIRModule
   async getWithFHIRParams(params) {
     // 1. Get data
-    logger.info(`Getting ${this.resourceType} FHIR resource`);
+    logger.debug(`Getting ${this.resourceType} FHIR resource`);
     const fhirResponseBundle = await this.baseFHIRModule.search(this.resourceType, params);
     if (isBundleEmpty(fhirResponseBundle)) {
       logger.warn(`${this.resourceType} bundle that was supposed to have entries had 0`);
       return fhirResponseBundle;
     }
-    logger.info(`Found ${fhirResponseBundle.entry.length} ${this.resourceType} FHIR resources in get`);
+    logger.debug(`Found ${fhirResponseBundle.entry.length} ${this.resourceType} FHIR resources in get`);
 
     // 2. Reformat versions where necessary;
     const resVersion = determineVersion(fhirResponseBundle);
     if (this.version && resVersion !== this.version) {
-      logger.info(`Mapping ${this.resourceType} FHIR responses from ${resVersion} to ${this.version}`);
+      logger.debug(`Mapping ${this.resourceType} FHIR responses from ${resVersion} to ${this.version}`);
       fhirResponseBundle.entry = fhirResponseBundle.entry.map((resource) => mapFHIRVersions(resource, resVersion, this.version));
       return fhirResponseBundle;
     }

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -7,7 +7,7 @@ const { getEmptyBundle } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(arrOfDiseaseStatusData) {
-  logger.info('Reformatting disease status data from CSV into template format');
+  logger.debug('Reformatting disease status data from CSV into template format');
   // Check the shape of the data
   arrOfDiseaseStatusData.forEach((record) => {
     if (!(record.mrn && record.conditionId && record.diseaseStatus && record.dateOfObservation)) {
@@ -43,7 +43,7 @@ class CSVCancerDiseaseStatusExtractor {
   }
 
   async getDiseaseStatusData(mrn, fromDate, toDate) {
-    logger.info('Getting disease status data');
+    logger.debug('Getting disease status data');
     return this.csvModule.get('mrn', mrn, fromDate, toDate);
   }
 

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -8,11 +8,11 @@ const logger = require('../helpers/logger');
 function getPatientId(context) {
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   if (patientInContext) {
-    logger.info('Patient resource found in context.');
+    logger.debug('Patient resource found in context.');
     return patientInContext.id;
   }
 
-  logger.info('No patient resource found in context.');
+  logger.debug('No patient resource found in context.');
   return undefined;
 }
 
@@ -25,6 +25,7 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
   }
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
+    logger.debug('Reformatting clinical trial data from CSV into template format');
     const { trialSubjectID, enrollmentStatus, trialResearchID, trialStatus } = clinicalTrialData;
     const { clinicalSiteID } = this;
 
@@ -49,7 +50,7 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
   }
 
   async getClinicalTrialData(mrn) {
-    logger.info('Getting clinical trial data');
+    logger.debug('Getting clinical trial data');
     const data = await this.csvModule.get('mrn', mrn);
     // Should only be one value return for clinical trial data
     return data[0];

--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -6,6 +6,7 @@ const logger = require('../helpers/logger');
 
 // Formats data to be passed into template-friendly format
 function formatData(conditionData) {
+  logger.debug('Reformatting condition data from CSV into template format');
   return conditionData.map((data) => {
     const { mrn, conditionId, codeSystem, code } = data;
 
@@ -29,7 +30,7 @@ class CSVConditionExtractor extends Extractor {
   }
 
   async getConditionData(mrn) {
-    logger.info('Getting Condition Data');
+    logger.debug('Getting Condition Data');
     return this.csvModule.get('mrn', mrn);
   }
 

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -5,7 +5,7 @@ const { Extractor } = require('./Extractor');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(patientData) {
-  logger.info('Reformatting patient data from CSV into template format');
+  logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
   const { mrn, family, given, gender } = patientData;
 
@@ -25,7 +25,7 @@ class CSVPatientExtractor extends Extractor {
   }
 
   async getPatientData(mrn) {
-    logger.info('Getting patient data');
+    logger.debug('Getting patient data');
     const data = await this.csvModule.get('mrn', mrn);
     // Should only be one patient with this mrn; get that pat from our arr
     return data[0];

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -8,6 +8,7 @@ const logger = require('../helpers/logger');
 
 // Formats data to be passed into template-friendly format
 function formatData(tpcData) {
+  logger.debug('Reformatting disease status data from CSV into template format');
   return tpcData.map((data) => {
     const { mrn, dateOfCarePlan, changed, reasonCode } = data;
     if (!mrn || !dateOfCarePlan || !changed) {
@@ -48,14 +49,14 @@ class CSVTreatmentPlanChangeExtractor extends Extractor {
   }
 
   async getTPCData(mrn, fromDate, toDate) {
-    logger.info('Getting Treatment Plan Change Data');
+    logger.debug('Getting Treatment Plan Change Data');
     return this.csvModule.get('mrn', mrn, fromDate, toDate);
   }
 
   async get({ mrn, fromDate, toDate }) {
     const tpcData = await this.getTPCData(mrn, fromDate, toDate);
     if (tpcData.length === 0) {
-      logger.warn('No disease status data found for patient');
+      logger.warn('No treatment plan change data found for patient');
       return getEmptyBundle();
     }
 

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -30,7 +30,7 @@ function renderTemplate(template, data) {
 }
 
 function generateMcodeResources(mcodeProfileID, data) {
-  logger.info(`Generating FHIR resource for ${mcodeProfileID} data element`);
+  logger.debug(`Generating FHIR resource for ${mcodeProfileID} data element`);
   const ejsTemplate = loadFhirTemplate(mcodeProfileID);
   if (!ejsTemplate) throw new Error(`No matching profile for ${mcodeProfileID} found`);
   return {

--- a/src/modules/BaseFHIRModule.js
+++ b/src/modules/BaseFHIRModule.js
@@ -12,7 +12,7 @@ class BaseFHIRModule {
   }
 
   async search(resourceType, params) {
-    logger.info(`GET ${this.baseUrl}/${resourceType}`);
+    logger.debug(`GET ${this.baseUrl}/${resourceType}`);
     return this.client.search({ resourceType, params });
   }
 }

--- a/src/modules/CSVModule.js
+++ b/src/modules/CSVModule.js
@@ -9,7 +9,7 @@ class CSVModule {
   }
 
   async get(key, value, fromDate, toDate) {
-    logger.info(`Get csvModule info by key '${key}'`);
+    logger.debug(`Get csvModule info by key '${key}'`);
     // return all rows if key and value aren't provided
     if (!key && !value) return this.data;
     let result = this.data.filter((d) => d[key] === value);


### PR DESCRIPTION
# Summary
Updates all `logger.info` statements to be `logger.debug` statements. 

## New behavior
No new code behavior, but limits the number of statements that get logged when running the CLI using extractors in this repo.

## Code changes
Uses `logger.debug` instead of `logger.info`. I also tried to align the logging statements across extractors, so I added a few debug statements in extractors to match those in the other extractors.

One small side effect is that the `log.warn` statements stand out a little more, but I think they all seem valid as warnings, so I left them.

# Testing guidance
Using the `icare-extraction-client` branch, running the CSV Client should result in fewer log statements and make the output easier to understand but still give a summary of what is happening.

I also have screenshots of the old logs and the new logs, so if you're interested in a side by side comparison, let me know.