### PR TITLE
Add dateRecorded column to Cancer Disease Status

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,5 +1,5 @@
-mrn,conditionId,diseaseStatusCode,diseaseStatusText,dateOfObservation,evidence,observationStatus
-pat-mrn-1,cond-1,268910001,Patient's Condition improved,2019-12-02,363679005|252416005,registered
-pat-mrn-2,cond-2,268910001,Patient's Condition improved,2019-12-03,363679005,amended
-pat-mrn-3,cond-3,260415000,Not detected,2019-12-04,363679005,corrected
-pat-mrn-4,cond-4,268910001,Patient's Condition improved,2019-12-05,271299001,final
+mrn,conditionId,diseaseStatusCode,diseaseStatusText,dateOfObservation,evidence,observationStatus,dateRecorded
+pat-mrn-1,cond-1,268910001,Patient's Condition improved,2019-12-02,363679005|252416005,registered,2020-01-10
+pat-mrn-2,cond-2,268910001,Patient's Condition improved,2019-12-03,363679005,amended,2020-01-10
+pat-mrn-3,cond-3,260415000,Not detected,2019-12-04,363679005,corrected,2020-01-10
+pat-mrn-4,cond-4,268910001,Patient's Condition improved,2019-12-05,,final,2020-05-10


### PR DESCRIPTION
I realized that the `dateRecorded` column was removed from the CancerDiseaseStatus CSV sheet. We had added this column to reflect the date the entry was added to the CSV sheet and use it to filter out data during extraction. However, since this doesn't map onto an element in the FHIR resource, it isn't reflected in Rob's spreadsheet. I can update the spreadsheet as well, as long as everyone agrees we should still have this column.