### PR TITLE
Category on cancer conditions

### DIFF
--- a/src/helpers/conditionUtils.js
+++ b/src/helpers/conditionUtils.js
@@ -32,7 +32,7 @@ function isConditionCodePrimary(code) {
 }
 
 /**
- * Checks if a condition code is a primary cancer condition
+ * Checks if a condition code is a secondary cancer condition
  * @param code ICD code, string
  * @return {boolean} if secondary cancer condition
  */
@@ -51,7 +51,7 @@ function isConditionPrimary(condition) {
 }
 
 /**
- * Checks if a condition resource is a primary cancer condition
+ * Checks if a condition resource is a secondary cancer condition
  * @param condition fhir resource
  * @return {boolean} if secondary cancer condition
  */
@@ -60,10 +60,30 @@ function isConditionSecondary(condition) {
   return icd10Code && isConditionCodeSecondary(icd10Code.code);
 }
 
+/**
+ * Checks if a condition code is a cancer condition we recognize
+ * @param code ICD code, string
+ * @return {boolean} if primary or secondary cancer condition
+ */
+function isConditionCodeCancer(code) {
+  return isConditionCodePrimary(code) || isConditionCodeSecondary(code);
+}
+
+/**
+ * Checks if a condition is a cancer condition we recognize
+ * @param condition fhir resource
+ * @return {boolean} if primary or secondary cancer condition
+ */
+function isConditionCancer(condition) {
+  return isConditionPrimary(condition) || isConditionSecondary(condition);
+}
+
 module.exports = {
   getICD10Code,
   isConditionPrimary,
   isConditionSecondary,
   isConditionCodePrimary,
   isConditionCodeSecondary,
+  isConditionCodeCancer,
+  isConditionCancer,
 };

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -1,6 +1,6 @@
 const { extensionArr, coding, valueCodeableConcept, reference } = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
-const { isConditionCodePrimary, isConditionCodeSecondary } = require('../helpers/conditionUtils');
+const { isConditionCodeCancer } = require('../helpers/conditionUtils');
 
 function histologyTemplate({ histology }) {
   return {
@@ -44,7 +44,7 @@ function individualCategoryTemplate(category) {
 function categoryArrayTemplate(array, code) {
   const category = array.map(individualCategoryTemplate);
   const codeValue = `${code}`;
-  if (isConditionCodePrimary(codeValue) || isConditionCodeSecondary(codeValue)) {
+  if (isConditionCodeCancer(codeValue)) {
     // On cancer conditions, include the fixed value for the disease category
     category.push({
       coding: [coding({

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -1,5 +1,6 @@
 const { extensionArr, coding, valueCodeableConcept, reference } = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
+const { isConditionCodePrimary, isConditionCodeSecondary } = require('../helpers/conditionUtils');
 
 function histologyTemplate({ histology }) {
   return {
@@ -40,16 +41,19 @@ function individualCategoryTemplate(category) {
   };
 }
 
-function categoryArrayTemplate(array) {
+function categoryArrayTemplate(array, code) {
   const category = array.map(individualCategoryTemplate);
-  // Including the fixed value for the category element at the end of the array
-  category.push({
-    coding: [coding({
-      system: 'http://snomed.info/sct',
-      code: '64572001',
-    }),
-    ],
-  });
+  const codeValue = `${code}`;
+  if (isConditionCodePrimary(codeValue) || isConditionCodeSecondary(codeValue)) {
+    // On cancer conditions, include the fixed value for the disease category
+    category.push({
+      coding: [coding({
+        system: 'http://snomed.info/sct',
+        code: '64572001',
+      }),
+      ],
+    });
+  }
   return { category };
 }
 
@@ -121,7 +125,7 @@ function conditionTemplate({
     ),
     ...ifAllArgsObj(clinicalStatusTemplate)({ clinicalStatus }),
     ...ifAllArgsObj(verificationStatusTemplate)({ verificationStatus }),
-    ...categoryArrayTemplate(category),
+    ...categoryArrayTemplate(category, code.code),
     ...codingTemplate({ code }),
     ...ifAllArgsObj(bodySiteTemplate)({ bodySite, laterality }),
     ...subjectTemplate({ subject }),

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -61,9 +61,9 @@
         "code": {
           "coding": [
             {
-              "system": "example-code-system",
-              "code": "example-code",
-              "display": "Example Name"
+              "system": "http://snomed.info/sct",
+              "code": "C020",
+              "display": "Some Cancer Condition"
             }
           ]
         },

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -5,100 +5,95 @@
     {
       "fullUrl": "urn:uuid:conditionId-1",
       "resource": {
-          "resourceType": "Condition",
-          "id": "conditionId-1", 
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
-              "valueDateTime": "YYYY-MM-DD"
-            }  , 
-            {
-              "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-histology-morphology-behavior",
-              "valueCodeableConcept": {
-                "coding": [
-                  {
-                    "system": "http://snomed.info/sct",
-                    "code": "example-histology"
-                  }
-                ]
-              }
+        "resourceType": "Condition",
+        "id": "conditionId-1",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
+            "valueDateTime": "YYYY-MM-DD"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-histology-morphology-behavior",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "example-histology"
+                }
+              ]
             }
-          ]  ,
-          "clinicalStatus": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
-                "code": "example-status"
-              }
-            ]
-          }  ,
-          "verificationStatus": {
-            "coding": [
-              {
-                "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
-                "code": "example-status"
-              }
-            ]
-          } , 
-          "category": [
-          
-            {
-              "coding": [ 
-                {
-                  "system": "http://terminology.hl7.org/CodeSystem/condition-category",
-                  "code": "example-category"
-                }
-              ]
-            },
-            {
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "64572001"
-                }
-              ]
-            } 
-          ],  
-          "code": {
-            "coding": [
-              {
-                "system": "example-code-system",
-                "code": "example-code",
-                "display": "Example Name"
-                
-              }
-            ]
-          }, 
-          
-          "bodySite": [
-          
-            {
-              
-              "extension": [
-                {
-                  "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality",
-                  "valueCodeableConcept": {
-                    "coding": [
-                      {
-                        "system": "http://snomed.info/sct",
-                        "code": "example-laterality"
-                      }
-                    ]
-                  }
-                }
-              ], 
-              "coding": [
-                {
-                  "system": "http://snomed.info/sct",
-                  "code": "example-site"
-                }
-              ]
-            }  
-          ], 
-          "subject" : {
-            "reference": "urn:uuid:mrn-1"
           }
+        ],
+        "clinicalStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-clinical",
+              "code": "example-status"
+            }
+          ]
+        },
+        "verificationStatus": {
+          "coding": [
+            {
+              "system": "http://terminology.hl7.org/CodeSystem/condition-ver-status",
+              "code": "example-status"
+            }
+          ]
+        },
+        "category": [
+          {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/condition-category",
+                "code": "example-category"
+              }
+            ]
+          },
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "64572001"
+              }
+            ]
+          }
+        ],
+        "code": {
+          "coding": [
+            {
+              "system": "example-code-system",
+              "code": "example-code",
+              "display": "Example Name"
+            }
+          ]
+        },
+        "bodySite": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "example-laterality"
+                    }
+                  ]
+                }
+              }
+            ],
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "example-site"
+              }
+            ]
+          }
+        ],
+        "subject": {
+          "reference": "urn:uuid:mrn-1"
         }
       }
+    }
   ]
 }

--- a/test/extractors/fixtures/csv-condition-module-response.json
+++ b/test/extractors/fixtures/csv-condition-module-response.json
@@ -2,9 +2,9 @@
   {
     "mrn": "mrn-1",
     "conditionId": "conditionId-1",
-    "codeSystem": "example-code-system",
-    "code": "example-code",
-    "displayName": "Example Name",
+    "codeSystem": "http://snomed.info/sct",
+    "code": "C020",
+    "displayName": "Some Cancer Condition",
     "category": "example-category",
     "dateOfDiagnosis": "YYYY-MM-DD",
     "clinicalStatus": "example-status",

--- a/test/helpers/conditionUtils.test.js
+++ b/test/helpers/conditionUtils.test.js
@@ -1,4 +1,6 @@
 const {
+  isConditionCancer,
+  isConditionCodeCancer,
   isConditionCodePrimary,
   isConditionCodeSecondary,
   isConditionPrimary,
@@ -44,5 +46,18 @@ describe('conditionUtils', () => {
   test('getICD10Code', () => {
     expect(getICD10Code(conditionWithICD10)).toEqual(icd10);
     expect(getICD10Code(conditionWithoutICD10)).toBeUndefined();
+  });
+
+  test('isConditionCodeCancer', () => {
+    expect(isConditionCodeCancer(primaryCancerConditionCode)).toBeTruthy();
+    expect(isConditionCodeCancer(secondaryCancerConditionCode)).toBeTruthy();
+    expect(isConditionCodeCancer('anything')).toBeFalsy();
+    expect(() => isConditionCodeCancer(undefined)).toThrowError(TypeError);
+  });
+
+  test('isConditionCancer', () => {
+    expect(isConditionCancer(examplePrimaryCondition)).toBeTruthy();
+    expect(isConditionCancer(exampleSecondaryCondition)).toBeTruthy();
+    expect(isConditionCancer(undefined)).toBeFalsy();
   });
 });

--- a/test/templates/condition.test.js
+++ b/test/templates/condition.test.js
@@ -1,5 +1,6 @@
 const maximalValidExampleCondition = require('./fixtures/maximal-condition-resource.json');
 const minimalValidExampleCondition = require('./fixtures/minimal-condition-resource.json');
+const cancerValidExampleCondition = require('./fixtures/cancer-condition-resource.json');
 const { conditionTemplate } = require('../../src/templates/ConditionTemplate.js');
 const { allOptionalKeyCombinationsNotThrow } = require('../utils');
 
@@ -109,5 +110,27 @@ describe('test Condition template', () => {
 
   test('invalid data should throw an error', () => {
     expect(() => conditionTemplate(CONDITION_INVALID_DATA)).toThrow(Error);
+  });
+
+  test('cancer conditions should include the "disease" category', () => {
+    const diseaseCategory = {
+      coding: [
+        {
+          code: '64572001',
+          system: 'http://snomed.info/sct',
+        },
+      ],
+    };
+    // Use a cancer condition code when generating resource
+    const cancerConditionData = { ...CONDITION_MINIMAL_DATA, code: { code: 'C020', system: 'http://snomed.info/sct' } };
+    const generatedCondition = conditionTemplate(cancerConditionData);
+    expect(generatedCondition.category).toContainEqual(diseaseCategory);
+    expect(generatedCondition).toEqual(cancerValidExampleCondition);
+  });
+
+  test('non-cancer conditions should not include the "disease" category', () => {
+    const generatedCondition = conditionTemplate(CONDITION_MINIMAL_DATA);
+    expect(generatedCondition.category).toHaveLength(1); // Only provided category is present
+    expect(generatedCondition).toEqual(minimalValidExampleCondition);
   });
 });

--- a/test/templates/fixtures/cancer-condition-resource.json
+++ b/test/templates/fixtures/cancer-condition-resource.json
@@ -9,13 +9,21 @@
           "code": "example-code"
         }
       ]
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "64572001"
+        }
+      ]
     }
   ],
   "code": {
     "coding": [
       {
-        "system": "example-system",
-        "code": "example-code"
+        "system": "http://snomed.info/sct",
+        "code": "C020"
       }
     ]
   },

--- a/test/templates/fixtures/maximal-condition-resource.json
+++ b/test/templates/fixtures/maximal-condition-resource.json
@@ -1,11 +1,11 @@
 {
   "resourceType": "Condition",
-  "id": "example-id", 
+  "id": "example-id",
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/condition-assertedDate",
       "valueDateTime": "YYYY-MM-DD"
-    }  , 
+    },
     {
       "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-histology-morphology-behavior",
       "valueCodeableConcept": {
@@ -17,7 +17,7 @@
         ]
       }
     }
-  ]  ,
+  ],
   "clinicalStatus": {
     "coding": [
       {
@@ -25,7 +25,7 @@
         "code": "example-code"
       }
     ]
-  }  ,
+  },
   "verificationStatus": {
     "coding": [
       {
@@ -33,11 +33,10 @@
         "code": "example-code"
       }
     ]
-  } , 
+  },
   "category": [
-  
     {
-      "coding": [ 
+      "coding": [
         {
           "system": "http://terminology.hl7.org/CodeSystem/condition-category",
           "code": "example-code"
@@ -51,23 +50,19 @@
           "code": "64572001"
         }
       ]
-    } 
-  ],  
+    }
+  ],
   "code": {
     "coding": [
       {
         "system": "example-system",
         "code": "example-code",
         "display": "exampleDisplayName"
-        
       }
     ]
-  }, 
-  
+  },
   "bodySite": [
-  
     {
-      
       "extension": [
         {
           "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality",
@@ -80,16 +75,16 @@
             ]
           }
         }
-      ], 
+      ],
       "coding": [
         {
           "system": "http://snomed.info/sct",
           "code": "example-code"
         }
       ]
-    }  
-  ], 
-  "subject" : {
+    }
+  ],
+  "subject": {
     "reference": "urn:uuid:example-subject-id"
   }
 }

--- a/test/templates/fixtures/maximal-condition-resource.json
+++ b/test/templates/fixtures/maximal-condition-resource.json
@@ -42,14 +42,6 @@
           "code": "example-code"
         }
       ]
-    },
-    {
-      "coding": [
-        {
-          "system": "http://snomed.info/sct",
-          "code": "64572001"
-        }
-      ]
     }
   ],
   "code": {

--- a/test/templates/fixtures/minimal-condition-resource.json
+++ b/test/templates/fixtures/minimal-condition-resource.json
@@ -1,35 +1,33 @@
 {
-    "resourceType": "Condition",
-    "id": "example-id", 
-    "category": [
-    
-      {
-        "coding": [ 
-          {
-            "system": "http://terminology.hl7.org/CodeSystem/condition-category",
-            "code": "example-code"
-          }
-        ]
-      },
-      {
-        "coding": [
-          {
-            "system": "http://snomed.info/sct",
-            "code": "64572001"
-          }
-        ]
-      } 
-    ],  
-    "code": {
+  "resourceType": "Condition",
+  "id": "example-id",
+  "category": [
+    {
       "coding": [
         {
-          "system": "example-system",
+          "system": "http://terminology.hl7.org/CodeSystem/condition-category",
           "code": "example-code"
-          
         }
       ]
-    }, 
-    "subject" : {
-      "reference": "urn:uuid:example-subject-id"
+    },
+    {
+      "coding": [
+        {
+          "system": "http://snomed.info/sct",
+          "code": "64572001"
+        }
+      ]
     }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "example-system",
+        "code": "example-code"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "urn:uuid:example-subject-id"
   }
+}


### PR DESCRIPTION
# Summary
Only cancer conditions should include the "disease" category coding.

## New behavior
Previously, we were adding the "disease" category coding to all conditions. This value is only fixed on primary and secondary cancer conditions, so it should only be included in the `category` array on those conditions. Now that we have the flexibility in our templates to support this, we are implementing this change.

## Code changes
Use the util functions to determine if a condition is a cancer condition. Only apply the "disease" fixed value on category if it is a cancer condition.

I also reformatted a couple JSON files, which should be contained to b3f8b7b. The changes for the task should be contained to 322e0f1 if it is easier to see the diffs.

# Testing guidance
Run the test and ensure they pass. Ensure the changes to the tests make sense. I did change to example values used in mocks to represent a cancer code, rather than remove the category code to correctly represent a non-cancer condition, but I can swap to the opposite approach if that's preferred.