### PR TITLE
Add disease category to condition template

### DIFF
--- a/src/extractors/FHIRAllergyIntoleranceExtractor.js
+++ b/src/extractors/FHIRAllergyIntoleranceExtractor.js
@@ -14,7 +14,7 @@ class FHIRAllergyIntoleranceExtractor extends BaseFHIRExtractor {
     const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
     return {
       ...paramsWithID,
-      'clinical-status': BASE_CLINICAL_STATUS,
+      'clinical-status': this.clinicalStatus,
     };
   }
 }

--- a/src/templates/Condition.ejs
+++ b/src/templates/Condition.ejs
@@ -41,6 +41,14 @@
           "code": "problem-list-item"
         }
       ]
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "64572001"
+        }
+      ]
     }
   ],
   "verificationStatus": {

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -21,6 +21,14 @@
                 "code": "problem-list-item"
               }
             ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "64572001"
+              }
+            ]
           }
         ],
         "verificationStatus": {

--- a/test/templates/fixtures/condition-resource.json
+++ b/test/templates/fixtures/condition-resource.json
@@ -20,6 +20,14 @@
           "code": "problem-list-item"
         }
       ]
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "64572001"
+        }
+      ]
     }
   ],
   "verificationStatus": {


### PR DESCRIPTION
# Summary
This PR adds the disease category coding to the Condition template.

## New behavior
The new disease category is a fixed value in mCODE, so we've added the required value. Right now, it is added to all conditions we template, but we have another task to only include it on cancer conditions.

## Code changes
Adds the category to the template and test fixtures. I also noticed that the FHIRAllergyIntoleranceExtractor wasn't using the provided clinical status, so I changed that, but I can always remove that if that was a purposeful decision.

# Testing guidance
Running CSV extraction with this branch should only produce the change to the `category` of conditions.