### PR TITLE
Minor updates for ObservationStatus and Study Reference

### DIFF
--- a/docs/cancer-disease-status.csv
+++ b/docs/cancer-disease-status.csv
@@ -1,5 +1,5 @@
 mrn,conditionId,diseaseStatusCode,diseaseStatusText,dateOfObservation,evidence,observationStatus,dateRecorded
 pat-mrn-1,cond-1,268910001,Patient's Condition improved,2019-12-02,363679005|252416005,registered,2020-01-10
 pat-mrn-2,cond-2,268910001,Patient's Condition improved,2019-12-03,363679005,amended,2020-01-10
-pat-mrn-3,cond-3,260415000,Not detected,2019-12-04,363679005,corrected,2020-01-10
+pat-mrn-3,cond-3,260415000,Not detected,2019-12-04,363679005,,2020-01-10
 pat-mrn-4,cond-4,268910001,Patient's Condition improved,2019-12-05,,final,2020-05-10

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -16,13 +16,13 @@ class CSVCancerDiseaseStatusExtractor {
     logger.debug('Reformatting disease status data from CSV into template format');
     // Check the shape of the data
     arrOfDiseaseStatusData.forEach((record) => {
-      if (!(record.mrn && record.conditionId && record.diseaseStatusCode && record.dateOfObservation && record.observationStatus)) {
-        throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, observationStatus, and dateOfObservation are required.');
+      if (!(record.mrn && record.conditionId && record.diseaseStatusCode && record.dateOfObservation)) {
+        throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, and dateOfObservation are required.');
       }
     });
     const evidenceDelimiter = '|';
     return arrOfDiseaseStatusData.map((record) => ({
-      status: record.observationStatus,
+      status: record.observationStatus || 'final',
       value: {
         code: record.diseaseStatusCode,
         system: 'http://snomed.info/sct',

--- a/src/templates/ResearchSubject.ejs
+++ b/src/templates/ResearchSubject.ejs
@@ -22,7 +22,10 @@
   ],
   "status": "<%- enrollmentStatus %>",
   "study": {
-      "reference": "ResearchStudy/<%- trialResearchID %>"
+      "identifier": {
+        "system": "http://example.com/clinicaltrialids",
+        "value": "<%- trialResearchID %>"
+      }
   },
   "individual": {
       "reference": "urn:uuid:<%- patientId %>"

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -25,13 +25,14 @@ const csvModuleSpy = jest.spyOn(csvModule, 'get');
 describe('CSVCancerDiseaseStatusExtractor', () => {
   describe('joinAndReformatData', () => {
     test('should join data appropriately and throw errors when missing required properties', () => {
-      const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, observationStatus, and dateOfObservation are required.';
+      const expectedErrorString = 'DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, and dateOfObservation are required.';
       const localData = _.cloneDeep(exampleCSVDiseaseStatusModuleResponse);
       // Test that valid data works fine
       expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(exampleCSVDiseaseStatusModuleResponse)).toEqual(expect.anything());
 
       // Test all required properties are
       delete localData[0].evidence; // Evidence is not required and will not throw an error
+      delete localData[0].observationStatus; // Observation Status is not required and will not throw an error
       Object.keys(localData[0]).forEach((key) => {
         const clonedData = _.cloneDeep(localData);
         delete clonedData[0][key];

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -33,6 +33,11 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       // Test all required properties are
       delete localData[0].evidence; // Evidence is not required and will not throw an error
       delete localData[0].observationStatus; // Observation Status is not required and will not throw an error
+
+      // Only including required properties is valid
+      expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
+
+      // Removing each required property should throw an error
       Object.keys(localData[0]).forEach((key) => {
         const clonedData = _.cloneDeep(localData);
         delete clonedData[0][key];

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -15,7 +15,12 @@
           }
         ],
         "status": "example-enrollment-status",
-        "study": { "reference": "ResearchStudy/example-researchId" },
+        "study": {
+          "identifier": {
+            "system": "http://example.com/clinicaltrialids",
+            "value": "example-researchId"
+          }
+        },
         "individual": { "reference": "urn:uuid:EXAMPLE-MRN" }
       }
     },


### PR DESCRIPTION
# Summary
While I was reviewing the ICARE documentation, I noticed a couple things that the extraction framework needed to update.

## New behavior
- We added in an `observationStatus` field in the cancer disease status CSV, but this should be an optional field in the CSV file. Even though it is a required `1..1` property in FHIR, we can reasonably assume a default value of `final` since this is describing the status of the FHIR resource and not anything to do with an observed piece of patient data (also confirmed this with Rob and others at stand up last week). This PR makes the `observationStatus` field no longer a required field and defaults it to 'final' if it is not provided.

- The way we were referencing the ResearchStudy on the ResearchSubject was incorrect. Most of our references to other resources within the bundle use the `urn:uuid` format, but this was still using an old `ResearchStudy/id` format. The old implementation was not correct because we were using an identifier value rather than the resource's id. In order to use the id of the ResearchStudy in the `urn:uuid` format, we'd need to generate the full ResearchStudy resource in order to generate the id, and then use that id when templating ResearchSubject. Rather than make those bigger changes to the extractor, I updated the reference to properly refer to the identifier of the study. I believe this idea is a "[business identifier](https://www.hl7.org/fhir/resource.html#identifiers)" since it is referencing an underlying, unchanging concept - the particular study. This format of a reference is also shown in the [bundle references example](http://www.hl7.org/fhir/bundle-references.json.html).

## Code changes
Observation status is not required and defaults to final. Support for the new reference format for `study` on the ResearchSubject.

# Testing guidance
Ensure you can run the extraction client without an `observationStatus` provided and ensure the identifier is templated correctly. Ensure tests still pass.
