### PR TITLE
Update to return a collection bundle

### DIFF
--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -61,7 +61,12 @@ class BaseFHIRExtractor extends Extractor {
   async get(argumentObject) {
     // Need to translate MRN to FHIR params
     const params = await this.parametrizeArgsForFHIRModule(argumentObject);
-    return this.getWithFHIRParams(params);
+    const searchSetBundle = this.getWithFHIRParams(params);
+    return {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: (searchSetBundle.total === 0) ? [] : searchSetBundle.entry
+    };
   }
 }
 


### PR DESCRIPTION
# Summary

This PR and its accompanying PRs update the BaseFHIRExtractor to return a 'collection' bundle instead of a 'searchset' bundle like before.

## New behavior

Changes as described above.

## Code changes

Small changes to the BaseFHIRExtractor, updating the return value.

# Testing guidance

Run the lints and tests of this and the other PRs, and run this linked with the other repos, and make sure it works! There should be no functional change at all.