### PR TITLE
New fields added to cancer disease status

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,5 +1,5 @@
-mrn,conditionId,evidence,diseaseStatus,dateOfObservation,dateRecorded
-pat-mrn-1,cond-1,363679005|252416005,268910001,2019-12-02,2020-01-10
-pat-mrn-2,cond-2,363679005,268910001,2019-12-03,2020-01-10
-pat-mrn-3,cond-3,,260415000,2019-12-04,2020-01-10
-pat-mrn-4,cond-4,271299001,268910001,2019-12-05,2020-05-10
+mrn,conditionId,diseaseStatusCode,diseaseStatusText,dateOfObservation,evidence,observationStatus
+pat-mrn-1,cond-1,268910001,Patient's Condition improved,2019-12-02,363679005|252416005,registered
+pat-mrn-2,cond-2,268910001,Patient's Condition improved,2019-12-03,363679005,amended
+pat-mrn-3,cond-3,260415000,Not detected,2019-12-04,363679005,corrected
+pat-mrn-4,cond-4,268910001,Patient's Condition improved,2019-12-05,271299001,final

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -10,18 +10,17 @@ function joinAndReformatData(arrOfDiseaseStatusData) {
   logger.debug('Reformatting disease status data from CSV into template format');
   // Check the shape of the data
   arrOfDiseaseStatusData.forEach((record) => {
-    if (!(record.mrn && record.conditionId && record.diseaseStatus && record.dateOfObservation)) {
-      throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.');
+    if (!(record.mrn && record.conditionId && record.diseaseStatusCode && record.dateOfObservation && record.observationStatus)) {
+      throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, observationStatus, and dateOfObservation are required.');
     }
   });
   const evidenceDelimiter = '|';
   return arrOfDiseaseStatusData.map((record) => ({
-    // We have no note to base our ObservationStatus off of; default to 'final'
-    status: 'final',
+    status: record.observationStatus,
     value: {
-      code: record.diseaseStatus,
+      code: record.diseaseStatusCode,
       system: 'http://snomed.info/sct',
-      display: getDiseaseStatusDisplay(record.diseaseStatus),
+      display: record.diseaseStatusText ? record.diseaseStatusText : getDiseaseStatusDisplay(record.diseaseStatusCode),
     },
     subject: {
       id: record.mrn,

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -10,11 +10,11 @@ function mEpochToDate(date) {
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for status
 const diseaseStatusTextToCodeLookup = {
-  'no evidence of disease': 260415000,
-  responding: 268910001,
-  stable: 359746009,
-  progressing: 271299001,
-  'not evaluated': 709137006,
+  'Not detected (qualifier)': 260415000,
+  'Patient condition improved (finding)': 268910001,
+  'Patient\'s condition stable (finding)': 359746009,
+  'Patient\'s condition worsened (finding)': 271299001,
+  'Patient condition undetermined (finding)': 709137006,
 };
 const diseaseStatusCodeToTextLookup = invertObject(diseaseStatusTextToCodeLookup);
 

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-else-return */
 const moment = require('moment');
 const { invertObject } = require('./helperUtils');
 
@@ -45,11 +44,12 @@ const evidenceCodeToTextLookup = invertObject(evidenceTextToCodeLookup);
  * @param {string} text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
  * @return {code} corresponding DiseaseStatus code
  */
-function getDiseaseStatusCode(text, implementation = 'icare') {
-  if (implementation === 'icare') {
-    return icareDiseaseStatusTextToCodeLookup[text];
-  } else {
-    return currentDiseaseStatusTextToCodeLookup[text];
+function getDiseaseStatusCode(text, implementation) {
+  switch (implementation) {
+    case 'icare':
+      return icareDiseaseStatusTextToCodeLookup[text];
+    default:
+      return currentDiseaseStatusTextToCodeLookup[text];
   }
 }
 
@@ -58,11 +58,12 @@ function getDiseaseStatusCode(text, implementation = 'icare') {
  * @param {string} code - limited to codes in the diseaseStatusTextToCodeLookup above
  * @return {string} corresponding DiseaseStatus display text
  */
-function getDiseaseStatusDisplay(code, implementation = 'icare') {
-  if (implementation === 'icare') {
-    return icareDiseaseStatusCodeToTextLookup[code];
-  } else {
-    return currentDiseaseStatusCodeToTextLookup[code];
+function getDiseaseStatusDisplay(code, implementation) {
+  switch (implementation) {
+    case 'icare':
+      return icareDiseaseStatusCodeToTextLookup[code];
+    default:
+      return currentDiseaseStatusCodeToTextLookup[code];
   }
 }
 

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-else-return */
 const moment = require('moment');
 const { invertObject } = require('./helperUtils');
 
@@ -7,16 +8,26 @@ function mEpochToDate(date) {
   return epochDate.add(date, 'days');
 }
 
-// Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
-// specifically using lowercase versions of the text specified by ICARE for status
-const diseaseStatusTextToCodeLookup = {
+// Code mapping is based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
+const currentDiseaseStatusTextToCodeLookup = {
   'Not detected (qualifier)': 260415000,
   'Patient condition improved (finding)': 268910001,
   'Patient\'s condition stable (finding)': 359746009,
   'Patient\'s condition worsened (finding)': 271299001,
   'Patient condition undetermined (finding)': 709137006,
 };
-const diseaseStatusCodeToTextLookup = invertObject(diseaseStatusTextToCodeLookup);
+const currentDiseaseStatusCodeToTextLookup = invertObject(currentDiseaseStatusTextToCodeLookup);
+
+// Code mapping is based on initial values still in use by icare implementors
+// specifically using lowercase versions of the text specified by ICARE for status
+const icareDiseaseStatusTextToCodeLookup = {
+  'no evidence of disease': 260415000,
+  responding: 268910001,
+  stable: 359746009,
+  progressing: 271299001,
+  'not evaluated': 709137006,
+};
+const icareDiseaseStatusCodeToTextLookup = invertObject(icareDiseaseStatusTextToCodeLookup);
 
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for Reason
@@ -34,8 +45,12 @@ const evidenceCodeToTextLookup = invertObject(evidenceTextToCodeLookup);
  * @param {string} text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
  * @return {code} corresponding DiseaseStatus code
  */
-function getDiseaseStatusCode(text) {
-  return diseaseStatusTextToCodeLookup[text];
+function getDiseaseStatusCode(text, implementation = 'icare') {
+  if (implementation === 'icare') {
+    return icareDiseaseStatusTextToCodeLookup[text];
+  } else {
+    return currentDiseaseStatusTextToCodeLookup[text];
+  }
 }
 
 /**
@@ -43,8 +58,12 @@ function getDiseaseStatusCode(text) {
  * @param {string} code - limited to codes in the diseaseStatusTextToCodeLookup above
  * @return {string} corresponding DiseaseStatus display text
  */
-function getDiseaseStatusDisplay(code) {
-  return diseaseStatusCodeToTextLookup[code];
+function getDiseaseStatusDisplay(code, implementation = 'icare') {
+  if (implementation === 'icare') {
+    return icareDiseaseStatusCodeToTextLookup[code];
+  } else {
+    return currentDiseaseStatusCodeToTextLookup[code];
+  }
 }
 
 /**

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -26,7 +26,6 @@ function generateResourceId(data) {
 function renderTemplate(template, data) {
   // Ensure that spread operator on data is last, so any data.id takes precedence
   const render = ejs.render(template, { id: generateResourceId(data), ...data });
-  console.log(render);
   return JSON.parse(render);
 }
 

--- a/src/helpers/ejsUtils.js
+++ b/src/helpers/ejsUtils.js
@@ -26,6 +26,7 @@ function generateResourceId(data) {
 function renderTemplate(template, data) {
   // Ensure that spread operator on data is last, so any data.id takes precedence
   const render = ejs.render(template, { id: generateResourceId(data), ...data });
+  console.log(render);
   return JSON.parse(render);
 }
 

--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -30,7 +30,7 @@
     "profile": [
       "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
     ]
-  }, <% if (typeof evidence !== 'undefined' && evidence && evidence.length > 0) { %>
+  }, <% if (evidence && evidence.length > 0) { %>
   "extension" : [<% evidence.forEach((e, i) => { %>
     {
       "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",

--- a/src/templates/CancerDiseaseStatus.ejs
+++ b/src/templates/CancerDiseaseStatus.ejs
@@ -30,50 +30,7 @@
     "profile": [
       "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
     ]
-  },
-  "category": [
-    {
-      "coding": [
-        {
-          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-          "code": "therapy",
-          "display": "Therapy"
-        }
-      ]
-    }
-  ],
-  "status": "<%- status %>",
-  "code": {
-    "coding": [
-      {
-          "system": "http://loinc.org",
-          "code": "88040-1",
-          "display": "Response to cancer treatment"
-      }
-    ]
-  },
-  "focus" : [
-    {
-      "reference": "urn:uuid:<%- condition.id %>"<% if (condition.name) { %>,
-      "display": "<%- condition.name %>"
-      <% } %>
-    }
-  ],
-  "subject" : {
-    "reference": "urn:uuid:<%- subject.id %>"<% if (subject.name) { %>,
-    "display": "<%- subject.name %>"
-    <% } %>
-  },
-  "effectiveDateTime" : "<%- effectiveDateTime %>",
-  "valueCodeableConcept": {
-    "coding": [
-      {
-        "system": "<%- value.system %>",
-        "code": "<%- value.code %>",
-        "display": "<%- value.display %>"
-      }
-    ]
-  }<% if (evidence && evidence.length > 0) { %>,
+  }, <% if (typeof evidence !== 'undefined' && evidence && evidence.length > 0) { %>
   "extension" : [<% evidence.forEach((e, i) => { %>
     {
       "url" : "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type",
@@ -87,6 +44,49 @@
         ]
       }
     }<% if (i + 1 < evidence.length) { %>,<% }%><% }) %>
-  ]<% } %>
+  ],<% } %>
+  "status": "<%- status %>",
+  "category": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "therapy",
+          "display": "Therapy"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+          "system": "http://loinc.org",
+          "code": "88040-1",
+          "display": "Response to cancer treatment"
+      }
+    ]
+  },
+  "subject" : {
+    "reference": "urn:uuid:<%- subject.id %>"<% if (subject.name) { %>,
+    "display": "<%- subject.name %>"
+    <% } %>
+  },
+  "focus" : [
+    {
+      "reference": "urn:uuid:<%- condition.id %>"<% if (condition.name) { %>,
+      "display": "<%- condition.name %>"
+      <% } %>
+    }
+  ],
+  "effectiveDateTime" : "<%- effectiveDateTime %>",
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "system": "<%- value.system %>",
+        "code": "<%- value.code %>",
+        "display": "<%- value.display %>"
+      }
+    ]
+  }
 }
 

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -1,20 +1,18 @@
 const path = require('path');
-const rewire = require('rewire');
 const _ = require('lodash');
 const { CSVCancerDiseaseStatusExtractor } = require('../../src/extractors');
 const exampleCSVDiseaseStatusModuleResponse = require('./fixtures/csv-cancer-disease-status-module-response.json');
 const exampleCSVDiseaseStatusBundle = require('./fixtures/csv-cancer-disease-status-bundle.json');
 
-// Rewired extractor for helper tests
-const CSVCancerDiseaseStatusExtractorRewired = rewire('../../src/extractors/CSVCancerDiseaseStatusExtractor.js');
-
 // Constants for tests
 const MOCK_PATIENT_MRN = 'pat-mrn-1'; // linked to values in example-module-response above
 const MOCK_CSV_PATH = path.join(__dirname, 'fixtures/example.csv'); // need a valid path/csv here to avoid parse error
+const IMPLEMENTATION = 'mcode';
 
 // Instantiate module with parameters
 const csvCancerDiseaseStatusExtractor = new CSVCancerDiseaseStatusExtractor({
   filePath: MOCK_CSV_PATH,
+  implementation: IMPLEMENTATION,
 });
 
 // Destructure all modules
@@ -23,7 +21,6 @@ const { csvModule } = csvCancerDiseaseStatusExtractor;
 // Spy on csvModule
 const csvModuleSpy = jest.spyOn(csvModule, 'get');
 
-const joinAndReformatData = CSVCancerDiseaseStatusExtractorRewired.__get__('joinAndReformatData');
 
 describe('CSVCancerDiseaseStatusExtractor', () => {
   describe('joinAndReformatData', () => {
@@ -31,14 +28,14 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, observationStatus, and dateOfObservation are required.';
       const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
       // Test that valid data works fine
-      expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
+      expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
 
       // Test all required properties are
       delete localData[0].evidence; // Evidence is not required and will not throw an error
       Object.keys(localData[0]).forEach((key) => {
         const clonedData = _.cloneDeep(localData);
         delete clonedData[0][key];
-        expect(() => joinAndReformatData(clonedData)).toThrow(new Error(expectedErrorString));
+        expect(() => csvCancerDiseaseStatusExtractor.joinAndReformatData(clonedData)).toThrow(new Error(expectedErrorString));
       });
     });
   });

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -28,7 +28,7 @@ const joinAndReformatData = CSVCancerDiseaseStatusExtractorRewired.__get__('join
 describe('CSVCancerDiseaseStatusExtractor', () => {
   describe('joinAndReformatData', () => {
     test('should join data appropriately and throw errors when missing required properties', () => {
-      const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatus and dateOfObservation are required.';
+      const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, observationStatus, and dateOfObservation are required.';
       const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
       // Test that valid data works fine
       expect(joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:63f3cf69813e1bfd1939706f9fa6214ef0bded2ddd89d1ed3def45079132636f",
+      "fullUrl": "urn:uuid:d1d13594c371179797ce1a58884f714624d5b1782c4775f0fa303d78e943d64c",
       "resource": {
         "resourceType": "Observation",
-        "id": "63f3cf69813e1bfd1939706f9fa6214ef0bded2ddd89d1ed3def45079132636f",
+        "id": "d1d13594c371179797ce1a58884f714624d5b1782c4775f0fa303d78e943d64c",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
@@ -23,7 +23,7 @@
             ]
           }
         ],
-        "status": "final",
+        "status": "amended",
         "code": {
           "coding": [
             {
@@ -47,7 +47,7 @@
             {
               "system": "http://snomed.info/sct",
               "code": "268910001",
-              "display": "responding"
+              "display": "Patient condition improved (finding)"
             }
           ]
         },

--- a/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
@@ -2,8 +2,9 @@
   {
     "mrn": "pat-mrn-1",
     "conditionId": "cond-1",
-    "diseaseStatus": "268910001",
+    "diseaseStatusCode": "268910001",
     "dateOfObservation": "2019-12-02",
-    "evidence": "363679005|252416005"
+    "evidence": "363679005|252416005",
+    "observationStatus": "amended"
   }
 ]

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -9,11 +9,11 @@ const {
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for status
 const diseaseStatusTextToCodeLookup = {
-  'no evidence of disease': 260415000,
-  responding: 268910001,
-  stable: 359746009,
-  progressing: 271299001,
-  'not evaluated': 709137006,
+  'Not detected (qualifier)': 260415000,
+  'Patient condition improved (finding)': 268910001,
+  'Patient\'s condition stable (finding)': 359746009,
+  'Patient\'s condition worsened (finding)': 271299001,
+  'Patient condition undetermined (finding)': 709137006,
 };
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for Reason

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -40,6 +40,7 @@ describe('diseaseStatusUtils', () => {
     Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
       const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusCode(dsText, 'mcode')).toEqual(dsCode);
+      expect(getDiseaseStatusCode(dsText)).toEqual(dsCode);
     });
   });
   test('getIcareDiseaseStatusCode,', () => {
@@ -52,6 +53,7 @@ describe('diseaseStatusUtils', () => {
     Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
       const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusDisplay(dsCode, 'mcode')).toEqual(dsText);
+      expect(getDiseaseStatusDisplay(dsCode)).toEqual(dsText);
     });
   });
   test('getIcareDiseaseStatusDisplay,', () => {

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -6,8 +6,7 @@ const {
   mEpochToDate,
 } = require('../../src/helpers/diseaseStatusUtils.js');
 
-// Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
-// specifically using lowercase versions of the text specified by ICARE for status
+// Code mapping is based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 const currentDiseaseStatusTextToCodeLookup = {
   'Not detected (qualifier)': 260415000,
   'Patient condition improved (finding)': 268910001,
@@ -15,6 +14,17 @@ const currentDiseaseStatusTextToCodeLookup = {
   'Patient\'s condition worsened (finding)': 271299001,
   'Patient condition undetermined (finding)': 709137006,
 };
+
+// Code mapping is based on initial values still in use by icare implementors
+// specifically using lowercase versions of the text specified by ICARE for status
+const icareDiseaseStatusTextToCodeLookup = {
+  'no evidence of disease': 260415000,
+  responding: 268910001,
+  stable: 359746009,
+  progressing: 271299001,
+  'not evaluated': 709137006,
+};
+
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for Reason
 const evidenceTextToCodeLookup = {
@@ -26,16 +36,28 @@ const evidenceTextToCodeLookup = {
 };
 
 describe('diseaseStatusUtils', () => {
-  test('getDiseaseStatusCode,', () => {
+  test('getMcodeDiseaseStatusCode,', () => {
     Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
       const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusCode(dsText, 'mcode')).toEqual(dsCode);
     });
   });
-  test('getDiseaseStatusDisplay,', () => {
+  test('getIcareDiseaseStatusCode,', () => {
+    Object.keys(icareDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = icareDiseaseStatusTextToCodeLookup[dsText];
+      expect(getDiseaseStatusCode(dsText, 'icare')).toEqual(dsCode);
+    });
+  });
+  test('getMcodeDiseaseStatusDisplay,', () => {
     Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
       const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusDisplay(dsCode, 'mcode')).toEqual(dsText);
+    });
+  });
+  test('getIcareDiseaseStatusDisplay,', () => {
+    Object.keys(icareDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = icareDiseaseStatusTextToCodeLookup[dsText];
+      expect(getDiseaseStatusDisplay(dsCode, 'icare')).toEqual(dsText);
     });
   });
   test('getDiseaseStatusEvidenceCode,', () => {

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -8,7 +8,7 @@ const {
 
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 // specifically using lowercase versions of the text specified by ICARE for status
-const diseaseStatusTextToCodeLookup = {
+const currentDiseaseStatusTextToCodeLookup = {
   'Not detected (qualifier)': 260415000,
   'Patient condition improved (finding)': 268910001,
   'Patient\'s condition stable (finding)': 359746009,
@@ -27,15 +27,15 @@ const evidenceTextToCodeLookup = {
 
 describe('diseaseStatusUtils', () => {
   test('getDiseaseStatusCode,', () => {
-    Object.keys(diseaseStatusTextToCodeLookup).forEach((dsText) => {
-      const dsCode = diseaseStatusTextToCodeLookup[dsText];
-      expect(getDiseaseStatusCode(dsText)).toEqual(dsCode);
+    Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
+      expect(getDiseaseStatusCode(dsText, 'mcode')).toEqual(dsCode);
     });
   });
   test('getDiseaseStatusDisplay,', () => {
-    Object.keys(diseaseStatusTextToCodeLookup).forEach((dsText) => {
-      const dsCode = diseaseStatusTextToCodeLookup[dsText];
-      expect(getDiseaseStatusDisplay(dsCode)).toEqual(dsText);
+    Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
+      expect(getDiseaseStatusDisplay(dsCode, 'mcode')).toEqual(dsText);
     });
   });
   test('getDiseaseStatusEvidenceCode,', () => {

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -50,6 +50,7 @@ const MINIMAL_DATA = {
     name: 'Walking Corpse Syndrome',
   },
   effectiveDateTime: '1994-12-09T09:07:00Z',
+  evidence: null,
 };
 
 const INVALID_DATA = {

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -1,6 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const validCancerDiseaseStatus = require('./fixtures/disease-status-resource.json');
+const minimalCancerDiseaseStatus = require('./fixtures/minimal-disease-status-resource.json');
 const { renderTemplate } = require('../../src/helpers/ejsUtils');
 
 const VALID_DATA = {
@@ -29,6 +30,26 @@ const VALID_DATA = {
       code: '12341234',
     },
   ],
+};
+
+const MINIMAL_DATA = {
+  // Minimal amount of data to be accepted, evience is excluded
+  id: 'CancerDiseaseStatus-fixture',
+  status: 'final',
+  value: {
+    code: '385633008',
+    system: 'http://snomed.info/sct',
+    display: 'Improving',
+  },
+  subject: {
+    id: '123-example-patient',
+    name: 'Mr. Patient Example',
+  },
+  condition: {
+    id: '123-Walking-Corpse-Syndrome',
+    name: 'Walking Corpse Syndrome',
+  },
+  effectiveDateTime: '1994-12-09T09:07:00Z',
 };
 
 const INVALID_DATA = {
@@ -62,6 +83,16 @@ describe('test CancerDiseaseStatus template', () => {
 
     // Relevant fields should match the valid FHIR
     expect(generatedDiseaseStatus).toEqual(validCancerDiseaseStatus);
+  });
+
+  test('valid data with only required attributes passed into template should generate valid FHIR resource', () => {
+    const generatedDiseaseStatus = renderTemplate(
+      DISEASE_STATUS_TEMPLATE,
+      MINIMAL_DATA,
+    );
+
+    // Relevant fields should match the valid FHIR
+    expect(generatedDiseaseStatus).toEqual(minimalCancerDiseaseStatus);
   });
 
   test('invalid data should throw an error', () => {

--- a/test/templates/fixtures/minimal-disease-status-resource.json
+++ b/test/templates/fixtures/minimal-disease-status-resource.json
@@ -1,0 +1,51 @@
+{
+    "resourceType": "Observation",
+    "id": "CancerDiseaseStatus-fixture",
+    "meta": {
+      "profile": [
+        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
+      ]
+    },
+    "category": [
+      {
+        "coding": [
+          {
+            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+            "code": "therapy",
+            "display": "Therapy"
+          }
+        ]
+      }
+    ],
+    "status": "final",
+    "code": {
+      "coding": [
+        {
+          "system": "http://loinc.org",
+          "code": "88040-1",
+          "display": "Response to cancer treatment"
+        }
+      ]
+    },
+    "focus" : [
+      {
+        "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
+        "display": "Walking Corpse Syndrome"
+      }
+    ],
+    "subject": {
+      "reference": "urn:uuid:123-example-patient",
+      "display": "Mr. Patient Example"
+    },
+    "effectiveDateTime" : "1994-12-09T09:07:00Z",
+    "valueCodeableConcept": {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "385633008",
+          "display": "Improving"
+        }
+      ]
+    }
+  }
+  


### PR DESCRIPTION
# Summary
Added support for an additional `observationStatus` field in the CancerDiseaseStatus extractor.
## New behavior
The extractor can now extract attributes for `observationStatus` and `diseaseStatusText`. It will no longer be able to extract a value for `dateRecorded`, per the example csv file. 
## Code changes
1. Added new example fields in `docs/cancer-disease-status.csv`.
2. Updated the Cancer Disease Status extractor to throw an error if `observationStatus` is omitted given that it is a mandatory attribute. Also updated the extractor to read in a display value for `diseaseStatus`, falling back to a lookup with the `diseaseStatus` code by way of the helper functions in `src/helpers/diseaseStatusUtils.js` if a display value is not included.
3. Updated the diseaseStatusText values in `src/helpers/diseaseStatusUtils.js`. They may have been updated since the extractor was first built, but the ones included in the file no longer matched up with the values on the [reference site](http://standardhealthrecord.org/guides/icare/mapping_guidance.html).
4. Updated all test cases to correlate with additions made to the extractor. Also, added a minimal viable test case that only passes in mandatory values to the template.
# Testing guidance
Should be tested with the updated base-icare-extraction-client.