### PR TITLE
Period hotfix

### DIFF
--- a/src/templates/CancerRelatedMedicationTemplate.js
+++ b/src/templates/CancerRelatedMedicationTemplate.js
@@ -26,8 +26,8 @@ function subjectTemplate({ id }) {
 function periodTemplate({ startDate, endDate }) {
   return {
     effectivePeriod: {
-      start: startDate,
-      end: endDate,
+      ...(startDate && { start: startDate }),
+      ...(endDate && { end: endDate }),
     },
   };
 }

--- a/test/templates/fixtures/minimal-medication-resource.json
+++ b/test/templates/fixtures/minimal-medication-resource.json
@@ -17,8 +17,5 @@
   "subject": {
     "reference": "urn:uuid:mrn-1"
   },
-  "effectivePeriod": {
-    "start": null,
-    "end": null
-  }
+  "effectivePeriod": {}
 }


### PR DESCRIPTION
# Summary
Properly handles the omission of the `startDate` and `endDate` fields from a csv. Prior to this, the resource would be generated but the message would fail to send.
## New behavior
`startDate` and `endDate` being omitted from the csv now results in the corresponding fields being left out of the effectivePeriod element, rather than nulling out their respective properties. 
## Code changes
1. Added two conditionals to the `periodTemplate` function within the CancerRelatedMedication template. These conditionals omit either `start` or `end` from the `period` property if they are not included in the csv.
2. Updated the minimal cancer related medication json to reflect the new behavior.
# Testing guidance
When running from the base icare client, remove the startDate and endDate columns within `cancer-related-medication-information.csv` and ensure that the messages are sent to the AWS server.
