### PR TITLE
Expand Patient CSV to handle more values

### DIFF
--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,family,given,gender,dateOfBirth,race,ethnicity,language,address,city,state,zip
-pat-mrn-1,last,first,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
-pat-mrn-2,final,preceding,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201
+mrn,family,given,gender,birthSex,dateOfBirth,race,ethnicity,language,address,city,state,zip
+pat-mrn-1,last,first,female,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
+pat-mrn-2,final,preceding,male,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201

--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,family,given,gender,birthSex,dateOfBirth,race,ethnicity,language,address,city,state,zip
+mrn,family,givenName,genderName,birthSex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
 pat-mrn-1,last,first,female,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
 pat-mrn-2,final,preceding,male,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201

--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,family,given,gender
-pat-mrn-1,last,first,female
-pat-mrn-2,final,preceding,male
+mrn,family,given,gender,dateOfBirth,race,ethnicity,language,address,city,state,zip
+pat-mrn-1,last,first,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
+pat-mrn-2,final,preceding,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201

--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,family,givenName,genderName,birthsex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
+mrn,familyName,givenName,gender,birthsex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
 pat-mrn-1,last,first,female,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
 pat-mrn-2,final,preceding,male,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201

--- a/docs/patient.csv
+++ b/docs/patient.csv
@@ -1,3 +1,3 @@
-mrn,family,givenName,genderName,birthSex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
+mrn,family,givenName,genderName,birthsex,dateOfBirth,race,ethnicity,language,addressLine,city,state,zip
 pat-mrn-1,last,first,female,female,1991-06-21,ASKU,2186-5,no,2 West Side Rd,Malden,MA,02186
 pat-mrn-2,final,preceding,male,male,1986-11-08,2106-3,2186-5,en-US,1 Main street,Brooklyn,NY,11201

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -2,13 +2,16 @@ const path = require('path');
 const { CSVModule } = require('../modules');
 const { generateMcodeResources } = require('../helpers/ejsUtils');
 const { Extractor } = require('./Extractor');
+const { getEthnicityDisplay,
+  getRaceCodesystem,
+  getRaceDisplay } = require('../helpers/patientUtils');
 const logger = require('../helpers/logger');
 
 function joinAndReformatData(patientData) {
   logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
   const {
-    mrn, family, given, gender, dateOfBirth, race, ethnicity, language, address, city, state, zip,
+    mrn, family, given, gender, birthSex, dateOfBirth, race, ethnicity, language, address, city, state, zip,
   } = patientData;
 
   if (!mrn || !family || !given || !gender) {
@@ -21,14 +24,18 @@ function joinAndReformatData(patientData) {
     family,
     given,
     gender,
+    birthSex,
     dateOfBirth,
-    race,
-    ethnicity,
     language,
     address,
     city,
     state,
     zip,
+    raceCode: race,
+    raceCodesystem: getRaceCodesystem(race),
+    raceText: getRaceDisplay(race),
+    ethnicityCode: ethnicity,
+    ethnicityText: getEthnicityDisplay(ethnicity),
   };
 }
 

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -11,23 +11,23 @@ function joinAndReformatData(patientData) {
   logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
   const {
-    mrn, family, given, gender, birthSex, dateOfBirth, race, ethnicity, language, address, city, state, zip,
+    mrn, familyName, givenName, gender, birthSex, dateOfBirth, race, ethnicity, language, addressLine, city, state, zip,
   } = patientData;
 
-  if (!mrn || !family || !given || !gender) {
-    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, family, given, gender');
+  if (!mrn || !familyName || !givenName || !gender) {
+    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, familyName, given, gender');
   }
 
   return {
     id: mrn,
     mrn,
-    family,
-    given,
+    familyName,
+    givenName,
     gender,
     birthSex,
     dateOfBirth,
     language,
-    address,
+    addressLine,
     city,
     state,
     zip,

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -7,7 +7,13 @@ const logger = require('../helpers/logger');
 function joinAndReformatData(patientData) {
   logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
-  const { mrn, family, given, gender, dateOfBirth, race, ethnicity, language, address, city, state, zip } = patientData;
+  const {
+    mrn, family, given, gender, dateOfBirth, race, ethnicity, language, address, city, state, zip,
+  } = patientData;
+
+  if (!mrn || !family || !given || !gender) {
+    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, family, given, gender');
+  }
 
   return {
     id: mrn,

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -15,7 +15,7 @@ function joinAndReformatData(patientData) {
   } = patientData;
 
   if (!mrn || !familyName || !givenName || !gender) {
-    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, familyName, given, gender');
+    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, familyName, givenName, gender');
   }
 
   return {

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -7,7 +7,7 @@ const logger = require('../helpers/logger');
 function joinAndReformatData(patientData) {
   logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
-  const { mrn, family, given, gender } = patientData;
+  const { mrn, family, given, gender, dateOfBirth, race, ethnicity, language, address, city, state, zip } = patientData;
 
   return {
     id: mrn,
@@ -15,6 +15,14 @@ function joinAndReformatData(patientData) {
     family,
     given,
     gender,
+    dateOfBirth,
+    race,
+    ethnicity,
+    language,
+    address,
+    city,
+    state,
+    zip,
   };
 }
 

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -11,7 +11,7 @@ function joinAndReformatData(patientData) {
   logger.debug('Reformatting patient data from CSV into template format');
   // No join needed, just a reformatting
   const {
-    mrn, familyName, givenName, gender, birthSex, dateOfBirth, race, ethnicity, language, addressLine, city, state, zip,
+    mrn, familyName, givenName, gender, birthsex, dateOfBirth, race, ethnicity, language, addressLine, city, state, zip,
   } = patientData;
 
   if (!mrn || !familyName || !givenName || !gender) {
@@ -24,7 +24,7 @@ function joinAndReformatData(patientData) {
     familyName,
     givenName,
     gender,
-    birthSex,
+    birthsex,
     dateOfBirth,
     language,
     addressLine,

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -31,7 +31,7 @@ const evidenceCodeToTextLookup = invertObject(evidenceTextToCodeLookup);
 
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
- * @param text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
+ * @param {string} text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
  * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
  */
 function getDiseaseStatusCode(text) {
@@ -40,7 +40,7 @@ function getDiseaseStatusCode(text) {
 
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
- * @param code - limited to codes in the diseaseStatusTextToCodeLookup above
+ * @param {string} code - limited to codes in the diseaseStatusTextToCodeLookup above
  * @return {string} corresponding code from mCODE's ConditionStatusTrendVS
  */
 function getDiseaseStatusDisplay(code) {
@@ -49,7 +49,7 @@ function getDiseaseStatusDisplay(code) {
 
 /**
  * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
- * @param text - limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
+ * @param {string} text - limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
  * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceCode(text) {
@@ -58,7 +58,7 @@ function getDiseaseStatusEvidenceCode(text) {
 
 /**
  * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
- * @param code - limited to codes in the evidenceTextToCodeLookup above
+ * @param {string} code - limited to codes in the evidenceTextToCodeLookup above
  * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceDisplay(code) {

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -1,14 +1,5 @@
 const moment = require('moment');
-
-// Helper function for inverting a object's keys and values s.t. (k->v) becomes (v->k)
-function invert(obj) {
-  return Object.entries(obj).reduce((ret, entry) => {
-    const [key, value] = entry;
-    // eslint-disable-next-line no-param-reassign
-    ret[value] = key;
-    return ret;
-  }, {});
-}
+const { invertObject } = require('./helperUtils')
 
 // Translate an M-language epoch date to an appropriate moment date
 function mEpochToDate(date) {
@@ -25,7 +16,7 @@ const diseaseStatusTextToCodeLookup = {
   progressing: 271299001,
   'not evaluated': 709137006,
 };
-const diseaseStatusCodeToTextLookup = invert(diseaseStatusTextToCodeLookup);
+const diseaseStatusCodeToTextLookup = invertObject(diseaseStatusTextToCodeLookup);
 
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for Reason
@@ -36,11 +27,11 @@ const evidenceTextToCodeLookup = {
   'physical exam': 5880005,
   'lab results': 386344002,
 };
-const evidenceCodeToTextLookup = invert(evidenceTextToCodeLookup);
+const evidenceCodeToTextLookup = invertObject(evidenceTextToCodeLookup);
 
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
- * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @param text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
  * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
  */
 function getDiseaseStatusCode(text) {
@@ -49,7 +40,7 @@ function getDiseaseStatusCode(text) {
 
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
- * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @param text, limited to codes in the diseaseStatusTextToCodeLookup above
  * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
  */
 function getDiseaseStatusDisplay(code) {
@@ -58,7 +49,7 @@ function getDiseaseStatusDisplay(code) {
 
 /**
  * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
- * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @param text, limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
  * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceCode(text) {
@@ -67,7 +58,7 @@ function getDiseaseStatusEvidenceCode(text) {
 
 /**
  * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
- * @param text, limited to No evidence of disease, Responding, Stable, Progressing, or not evaluated
+ * @param text, limited to codes in the evidenceTextToCodeLookup above
  * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceDisplay(code) {

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -32,7 +32,7 @@ const evidenceCodeToTextLookup = invertObject(evidenceTextToCodeLookup);
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
  * @param {string} text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
- * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ * @return {code} corresponding DiseaseStatus code
  */
 function getDiseaseStatusCode(text) {
   return diseaseStatusTextToCodeLookup[text];
@@ -41,7 +41,7 @@ function getDiseaseStatusCode(text) {
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
  * @param {string} code - limited to codes in the diseaseStatusTextToCodeLookup above
- * @return {string} corresponding code from mCODE's ConditionStatusTrendVS
+ * @return {string} corresponding DiseaseStatus display text
  */
 function getDiseaseStatusDisplay(code) {
   return diseaseStatusCodeToTextLookup[code];
@@ -50,7 +50,7 @@ function getDiseaseStatusDisplay(code) {
 /**
  * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
  * @param {string} text - limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
- * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
+ * @return {string} corresponding Evidence code
  */
 function getDiseaseStatusEvidenceCode(text) {
   return evidenceTextToCodeLookup[text];
@@ -59,7 +59,7 @@ function getDiseaseStatusEvidenceCode(text) {
 /**
  * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
  * @param {string} code - limited to codes in the evidenceTextToCodeLookup above
- * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
+ * @return {string} corresponding Evidence display text
  */
 function getDiseaseStatusEvidenceDisplay(code) {
   return evidenceCodeToTextLookup[code];

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -1,5 +1,5 @@
 const moment = require('moment');
-const { invertObject } = require('./helperUtils')
+const { invertObject } = require('./helperUtils');
 
 // Translate an M-language epoch date to an appropriate moment date
 function mEpochToDate(date) {

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -40,8 +40,8 @@ function getDiseaseStatusCode(text) {
 
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
- * @param text, limited to codes in the diseaseStatusTextToCodeLookup above
- * @return {code} corresponding code from mCODE's ConditionStatusTrendVS
+ * @param code - limited to codes in the diseaseStatusTextToCodeLookup above
+ * @return {string} corresponding code from mCODE's ConditionStatusTrendVS
  */
 function getDiseaseStatusDisplay(code) {
   return diseaseStatusCodeToTextLookup[code];
@@ -49,8 +49,8 @@ function getDiseaseStatusDisplay(code) {
 
 /**
  * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
- * @param text, limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
- * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
+ * @param text - limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
+ * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceCode(text) {
   return evidenceTextToCodeLookup[text];
@@ -58,8 +58,8 @@ function getDiseaseStatusEvidenceCode(text) {
 
 /**
  * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
- * @param text, limited to codes in the evidenceTextToCodeLookup above
- * @return {code} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
+ * @param code - limited to codes in the evidenceTextToCodeLookup above
+ * @return {string} corresponding code from mCODE's CancerDiseaseStatusEvidenceTypeVS
  */
 function getDiseaseStatusEvidenceDisplay(code) {
   return evidenceCodeToTextLookup[code];

--- a/src/helpers/helperUtils.js
+++ b/src/helpers/helperUtils.js
@@ -9,5 +9,5 @@ function invertObject(obj) {
 }
 
 module.exports = {
-  invertObject
-}
+  invertObject,
+};

--- a/src/helpers/helperUtils.js
+++ b/src/helpers/helperUtils.js
@@ -1,0 +1,13 @@
+// Helper function for inverting a object's keys and values s.t. (k->v) becomes (v->k)
+function invertObject(obj) {
+  return Object.entries(obj).reduce((ret, entry) => {
+    const [key, value] = entry;
+    // eslint-disable-next-line no-param-reassign
+    ret[value] = key;
+    return ret;
+  }, {});
+}
+
+module.exports = {
+  invertObject
+}

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -1,9 +1,7 @@
-const { invertObject } = require('./helperUtils')
-
 // Based on the OMB Ethnicity table found here:http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-ethnicity-category.html
 const ethnicityCodeToDisplay = {
-  "2135-2": "Hispanic or Latino",
-  "2186-5": "Non Hispanic or Latino",
+  '2135-2': 'Hispanic or Latino',
+  '2186-5': 'Non Hispanic or Latino',
 };
 
 /**
@@ -18,13 +16,13 @@ function getEthnicityDisplay(code) {
 
 // Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
 const raceCodeToCodesystem = {
-  "1002-5": "urn:oid:2.16.840.1.113883.6.238",
-  "2028-9": "urn:oid:2.16.840.1.113883.6.238",
-  "2054-5": "urn:oid:2.16.840.1.113883.6.238",
-  "2076-8": "urn:oid:2.16.840.1.113883.6.238",
-  "2106-3": "urn:oid:2.16.840.1.113883.6.238",
-  "UNK": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
-  "ASKU": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+  '1002-5': 'urn:oid:2.16.840.1.113883.6.238',
+  '2028-9': 'urn:oid:2.16.840.1.113883.6.238',
+  '2054-5': 'urn:oid:2.16.840.1.113883.6.238',
+  '2076-8': 'urn:oid:2.16.840.1.113883.6.238',
+  '2106-3': 'urn:oid:2.16.840.1.113883.6.238',
+  UNK: 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
+  ASKU: 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
 };
 
 /**
@@ -39,13 +37,13 @@ function getRaceCodesystem(code) {
 
 // Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
 const raceCodeToDisplay = {
-  "1002-5": "American Indian or Alaska Native",
-  "2028-9": "Asian",
-  "2054-5": "Black or African American",
-  "2076-8": "Native Hawaiian or Other Pacific Islander",
-  "2106-3": "White",
-  "UNK": "Unknown Description: A proper value is applicable, but not known",
-  "ASKU": "Asked but no answer",
+  '1002-5': 'American Indian or Alaska Native',
+  '2028-9': 'Asian',
+  '2054-5': 'Black or African American',
+  '2076-8': 'Native Hawaiian or Other Pacific Islander',
+  '2106-3': 'White',
+  UNK: 'Unknown Description: A proper value is applicable, but not known',
+  ASKU: 'Asked but no answer',
 };
 
 /**

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -1,7 +1,78 @@
+const { invertObject } = require('./helperUtils')
+
+// Based on the OMB Ethnicity table found here:http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-ethnicity-category.html
+const ethnicityCodeToDisplay = {
+  "2135-2": "Hispanic or Latino",
+  "2186-5": "Non Hispanic or Latino",
+};
+
+/**
+ * Converts code in OMB Ethnicity to Text Value
+ * @param {string} code, coded ethinicity value from the above table
+ * @return {string} display code from the OMB Ethnicity table
+ */
+function getEthnicityDisplay(code) {
+  return ethnicityCodeToDisplay[code];
+}
+
+
+// Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
+const raceCodeToCodesystem = {
+  "1002-5": "urn:oid:2.16.840.1.113883.6.238",
+  "2028-9": "urn:oid:2.16.840.1.113883.6.238",
+  "2054-5": "urn:oid:2.16.840.1.113883.6.238",
+  "2076-8": "urn:oid:2.16.840.1.113883.6.238",
+  "2106-3": "urn:oid:2.16.840.1.113883.6.238",
+  "UNK": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+  "ASKU": "http://terminology.hl7.org/CodeSystem/v3-NullFlavor",
+};
+
+/**
+ * Converts code in OMB Race to a codesystem value
+ * @param {string} code, coded race value from the above table
+ * @return {string} corresponding codesystem found in the OMB Race table f
+ */
+function getRaceCodesystem(code) {
+  return raceCodeToCodesystem[code];
+}
+
+
+// Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
+const raceCodeToDisplay = {
+  "1002-5": "American Indian or Alaska Native",
+  "2028-9": "Asian",
+  "2054-5": "Black or African American",
+  "2076-8": "Native Hawaiian or Other Pacific Islander",
+  "2106-3": "White",
+  "UNK": "Unknown Description: A proper value is applicable, but not known",
+  "ASKU": "Asked but no answer",
+};
+
+/**
+ * Converts code in OMB Race to a display value
+ * @param {string} code, coded race value from the above table
+ * @return {string} corresponding code from mCODE's ConditionStatusTrendVS
+ */
+function getRaceDisplay(code) {
+  return raceCodeToDisplay[code];
+}
+
+
+/**
+ * Turn a name object into a single name string
+ * @param {Object} name object of the following shape: [{
+ *   given: Array[String],
+ *   ƒamily: String,
+ * }]
+ * @return {string} concatenated string of name values
+ */
 function getPatientName(name) {
   return `${name[0].given.join(' ')} ${name[0].family}`;
 }
 
 module.exports = {
+  getEthnicityDisplay,
+  getRaceCodesystem,
+  getRaceDisplay,
   getPatientName,
 };

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -57,7 +57,7 @@ function getRaceDisplay(code) {
 
 
 /**
- * Turn a name object into a single name string
+ * Turn a FHIR name object into a single name string
  * @param {Object} name object of the following shape: [{
  *   given: Array[String],
  *   ƒamily: String,

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,10 @@ const {
   FHIRProcedureExtractor,
 } = require('./extractors');
 const { BaseFHIRModule, CSVModule } = require('./modules');
-const { getPatientName } = require('./helpers/patientUtils');
+const { getEthnicityDisplay,
+  getPatientName,
+  getRaceCodesystem,
+  getRaceDisplay } = require('./helpers/patientUtils');
 const {
   allResourcesInBundle,
   firstEntryInBundle,
@@ -64,18 +67,21 @@ module.exports = {
   firstResourceInBundle,
   formatDate,
   formatDateTime,
-  getEmptyBundle,
   generateMcodeResources,
   getBundleEntriesByResourceType,
   getBundleResourcesByType,
   getDiseaseStatusCode,
   getDiseaseStatusEvidenceCode,
+  getEmptyBundle,
+  getEthnicityDisplay,
   getICD10Code,
   getPatientName,
+  getRaceCodesystem,
+  getRaceDisplay,
   isBundleEmpty,
   isConditionCodePrimary,
-  isConditionPrimary,
   isConditionCodeSecondary,
+  isConditionPrimary,
   isConditionSecondary,
   mEpochToDate,
 };

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -59,7 +59,7 @@
       "postalCode": "<%- zip %>",
       "country": "US"
     }
-  ]<% } %><% if (language) { %>,
+  ]<% } %><% if (locals.language && language) { %>,
   "communication": [
     {
       "language": {
@@ -68,7 +68,7 @@
             "system": "urn:ietf:bcp:47",
             "code": "<%- language %>"
           }
-        ],
+        ]
       }
     }
   ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText)) { %>,
@@ -88,8 +88,8 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-    }<% } %><% if ((raceCodesystem && raceCode && raceText) && (ethnicityCode && ethnicityText)) { %>,<% } %>
-    <% if (ethnicityCode && ethnicityText) { %> {
+    }<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) && (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText)) { %>,<% } %>
+    <% if (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) { %> {
       "extension": [
         {
           "url": "ombCategory",

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -8,6 +8,7 @@
   family: String,
   given: String,
   gender: String,
+  birthSex: String,
   dateOfBirth: String,
   language: String,
   address: String,
@@ -71,7 +72,7 @@
         ]
       }
     }
-  ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText)) { %>,
+  ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthSex && birthSex)) { %>,
   "extension": [
     <% if (locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) { %> {
       "extension": [
@@ -88,7 +89,7 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-    }<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) && (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText)) { %>,<% } %>
+    }<% if ((locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthSex && birthSex)) { %>,<% } %><% } %>
     <% if (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) { %> {
       "extension": [
         {
@@ -104,6 +105,10 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+    }<% if (locals.birthSex && birthSex) { %>,<% } %><% } %>
+    <% if (locals.birthSex && birthSex) { %> {
+      "url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+      "valueCode" : "<%- birthSex %>"
     }<% } %>
   ]<% } %>
 }

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -49,15 +49,15 @@
       }
   ],
   "gender": "<%- gender %>"<% if(locals.dateOfBirth && dateOfBirth) { %>,
-  "birthDate": "<%- dateOfBirth%>"<% } %><% if (locals.address && address && locals.city && city && locals.state && state && locals.zip && zip) { %>,
+  "birthDate": "<%- dateOfBirth%>"<% } %><% if (locals.address || locals.city || locals.state || locals.zip) { %>,
   "address": [
     {
-      "line": [
+      <% if (locals.address && address) { %>"line": [
         "<%- address %>"
-      ],
-      "city": "<%- city %>",
-      "state": "<%- state %>",
-      "postalCode": "<%- zip %>",
+      ],<% } %>
+      <% if (locals.city && city) { %>"city": "<%- city %>",<% } %>
+      <% if (locals.state && state) { %>"state": "<%- state %>",<% } %>
+      <% if (locals.zip && zip) { %>"postalCode": "<%- zip %>",<% } %>
       "country": "US"
     }
   ]<% } %><% if (locals.language && language) { %>,

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -5,13 +5,13 @@
 {
   id: String,
   mrn: String,
-  family: String,
-  given: String,
+  familyName: String,
+  givenName: String,
   gender: String,
   birthSex: String,
   dateOfBirth: String,
   language: String,
-  address: String,
+  addressLine: String,
   city: String,
   state: String,
   zip: String,
@@ -43,17 +43,17 @@
   ],
   "name": [
       {
-          "text": "<%- `${given} ${family}` %>",
-          "family": "<%- family %>",
-          "given": [ <%- given.split(' ').map(e => `"${e}"`) %> ]
+          "text": "<%- `${givenName} ${familyName}` %>",
+          "family": "<%- familyName %>",
+          "given": [ <%- givenName.split(' ').map(e => `"${e}"`) %> ]
       }
   ],
   "gender": "<%- gender %>"<% if(locals.dateOfBirth && dateOfBirth) { %>,
-  "birthDate": "<%- dateOfBirth%>"<% } %><% if (locals.address || locals.city || locals.state || locals.zip) { %>,
+  "birthDate": "<%- dateOfBirth%>"<% } %><% if (locals.addressLine || locals.city || locals.state || locals.zip) { %>,
   "address": [
     {
-      <% if (locals.address && address) { %>"line": [
-        "<%- address %>"
+      <% if (locals.addressLine && addressLine) { %>"line": [
+        "<%- addressLine %>"
       ],<% } %>
       <% if (locals.city && city) { %>"city": "<%- city %>",<% } %>
       <% if (locals.state && state) { %>"state": "<%- state %>",<% } %>

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -1,6 +1,6 @@
 <%# Patient Template %>
 <%# Based on http://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html %>
-<%# Official url: http://hl7.org/fhir/us/mcode/StructureDefinition/obf-Patient %>
+<%# Official url: http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-patient %>
 <% /* %>
 {
   id: String,

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -8,7 +8,7 @@
   familyName: String,
   givenName: String,
   gender: String,
-  birthSex: String,
+  birthsex: String,
   dateOfBirth: String,
   language: String,
   addressLine: String,
@@ -72,7 +72,7 @@
         ]
       }
     }
-  ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthSex && birthSex)) { %>,
+  ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthsex && birthsex)) { %>,
   "extension": [
     <% if (locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) { %> {
       "extension": [
@@ -89,7 +89,7 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
-    }<% if ((locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthSex && birthSex)) { %>,<% } %><% } %>
+    }<% if ((locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) || (locals.birthsex && birthsex)) { %>,<% } %><% } %>
     <% if (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText) { %> {
       "extension": [
         {
@@ -105,10 +105,10 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
-    }<% if (locals.birthSex && birthSex) { %>,<% } %><% } %>
-    <% if (locals.birthSex && birthSex) { %> {
+    }<% if (locals.birthsex && birthsex) { %>,<% } %><% } %>
+    <% if (locals.birthsex && birthsex) { %> {
       "url" : "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
-      "valueCode" : "<%- birthSex %>"
+      "valueCode" : "<%- birthsex %>"
     }<% } %>
   ]<% } %>
 }

--- a/src/templates/Patient.ejs
+++ b/src/templates/Patient.ejs
@@ -1,5 +1,5 @@
 <%# Patient Template %>
-<%# Based on https://mcodeinitiative.github.io/StructureDefinition-obf-Patient.html %>
+<%# Based on http://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html %>
 <%# Official url: http://hl7.org/fhir/us/mcode/StructureDefinition/obf-Patient %>
 <% /* %>
 {
@@ -8,33 +8,102 @@
   family: String,
   given: String,
   gender: String,
+  dateOfBirth: String,
+  language: String,
+  address: String,
+  city: String,
+  state: String,
+  zip: String,
+  raceCodesystem: String,
+  raceCode: String,
+  raceText: String,
+  ethnicityCode: String,
+  ethnicityText: String,
 }
 <% */ %>
 {
-    "resourceType": "Patient",
-    "id": "<%- id %>",
-    "identifier": [
+  "resourceType": "Patient",
+  "id": "<%- id %>",
+  "identifier": [
+      {
+          "type" : {
+              "coding" : [
+                {
+                  "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code" : "MR",
+                  "display" : "Medical Record Number"
+                }
+              ],
+              "text" : "Medical Record Number"
+          },
+          "system": "http://example.com/system/mrn",
+          "value": "<%- mrn %>"
+      }
+  ],
+  "name": [
+      {
+          "text": "<%- `${given} ${family}` %>",
+          "family": "<%- family %>",
+          "given": [ <%- given.split(' ').map(e => `"${e}"`) %> ]
+      }
+  ],
+  "gender": "<%- gender %>"<% if(locals.dateOfBirth && dateOfBirth) { %>,
+  "birthDate": "<%- dateOfBirth%>"<% } %><% if (locals.address && address && locals.city && city && locals.state && state && locals.zip && zip) { %>,
+  "address": [
+    {
+      "line": [
+        "<%- address %>"
+      ],
+      "city": "<%- city %>",
+      "state": "<%- state %>",
+      "postalCode": "<%- zip %>",
+      "country": "US"
+    }
+  ]<% } %><% if (language) { %>,
+  "communication": [
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "<%- language %>"
+          }
+        ],
+      }
+    }
+  ]<% } %><% if ((locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) || (locals.ethnicityCode && locals.ethnicityText && ethnicityCode && ethnicityText)) { %>,
+  "extension": [
+    <% if (locals.raceCodesystem && locals.raceCode && locals.raceText && raceCodesystem && raceCode && raceText) { %> {
+      "extension": [
         {
-            "type" : {
-                "coding" : [
-                  {
-                    "system" : "http://terminology.hl7.org/CodeSystem/v2-0203",
-                    "code" : "MR",
-                    "display" : "Medical Record Number"
-                  }
-                ],
-                "text" : "Medical Record Number"
-            },
-            "system": "http://example.com/system/mrn",
-            "value": "<%- mrn %>"
-        }
-    ],
-    "name": [
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "<%- raceCodesystem %>",
+            "code": "<%- raceCode %>"
+          }
+        },
         {
-            "text": "<%- `${given} ${family}` %>",
-            "family": "<%- family %>",
-            "given": [ <%- given.split(' ').map(e => `"${e}"`) %> ]
+          "url": "text",
+          "valueString": "<%- raceText %>"
         }
-    ],
-    "gender": "<%- gender %>"
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+    }<% } %><% if ((raceCodesystem && raceCode && raceText) && (ethnicityCode && ethnicityText)) { %>,<% } %>
+    <% if (ethnicityCode && ethnicityText) { %> {
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "<%- ethnicityCode %>"
+          }
+        },
+        {
+          "url": "text",
+          "valueString": "<%- ethnicityText %>"
+        }
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+    }<% } %>
+  ]<% } %>
 }

--- a/test/extractors/CSVPatientExtractor.test.js
+++ b/test/extractors/CSVPatientExtractor.test.js
@@ -23,6 +23,7 @@ csvModuleSpy
 describe('CSV Patient Extractor tests', () => {
   test('get should return a fhir bundle when MRN is known', async () => {
     const data = await csvPatientExtractor.get({ mrn: MOCK_PATIENT_MRN });
+    console.log('data', JSON.stringify(data));
 
     expect(data.resourceType).toEqual('Bundle');
     expect(data.type).toEqual('collection');

--- a/test/extractors/CSVPatientExtractor.test.js
+++ b/test/extractors/CSVPatientExtractor.test.js
@@ -14,21 +14,23 @@ const csvPatientExtractor = new CSVPatientExtractor({
 
 // Destructure all modules
 const { csvModule } = csvPatientExtractor;
-
 // Spy on csvModule
 const csvModuleSpy = jest.spyOn(csvModule, 'get');
-csvModuleSpy
-  .mockReturnValue(examplePatientResponse);
 
-describe('CSV Patient Extractor tests', () => {
-  test('get should return a fhir bundle when MRN is known', async () => {
-    const data = await csvPatientExtractor.get({ mrn: MOCK_PATIENT_MRN });
-    console.log('data', JSON.stringify(data));
 
-    expect(data.resourceType).toEqual('Bundle');
-    expect(data.type).toEqual('collection');
-    expect(data.entry).toBeDefined();
-    expect(data.entry.length).toEqual(1);
-    expect(data.entry).toEqual(examplePatientBundle.entry);
+describe('CSV Patient Extractor', () => {
+  describe('get', () => {
+    test('should return a fhir bundle when MRN is known', async () => {
+      csvModuleSpy.mockReset();
+      csvModuleSpy
+        .mockReturnValue(examplePatientResponse);
+      const data = await csvPatientExtractor.get({ mrn: MOCK_PATIENT_MRN });
+
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry).toBeDefined();
+      expect(data.entry.length).toEqual(1);
+      expect(data.entry).toEqual(examplePatientBundle.entry);
+    });
   });
 });

--- a/test/extractors/fixtures/csv-patient-bundle.json
+++ b/test/extractors/fixtures/csv-patient-bundle.json
@@ -59,6 +59,38 @@
         ],
         "extension": [
           {
+          "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "1002-5",
+                  "system": "urn:oid:2.16.840.1.113883.6.238"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "American Indian or Alaska Native"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "system": "urn:oid:2.16.840.1.113883.6.238"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Non Hispanic or Latino"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+          },
+          {
             "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
             "valueCode": "male"
           }

--- a/test/extractors/fixtures/csv-patient-bundle.json
+++ b/test/extractors/fixtures/csv-patient-bundle.json
@@ -56,6 +56,12 @@
               ]
             }
           }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "male"
+          }
         ]
       }
     }

--- a/test/extractors/fixtures/csv-patient-bundle.json
+++ b/test/extractors/fixtures/csv-patient-bundle.json
@@ -32,7 +32,31 @@
             ]
           }
         ],
-        "gender": "male"
+        "gender": "male",
+        "birthDate": "1994-08-24",
+        "address": [
+          {
+            "line": [
+              "57 Adams St"
+            ],
+            "city": "New Rochelle",
+            "state": "NY",
+            "postalCode": "10801",
+            "country": "US"
+          }
+        ],
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en"
+                }
+              ]
+            }
+          }
+        ]
       }
     }
   ]

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -4,6 +4,7 @@
     "family": "Marshall",
     "given": "Archy",
     "gender": "male",
+    "birthSex": "male",
     "dateOfBirth":"1994-08-24",
     "language": "en",
     "address": "57 Adams St",

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -5,6 +5,15 @@
     "given": "Archy",
     "gender": "male",
     "dateOfBirth":"1994-08-24",
-    "language": null
+    "language": "en",
+    "address": "57 Adams St",
+    "city": "New Rochelle",
+    "state": "NY",
+    "zip": "10801",
+    "raceCodesystem": "http://some.codesystem.com",
+    "raceCode": "29178",
+    "raceText": "Some Race",
+    "ethnicityCode": "90210",
+    "ethnicityText": "Some Ethnicity"
   }
 ]

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -3,6 +3,8 @@
     "mrn": "119147111821125",
     "family": "Marshall",
     "given": "Archy",
-    "gender": "male"
+    "gender": "male",
+    "dateOfBirth":"1994-08-24",
+    "language": null
   }
 ]

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -1,20 +1,17 @@
 [
   {
     "mrn": "119147111821125",
-    "family": "Marshall",
-    "given": "Archy",
+    "familyName": "Marshall",
+    "givenName": "Archy",
     "gender": "male",
     "birthSex": "male",
     "dateOfBirth":"1994-08-24",
     "language": "en",
-    "address": "57 Adams St",
+    "addressLine": "57 Adams St",
     "city": "New Rochelle",
     "state": "NY",
     "zip": "10801",
-    "raceCodesystem": "http://some.codesystem.com",
-    "raceCode": "29178",
-    "raceText": "Some Race",
-    "ethnicityCode": "90210",
-    "ethnicityText": "Some Ethnicity"
+    "race": "1002-5",
+    "ethnicity": "2186-5"
   }
 ]

--- a/test/extractors/fixtures/csv-patient-module-response.json
+++ b/test/extractors/fixtures/csv-patient-module-response.json
@@ -4,7 +4,7 @@
     "familyName": "Marshall",
     "givenName": "Archy",
     "gender": "male",
-    "birthSex": "male",
+    "birthsex": "male",
     "dateOfBirth":"1994-08-24",
     "language": "en",
     "addressLine": "57 Adams St",

--- a/test/extractors/fixtures/patient-bundle.json
+++ b/test/extractors/fixtures/patient-bundle.json
@@ -64,7 +64,7 @@
             "use": "usual",
             "text": "Elizabeth-Test Smith-Mitre",
             "family": [
-              "Smith-Mitre"
+            "Smith-Mitre"
             ],
             "given": [
               "Elizabeth-Test"

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -70,7 +70,7 @@ describe('PatientUtils', () => {
     });
   });
   describe('getPatientName', () => {
-    test('valid name object is concatenated', () => {
+    test('valid FHIR name object is concatenated', () => {
       const name = [{
         given: ['Peter', 'Christen'],
         family: 'Asbjørnsen',

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -1,0 +1,82 @@
+const { getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName } = require('../../src/helpers/patientUtils');
+
+
+describe('PatientUtils', () => {
+  describe('getEthnicityDisplay', () => {
+    // Based on the OMB Ethnicity table found here:http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-ethnicity-category.html
+    const ethnicityCodeToDisplay = {
+      '2135-2': 'Hispanic or Latino',
+      '2186-5': 'Non Hispanic or Latino',
+    };
+    test('no code should return undefined', () => {
+      expect(getEthnicityDisplay()).toBeUndefined();
+    });
+    test('invalid codes should return undefined', () => {
+      const invalidCode = 'anything';
+      expect(getEthnicityDisplay(invalidCode)).toBeUndefined();
+    });
+    test('Valid codes should return a recognizable string ', () => {
+      const validEthnicityCode = Object.keys(ethnicityCodeToDisplay)[0];
+      const expectedEthnicityDisplay = ethnicityCodeToDisplay[validEthnicityCode];
+      expect(getEthnicityDisplay(validEthnicityCode)).toBe(expectedEthnicityDisplay);
+    });
+  });
+  describe('getRaceCodesystem', () => {
+    // Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
+    const raceCodeToCodesystem = {
+      '1002-5': 'urn:oid:2.16.840.1.113883.6.238',
+      '2028-9': 'urn:oid:2.16.840.1.113883.6.238',
+      '2054-5': 'urn:oid:2.16.840.1.113883.6.238',
+      '2076-8': 'urn:oid:2.16.840.1.113883.6.238',
+      '2106-3': 'urn:oid:2.16.840.1.113883.6.238',
+      UNK: 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
+      ASKU: 'http://terminology.hl7.org/CodeSystem/v3-NullFlavor',
+    };
+    test('no code should return undefined', () => {
+      expect(getRaceCodesystem()).toBeUndefined();
+    });
+    test('invalid codes should return undefined', () => {
+      const invalidCode = 'anything';
+      expect(getRaceCodesystem(invalidCode)).toBeUndefined();
+    });
+    test('Valid codes should return a recognizable race codesystem ', () => {
+      const validRaceCode = Object.keys(raceCodeToCodesystem)[0];
+      const expectedCodeSystem = raceCodeToCodesystem[validRaceCode];
+      expect(getRaceCodesystem(validRaceCode)).toBe(expectedCodeSystem);
+    });
+  });
+  describe('getRaceDisplay', () => {
+    // Based on the OMB Race table found here: http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
+    const raceCodeToDisplay = {
+      '1002-5': 'American Indian or Alaska Native',
+      '2028-9': 'Asian',
+      '2054-5': 'Black or African American',
+      '2076-8': 'Native Hawaiian or Other Pacific Islander',
+      '2106-3': 'White',
+      UNK: 'Unknown Description: A proper value is applicable, but not known',
+      ASKU: 'Asked but no answer',
+    };
+    test('no code should return undefined', () => {
+      expect(getRaceDisplay()).toBeUndefined();
+    });
+    test('invalid codes should return undefined', () => {
+      const invalidCode = 'anything';
+      expect(getRaceDisplay(invalidCode)).toBeUndefined();
+    });
+    test('Valid codes should return a recognizable race display', () => {
+      const validRaceCode = Object.keys(raceCodeToDisplay)[0];
+      const validRaceDisplay = raceCodeToDisplay[validRaceCode];
+      expect(getRaceDisplay(validRaceCode)).toBe(validRaceDisplay);
+    });
+  });
+  describe('getPatientName', () => {
+    test('valid name object is concatenated', () => {
+      const name = [{
+        given: ['Peter', 'Christen'],
+        family: 'Asbjørnsen',
+      }];
+      const expectedConcatenatedName = 'Peter Christen Asbjørnsen';
+      expect(getPatientName(name)).toBe(expectedConcatenatedName);
+    });
+  });
+});

--- a/test/templates/fixtures/maximal-patient-resource.json
+++ b/test/templates/fixtures/maximal-patient-resource.json
@@ -83,6 +83,10 @@
         }
       ],
       "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+    },
+    {
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+      "valueCode": "female"
     }
   ]
 }

--- a/test/templates/fixtures/maximal-patient-resource.json
+++ b/test/templates/fixtures/maximal-patient-resource.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "Patient",
+  "id": "Some Id",
+  "identifier": [
+    {
+      "type": {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+            "code": "MR",
+            "display": "Medical Record Number"
+          }
+        ],
+        "text": "Medical Record Number"
+      },
+      "system": "http://example.com/system/mrn",
+      "value": "1234"
+    }
+  ],
+  "name": [
+    {
+      "text": "Test Patient",
+      "family": "Patient",
+      "given": [
+        "Test"
+      ]
+    }
+  ],
+  "gender": "female",
+  "birthDate": "2001-02-06",
+  "address": [
+    {
+      "line": [
+        "57 Adams St"
+      ],
+      "city": "New Rochelle",
+      "state": "NY",
+      "postalCode": "10801",
+      "country": "US"
+    }
+  ],
+  "communication": [
+    {
+      "language": {
+        "coding": [
+          {
+            "system": "urn:ietf:bcp:47",
+            "code": "en"
+          }
+        ]
+      }
+    }
+  ],
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "http://some.codesystem.com",
+            "code": "29178"
+          }
+        },
+        {
+          "url": "text",
+          "valueString": "Some Race"
+        }
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+    },
+    {
+      "extension": [
+        {
+          "url": "ombCategory",
+          "valueCoding": {
+            "system": "urn:oid:2.16.840.1.113883.6.238",
+            "code": "90210"
+          }
+        },
+        {
+          "url": "text",
+          "valueString": "Some Ethnicity"
+        }
+      ],
+      "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+    }
+  ]
+}

--- a/test/templates/fixtures/patient-resource.json
+++ b/test/templates/fixtures/patient-resource.json
@@ -1,6 +1,6 @@
 {
   "resourceType": "Patient",
-  "id": "example-id",
+  "id": "Some Id",
   "identifier": [
     {
       "type": {

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -29,7 +29,7 @@ describe('EJS Render Patient', () => {
       familyName: 'Patient',
       givenName: 'Test',
       gender: 'female',
-      birthSex: 'female',
+      birthsex: 'female',
       dateOfBirth: '2001-02-06',
       language: 'en',
       addressLine: '57 Adams St',

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -12,8 +12,8 @@ describe('EJS Render Patient', () => {
     const PATIENT_VALID_DATA = {
       id: 'Some Id',
       mrn: '1234',
-      family: 'Patient',
-      given: 'Test',
+      familyName: 'Patient',
+      givenName: 'Test',
       gender: 'female',
     };
     const generatedPatient = renderTemplate(
@@ -26,13 +26,13 @@ describe('EJS Render Patient', () => {
     const MAX_PATIENT_DATA = {
       id: 'Some Id',
       mrn: '1234',
-      family: 'Patient',
-      given: 'Test',
+      familyName: 'Patient',
+      givenName: 'Test',
       gender: 'female',
       birthSex: 'female',
       dateOfBirth: '2001-02-06',
       language: 'en',
-      address: '57 Adams St',
+      addressLine: '57 Adams St',
       city: 'New Rochelle',
       state: 'NY',
       zip: '10801',
@@ -54,14 +54,14 @@ describe('EJS Render Patient', () => {
     const NECESSARY_DATA = {
       id: 'Some Id',
       mrn: '1234',
-      family: 'Patient',
-      given: 'Test',
+      familyName: 'Patient',
+      givenName: 'Test',
       gender: 'female',
     };
     const OPTIONAL_DATA = {
       dateOfBirth: '2001-02-06',
       language: 'en',
-      address: '57 Adams St',
+      addressLine: '57 Adams St',
       city: 'New Rochelle',
       state: 'NY',
       zip: '10801',
@@ -85,8 +85,8 @@ describe('EJS Render Patient', () => {
   test('missing required data should thrown an error', () => {
     const PATIENT_INVALID_DATA = {
       // Omitting mrn information, which is required
-      family: 'Patient',
-      given: 'Test',
+      familyName: 'Patient',
+      givenName: 'Test',
       gender: 'female',
     };
 

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -29,6 +29,7 @@ describe('EJS Render Patient', () => {
       family: 'Patient',
       given: 'Test',
       gender: 'female',
+      birthSex: 'female',
       dateOfBirth: '2001-02-06',
       language: 'en',
       address: '57 Adams St',

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -7,7 +7,7 @@ const { renderTemplate } = require('../../src/helpers/ejsUtils');
 const PATIENT_TEMPLATE = fs.readFileSync(path.join(__dirname, '../../src/templates/Patient.ejs'), 'utf8');
 
 
-describe('Patient EJS', () => {
+describe('EJS Render Patient', () => {
   test('minimal required data passed into template should generate FHIR resource', () => {
     const PATIENT_VALID_DATA = {
       id: 'Some Id',
@@ -47,7 +47,6 @@ describe('Patient EJS', () => {
       MAX_PATIENT_DATA,
     );
 
-    console.log(JSON.stringify(generatedPatient));
     expect(generatedPatient).toEqual(maximalPatient);
   });
   test('missing non-required data should not throw an error', () => {

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -1,36 +1,95 @@
 const fs = require('fs');
 const path = require('path');
-const validExamplePatient = require('./fixtures/patient-resource.json');
+const basicPatient = require('./fixtures/patient-resource.json');
+const maximalPatient = require('./fixtures/maximal-patient-resource.json');
 const { renderTemplate } = require('../../src/helpers/ejsUtils');
-
-const PATIENT_VALID_DATA = {
-  mrn: '1234',
-  family: 'Patient',
-  given: 'Test',
-  gender: 'female',
-};
-
-const PATIENT_INVALID_DATA = {
-  // Omitting mrn information, which is required
-  family: 'Patient',
-  given: 'Test',
-  gender: 'female',
-};
 
 const PATIENT_TEMPLATE = fs.readFileSync(path.join(__dirname, '../../src/templates/Patient.ejs'), 'utf8');
 
-describe('test Patient template', () => {
-  test('valid data passed into template should generate FHIR resource', () => {
+
+describe('Patient EJS', () => {
+  test('minimal required data passed into template should generate FHIR resource', () => {
+    const PATIENT_VALID_DATA = {
+      id: 'Some Id',
+      mrn: '1234',
+      family: 'Patient',
+      given: 'Test',
+      gender: 'female',
+    };
     const generatedPatient = renderTemplate(
       PATIENT_TEMPLATE,
       PATIENT_VALID_DATA,
     );
-    expect(generatedPatient.identifier).toEqual(validExamplePatient.identifier);
-    expect(generatedPatient.name).toEqual(validExamplePatient.name);
-    expect(generatedPatient.gender).toEqual(validExamplePatient.gender);
+    expect(generatedPatient).toEqual(basicPatient);
   });
+  test('maximal data passed into template should generate FHIR resource', () => {
+    const MAX_PATIENT_DATA = {
+      id: 'Some Id',
+      mrn: '1234',
+      family: 'Patient',
+      given: 'Test',
+      gender: 'female',
+      dateOfBirth: '2001-02-06',
+      language: 'en',
+      address: '57 Adams St',
+      city: 'New Rochelle',
+      state: 'NY',
+      zip: '10801',
+      raceCodesystem: 'http://some.codesystem.com',
+      raceCode: '29178',
+      raceText: 'Some Race',
+      ethnicityCode: '90210',
+      ethnicityText: 'Some Ethnicity',
+    };
 
-  test('invalid data should thrown an error', () => {
+    const generatedPatient = renderTemplate(
+      PATIENT_TEMPLATE,
+      MAX_PATIENT_DATA,
+    );
+
+    console.log(JSON.stringify(generatedPatient));
+    expect(generatedPatient).toEqual(maximalPatient);
+  });
+  test('missing non-required data should not throw an error', () => {
+    const NECESSARY_DATA = {
+      id: 'Some Id',
+      mrn: '1234',
+      family: 'Patient',
+      given: 'Test',
+      gender: 'female',
+    };
+    const OPTIONAL_DATA = {
+      dateOfBirth: '2001-02-06',
+      language: 'en',
+      address: '57 Adams St',
+      city: 'New Rochelle',
+      state: 'NY',
+      zip: '10801',
+      raceCodesystem: 'http://some.codesystem.com',
+      raceCode: '29178',
+      raceText: 'Some Race',
+      ethnicityCode: '90210',
+      ethnicityText: 'Some Ethnicity',
+    };
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const key of Object.keys(OPTIONAL_DATA)) {
+      const patientData = {
+        ...NECESSARY_DATA,
+        ...OPTIONAL_DATA,
+      };
+      delete patientData[key];
+      expect(() => renderTemplate(PATIENT_TEMPLATE, patientData)).not.toThrow();
+    }
+  });
+  test('missing required data should thrown an error', () => {
+    const PATIENT_INVALID_DATA = {
+      // Omitting mrn information, which is required
+      family: 'Patient',
+      given: 'Test',
+      gender: 'female',
+    };
+
     expect(() => renderTemplate(PATIENT_TEMPLATE, PATIENT_INVALID_DATA)).toThrow(ReferenceError);
   });
 });


### PR DESCRIPTION
# Summary
Expand the Patient CSV Extractor to support new fields, including: 
- dateOfBirth,
- race,
- ethnicity,
- language,
- address,
- city,
- state,
- zip

## New behavior
CSV's can have those values and they will be exported into FHIR templates, but templates will still render if some of that data is missing.

## Code changes
- Updated the docs file for patient CSV format
- Added new utils in `patientUtils` for translating ethnicity and race codes
- Updated the `Patient.ejs` template to support these new optional fields
- Updated the CSVPatientExtractor to support these new fields, adding explicit requirement of some fields based on the Spec document provided by Rob in #shr-steam 
- Updated comments to be accurate in `diseaseStatusUtils`
- Created new tests and updated tests where needed

# Testing guidance
- Ensure all tests pass
- Try connecting this with the ICARE-ext-cli and confirm that changing the patient data passed into the csv extractor produces expected output/.