### PR TITLE
ValueX type parameter

### DIFF
--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -1,11 +1,11 @@
-const { coding, extensionArr, reference, valueCodeableConcept } = require('./snippets');
+const { coding, extensionArr, reference, valueX } = require('./snippets');
 
 function evidenceTemplate({ evidence }) {
   if (!evidence || evidence.length === 0) return [];
 
   return evidence.map((e) => ({
     url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-evidence-type',
-    ...valueCodeableConcept({ ...e, system: 'http://snomed.info/sct' }),
+    ...valueX({ ...e, system: 'http://snomed.info/sct' }, 'valueCodeableConcept'),
   }));
 }
 
@@ -70,7 +70,7 @@ function cancerDiseaseStatusTemplate({
     effectiveDateTime,
     ...focusTemplate({ condition }),
     ...subjectTemplate({ subject }),
-    ...valueCodeableConcept(value),
+    ...valueX(value, 'valueCodeableConcept'),
   };
 }
 

--- a/src/templates/CancerRelatedMedicationTemplate.js
+++ b/src/templates/CancerRelatedMedicationTemplate.js
@@ -1,10 +1,10 @@
-const { coding, extensionArr, reference, valueCodeableConcept } = require('./snippets');
+const { coding, extensionArr, reference, valueX } = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
 
 function treatmentIntentTemplate({ treatmentIntent }) {
   return {
     url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent',
-    ...valueCodeableConcept({ code: treatmentIntent, system: 'http://snomed.info/sct' }),
+    ...valueX({ code: treatmentIntent, system: 'http://snomed.info/sct' }, 'valueCodeableConcept'),
   };
 }
 

--- a/src/templates/CarePlanWithReviewTemplate.js
+++ b/src/templates/CarePlanWithReviewTemplate.js
@@ -1,5 +1,5 @@
 const {
-  coding, extensionArr, meta, narrative, reference, valueCodeableConcept, valueX,
+  coding, extensionArr, meta, narrative, reference, valueX,
 } = require('./snippets');
 const { ifAllArgs } = require('../helpers/templateUtils');
 
@@ -27,12 +27,12 @@ function createdTemplate({ effectiveDateTime }) {
 function carePlanReasonTemplate({ reasonCode, reasonDisplayText }) {
   return {
     url: 'CarePlanChangeReason',
-    ...valueCodeableConcept({
+    ...valueX({
       system: 'http://snomed.info/sct',
       code: reasonCode,
       display: reasonDisplayText,
       text: reasonDisplayText,
-    }),
+    }, 'valueCodeableConcept'),
   };
 }
 

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -1,11 +1,11 @@
-const { extensionArr, coding, valueCodeableConcept, reference } = require('./snippets');
+const { extensionArr, coding, valueX, reference } = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
 const { isConditionCodeCancer } = require('../helpers/conditionUtils');
 
 function histologyTemplate({ histology }) {
   return {
     url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-histology-morphology-behavior',
-    ...valueCodeableConcept({ code: histology, system: 'http://snomed.info/sct' }),
+    ...valueX({ code: histology, system: 'http://snomed.info/sct' }, 'valueCodeableConcept'),
   };
 }
 
@@ -73,7 +73,7 @@ function bodySiteTemplate({ bodySite, laterality }) {
         extension: [
           {
             url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality',
-            ...valueCodeableConcept({ code: laterality, system: 'http://snomed.info/sct' }),
+            ...valueX({ code: laterality, system: 'http://snomed.info/sct' }, 'valueCodeableConcept'),
           },
         ],
         coding: [coding({ code: bodySite[0], system: 'http://snomed.info/sct' }),

--- a/src/templates/ObservationTemplate.js
+++ b/src/templates/ObservationTemplate.js
@@ -1,9 +1,4 @@
-const {
-  bodySiteTemplate,
-  coding,
-  reference,
-  valueX,
-} = require('./snippets');
+const { bodySiteTemplate, coding, reference, valueX } = require('./snippets');
 const { ifSomeArgsObj } = require('../helpers/templateUtils');
 const { isTumorMarker, isVitalSign, isKarnofskyPerformanceStatus, isECOGPerformanceStatus } = require('../helpers/observationUtils');
 

--- a/src/templates/ObservationTemplate.js
+++ b/src/templates/ObservationTemplate.js
@@ -2,7 +2,6 @@ const {
   bodySiteTemplate,
   coding,
   reference,
-  valueCodeableConcept,
   valueX,
 } = require('./snippets');
 const { ifSomeArgsObj } = require('../helpers/templateUtils');
@@ -57,12 +56,10 @@ function subjectTemplate({ subjectId }) {
   };
 }
 
-// TODO: We might want to consider a better way to handle the value field
-// if we revisit the valueX inference approach at a later date
 function valueTemplate({ code, valueCode, valueCodeSystem }) {
   if (!(code && valueCode)) return null;
-  if (isTumorMarker(code)) return valueCodeableConcept({ code: valueCode, system: valueCodeSystem });
-  if (isECOGPerformanceStatus(code) || isKarnofskyPerformanceStatus(code)) return valueX(parseInt(valueCode, 10));
+  if (isTumorMarker(code)) return valueX({ code: valueCode, system: valueCodeSystem }, 'valueCodeableConcept');
+  if (isECOGPerformanceStatus(code) || isKarnofskyPerformanceStatus(code)) return valueX(valueCode, 'valueInteger');
   return valueX(valueCode); // Vital Sign will be parsed as quantity, others will be parsed as appropriate
 }
 

--- a/src/templates/ProcedureTemplate.js
+++ b/src/templates/ProcedureTemplate.js
@@ -3,7 +3,7 @@ const {
   coding,
   extensionArr,
   reference,
-  valueCodeableConcept,
+  valueX,
 } = require('./snippets');
 const { ifAllArgsObj, ifSomeArgsObj } = require('../helpers/templateUtils');
 
@@ -34,10 +34,10 @@ function reasonReference(conditionId) {
 function treatmentIntentTemplate({ treatmentIntent }) {
   return {
     url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent',
-    ...valueCodeableConcept({
+    ...valueX({
       system: 'http://snomed.info/sct',
       code: treatmentIntent,
-    }),
+    }, 'valueCodeableConcept'),
   };
 }
 

--- a/src/templates/snippets/bodySiteTemplate.js
+++ b/src/templates/snippets/bodySiteTemplate.js
@@ -1,4 +1,4 @@
-const { valueCodeableConcept } = require('./valueX');
+const { valueX } = require('./valueX');
 const { coding } = require('./coding');
 const { ifAllArgsObj } = require('../../helpers/templateUtils');
 
@@ -7,7 +7,7 @@ function lateralityTemplate({ laterality }) {
     extension: [
       {
         url: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality',
-        ...valueCodeableConcept({ code: laterality, system: 'http://snomed.info/sct' }),
+        ...valueX({ code: laterality, system: 'http://snomed.info/sct' }, 'valueCodeableConcept'),
       },
     ],
   };

--- a/src/templates/snippets/index.js
+++ b/src/templates/snippets/index.js
@@ -1,5 +1,5 @@
 const { coding } = require('./coding');
-const { valueCodeableConcept, valueX } = require('./valueX');
+const { valueX } = require('./valueX');
 const { reference } = require('./reference');
 const { meta, narrative } = require('./resource');
 const { extensionArr } = require('./extensionArr');
@@ -17,6 +17,5 @@ module.exports = {
   meta,
   narrative,
   reference,
-  valueCodeableConcept,
   valueX,
 };

--- a/src/templates/snippets/valueX.js
+++ b/src/templates/snippets/valueX.js
@@ -8,7 +8,105 @@ const dateRegex = /^([0-9]([0-9]([0-9][1-9]|[1-9]0)|[1-9]00)|[1-9]000)(-(0[1-9]|
 const dateTimeRegex = /^\d\d\d\d-\d\d-\d\dT\d\d(:\d\d(:\d\d(-\d\d:\d\d)?)?)?$/;
 const valueTimeRegex = /^([01][0-9]|2[0-3]):[0-5][0-9]:([0-5][0-9]|60)(\.[0-9]+)?$/;
 
-function valueX(value) {
+function valueByType(value, type) {
+  switch (type) {
+    case 'valueCodeableConcept':
+      return {
+        valueCodeableConcept: {
+          coding: [
+            coding(value),
+          ],
+          ...(value.text && { text: value.text }),
+        },
+      };
+
+    case 'valueInteger':
+      return {
+        valueInteger: parseInt(value, 10),
+      };
+
+    case 'valueBoolean':
+      return {
+        valueBoolean: value,
+      };
+
+    case 'valueDate':
+      return {
+        valueDate: value,
+      };
+
+    case 'valueDateTime':
+      return {
+        valueDateTime: value,
+      };
+
+    case 'valueTime':
+      return {
+        valueTime: value,
+      };
+
+    case 'valueQuantity':
+      if (typeof value === 'string') {
+        const quantMatch = quantRegex.exec(value);
+        return {
+          valueQuantity: {
+            value: parseFloat(`${quantMatch[1]}${quantMatch[2] ? quantMatch[2] : ''}`, 10),
+            ...(quantMatch[6] && {
+              code: quantMatch[6],
+              system: 'http://unitsofmeasure.org',
+              unit: getQuantityUnit(quantMatch[6]),
+            }),
+          },
+        };
+      }
+      return {
+        valueQuantity: {
+          unit: value.unit,
+          code: value.code,
+          value: value.value,
+          system: 'http://unitsofmeasure.org',
+        },
+      };
+
+    case 'valueString':
+      return {
+        valueString: value,
+      };
+
+    case 'valueRange':
+      return {
+        valueRange: {
+          high: value.high,
+          low: value.low,
+        },
+      };
+
+    case 'valuePeriod':
+      return {
+        valuePeriod: {
+          start: value.start,
+          end: value.end,
+        },
+      };
+
+    case 'valueCoding':
+      return {
+        valueCoding: coding(value),
+      };
+
+    default:
+      logger.warn(`The type ${type} is not recognized by the ValueTemplate, attempting to infer the type of the value.`);
+      return null;
+  }
+}
+
+function valueX(value, type = null) {
+  if (type) {
+    const returnValue = valueByType(value, type);
+    if (returnValue != null) {
+      return returnValue;
+    }
+  }
   switch (typeof value) {
     case 'number':
       return {
@@ -89,19 +187,6 @@ function valueX(value) {
   }
 }
 
-// TODO: move this into valueX when we define optional args
-function valueCodeableConcept(value) {
-  return {
-    valueCodeableConcept: {
-      coding: [
-        coding(value),
-      ],
-      ...(value.text && { text: value.text }),
-    },
-  };
-}
-
 module.exports = {
-  valueCodeableConcept,
   valueX,
 };

--- a/src/templates/snippets/valueX.js
+++ b/src/templates/snippets/valueX.js
@@ -58,14 +58,13 @@ function valueX(value, type = null) {
           valueType = 'valueQuantity';
         } else if (value.system || value.version || value.code || value.display || value.userSelected) {
           valueType = 'valueCoding';
+        } else {
+          logger.debug(`The provided object has an unknown shape, including properties ${Object.keys(value)}`);
         }
         break;
 
       default:
         logger.warn(`Unable to determine the value[x] specialization with the provided value of type - ${typeof value}`);
-        if (typeof value === 'object') {
-          logger.debug(`The provided object has an unknown shape, including properties ${Object.keys(value)}`);
-        }
         break;
     }
   }

--- a/src/templates/snippets/valueX.js
+++ b/src/templates/snippets/valueX.js
@@ -63,6 +63,9 @@ function valueX(value, type = null) {
 
       default:
         logger.warn(`Unable to determine the value[x] specialization with the provided value of type - ${typeof value}`);
+        if (typeof value === 'object') {
+          logger.debug(`The provided object has an unknown shape, including properties ${Object.keys(value)}`);
+        }
         break;
     }
   }

--- a/src/templates/snippets/valueX.js
+++ b/src/templates/snippets/valueX.js
@@ -25,6 +25,11 @@ function valueByType(value, type) {
         valueInteger: parseInt(value, 10),
       };
 
+    case 'valueDecimal':
+      return {
+        valueInteger: parseFloat(value),
+      };
+
     case 'valueBoolean':
       return {
         valueBoolean: value,
@@ -95,7 +100,7 @@ function valueByType(value, type) {
       };
 
     default:
-      logger.warn(`The type ${type} is not recognized by the ValueTemplate, attempting to infer the type of the value.`);
+      logger.debug(`The type ${type} is not recognized by the ValueTemplate, attempting to infer the type of the value.`);
       return null;
   }
 }
@@ -166,11 +171,13 @@ function valueX(value, type = null) {
             end: value.end,
           },
         };
-      } if (value.unit) {
+      } if (value.value && value.code) {
         return {
           valueQuantity: {
-            unit: value.unit,
+            unit: !value.unit ? getQuantityUnit(value.code) : value.unit,
             value: value.value,
+            code: value.code,
+            system: 'http://unitsofmeasure.org',
           },
         };
       } if (value.system || value.version || value.code || value.display || value.userSelected) {

--- a/test/templates/snippets/valueX.test.js
+++ b/test/templates/snippets/valueX.test.js
@@ -81,6 +81,14 @@ describe('valueX snippet', () => {
     expect(valueX(exampleDateTime, 'valueDateTime')).toEqual(exampleValueDateTime);
   });
 
+  test('Should generate valueDateTime when type parameter is not used', () => {
+    const exampleDateTime = '2020-02-01T10:35:59';
+    const exampleValueDateTime = {
+      valueDateTime: '2020-02-01T10:35:59',
+    };
+    expect(valueX(exampleDateTime)).toEqual(exampleValueDateTime);
+  });
+
   test('Should generate valueTime when type parameter is used', () => {
     const exampconstime = '10:35:59';
     const exampleValueTime = {

--- a/test/templates/snippets/valueX.test.js
+++ b/test/templates/snippets/valueX.test.js
@@ -1,0 +1,235 @@
+const { valueX } = require('../../../src/templates/snippets');
+
+describe('valueX snippet', () => {
+  test('Should generate valueCodeableConcept when type parameter is used', () => {
+    const exampleCode = { system: 'exampleSystem', code: 'exampleCode', display: 'Example Display' };
+    const exampleCodeableConcept = {
+      valueCodeableConcept: {
+        coding: [
+          {
+            system: 'exampleSystem',
+            code: 'exampleCode',
+            display: 'Example Display',
+          },
+        ],
+      },
+    };
+    expect(valueX(exampleCode, 'valueCodeableConcept')).toEqual(exampleCodeableConcept);
+  });
+
+  test('Should generate valueInteger when type parameter is used', () => {
+    const exampleInt = 17;
+    const exampleValueInt = {
+      valueInteger: 17,
+    };
+    expect(valueX(exampleInt, 'valueInteger')).toEqual(exampleValueInt);
+  });
+
+  test('Should generate valueInteger when type parameter is not used', () => {
+    const exampleInt = 17;
+    const exampleValueInt = {
+      valueInteger: 17,
+    };
+    expect(valueX(exampleInt)).toEqual(exampleValueInt);
+  });
+
+  test('Should generate valueDecimal when type parameter is used', () => {
+    const exampleNumber = 17;
+    const exampleValueDecimal = {
+      valueInteger: 17,
+    };
+    expect(valueX(exampleNumber, 'valueDecimal')).toEqual(exampleValueDecimal);
+  });
+
+  test('Should generate valueBoolean when type parameter is used', () => {
+    const exampleBool = true;
+    const exampleValueBool = {
+      valueBoolean: true,
+    };
+    expect(valueX(exampleBool, 'valueBoolean')).toEqual(exampleValueBool);
+  });
+
+  test('Should generate valueBoolean when type parameter is not used', () => {
+    const exampleBool = true;
+    const exampleValueBool = {
+      valueBoolean: true,
+    };
+    expect(valueX(exampleBool)).toEqual(exampleValueBool);
+  });
+
+  test('Should generate valueDate when type parameter is used', () => {
+    const exampleDate = '2020-02-01';
+    const exampleValueDate = {
+      valueDate: '2020-02-01',
+    };
+    expect(valueX(exampleDate, 'valueDate')).toEqual(exampleValueDate);
+  });
+
+  test('Should generate valueDate when type parameter is not used', () => {
+    const exampleDate = '2020-02-01';
+    const exampleValueDate = {
+      valueDate: '2020-02-01',
+    };
+    expect(valueX(exampleDate)).toEqual(exampleValueDate);
+  });
+
+  test('Should generate valueDateTime when type parameter is used', () => {
+    const exampleDateTime = '2020-02-01';
+    const exampleValueDateTime = {
+      valueDateTime: '2020-02-01',
+    };
+    expect(valueX(exampleDateTime, 'valueDateTime')).toEqual(exampleValueDateTime);
+  });
+
+  test('Should generate valueTime when type parameter is used', () => {
+    const exampconstime = '10:35:59';
+    const exampleValueTime = {
+      valueTime: '10:35:59',
+    };
+    expect(valueX(exampconstime, 'valueTime')).toEqual(exampleValueTime);
+  });
+
+  test('Should generate valueTime when type parameter is not used', () => {
+    const exampconstime = '10:35:59';
+    const exampleValueTime = {
+      valueTime: '10:35:59',
+    };
+    expect(valueX(exampconstime)).toEqual(exampleValueTime);
+  });
+
+  test('Should generate valueQuantity from object when type parameter is used', () => {
+    const exampleObj = { value: 'exampleValue', code: 'exampleCode', unit: 'Example Unit' };
+    const exampleQuantity = {
+      valueQuantity: {
+        value: 'exampleValue',
+        code: 'exampleCode',
+        unit: 'Example Unit',
+        system: 'http://unitsofmeasure.org',
+      },
+    };
+    expect(valueX(exampleObj, 'valueQuantity')).toEqual(exampleQuantity);
+  });
+
+  test('Should generate valueQuantity from object when type parameter is not used', () => {
+    const exampleObj = { value: 'exampleValue', code: 'exampleCode', unit: 'Example Unit' };
+    const exampleQuantity = {
+      valueQuantity: {
+        value: 'exampleValue',
+        code: 'exampleCode',
+        unit: 'Example Unit',
+        system: 'http://unitsofmeasure.org',
+      },
+    };
+    expect(valueX(exampleObj)).toEqual(exampleQuantity);
+  });
+
+  test('Should generate valueQuantity from string when type parameter is used', () => {
+    const exampleString = '66.89 [in_i]';
+    const exampleQuantity = {
+      valueQuantity: {
+        value: 66.89,
+        code: '[in_i]',
+        unit: 'in',
+        system: 'http://unitsofmeasure.org',
+      },
+    };
+    expect(valueX(exampleString, 'valueQuantity')).toEqual(exampleQuantity);
+  });
+
+  test('Should generate valueQuantity from string when type parameter is not used', () => {
+    const exampleString = '66.89 [in_i]';
+    const exampleQuantity = {
+      valueQuantity: {
+        value: 66.89,
+        code: '[in_i]',
+        unit: 'in',
+        system: 'http://unitsofmeasure.org',
+      },
+    };
+    expect(valueX(exampleString)).toEqual(exampleQuantity);
+  });
+
+  test('Should generate valueString when type parameter is used', () => {
+    const exampleString = 'Hello!';
+    const exampleValueString = {
+      valueString: 'Hello!',
+    };
+    expect(valueX(exampleString, 'valueString')).toEqual(exampleValueString);
+  });
+
+  test('Should generate valueString when type parameter is not used', () => {
+    const exampleString = 'Hello!';
+    const exampleValueString = {
+      valueString: 'Hello!',
+    };
+    expect(valueX(exampleString)).toEqual(exampleValueString);
+  });
+
+  test('Should generate valueRange from object when type parameter is used', () => {
+    const exampleObj = { high: 19, low: 15 };
+    const exampleRange = {
+      valueRange: {
+        high: 19,
+        low: 15,
+      },
+    };
+    expect(valueX(exampleObj, 'valueRange')).toEqual(exampleRange);
+  });
+
+  test('Should generate valueRange from object when type parameter is not used', () => {
+    const exampleObj = { high: 19, low: 15 };
+    const exampleRange = {
+      valueRange: {
+        high: 19,
+        low: 15,
+      },
+    };
+    expect(valueX(exampleObj)).toEqual(exampleRange);
+  });
+
+  test('Should generate valuePeriod from object when type parameter is used', () => {
+    const exampleObj = { start: '2020-01-01', end: '20202-02-02' };
+    const examplePeriod = {
+      valuePeriod: {
+        start: '2020-01-01',
+        end: '20202-02-02',
+      },
+    };
+    expect(valueX(exampleObj, 'valuePeriod')).toEqual(examplePeriod);
+  });
+
+  test('Should generate valuePeriod from object when type parameter is not used', () => {
+    const exampleObj = { start: '2020-01-01', end: '20202-02-02' };
+    const examplePeriod = {
+      valuePeriod: {
+        start: '2020-01-01',
+        end: '20202-02-02',
+      },
+    };
+    expect(valueX(exampleObj)).toEqual(examplePeriod);
+  });
+
+  test('Should generate valueCoding when type parameter is used', () => {
+    const exampleCode = { system: 'exampleSystem', code: 'exampleCode', display: 'Example Display' };
+    const exampleValueCoding = {
+      valueCoding: {
+        system: 'exampleSystem',
+        code: 'exampleCode',
+        display: 'Example Display',
+      },
+    };
+    expect(valueX(exampleCode, 'valueCoding')).toEqual(exampleValueCoding);
+  });
+
+  test('Should generate valueCoding when type parameter is not used', () => {
+    const exampleCode = { system: 'exampleSystem', code: 'exampleCode', display: 'Example Display' };
+    const exampleValueCoding = {
+      valueCoding: {
+        system: 'exampleSystem',
+        code: 'exampleCode',
+        display: 'Example Display',
+      },
+    };
+    expect(valueX(exampleCode)).toEqual(exampleValueCoding);
+  });
+});

--- a/test/templates/snippets/valueX.test.js
+++ b/test/templates/snippets/valueX.test.js
@@ -36,7 +36,7 @@ describe('valueX snippet', () => {
   test('Should generate valueDecimal when type parameter is used', () => {
     const exampleNumber = 17;
     const exampleValueDecimal = {
-      valueInteger: 17,
+      valueDecimal: 17,
     };
     expect(valueX(exampleNumber, 'valueDecimal')).toEqual(exampleValueDecimal);
   });


### PR DESCRIPTION
# Summary
An optional `type` parameter has been added to the `valueX()` snippet. The `valueCodeableConcept()` snippet has also been removed and integrated with the `valueX` snippet.
## New behavior
The `valueX()` function will now default to using the `type` parameter to determine the return type when this parameter is included. If the type parameter is not included; or is included and the specified type is not recognized, the old inferential approach is used. Also, the separate `valueCodeableConcept` snippet has been removed in favor of including `'valueCodeableConcept'` as a parameter in the base `valueX` snippet.
## Code changes
1. `type` was added as an optional parameter to the `valueX()` snippet. A `valueByType()` helper function has also been introduced, returning the appropriate value[x] element based on the type parameter rather than the value parameter. This new helper function returns null if the type parameter is recognizable. 
2. `'valueCodeableConcept'` has been added as a supported type to the `valueX()` snippet. Consequently, the `valueCodeableConcept()` snippet and all of it's references have been removed throughout the codebase and replaced with `valueX()` references with a `'valueCodeableConcept'` argument.
# Testing guidance
Ensure that all tests pass from MEF, also ensure that all bundles still validate when run from the base icare extraction client. Happy Testing!