### PR TITLE
Improve logging when OperationOutcomes are present

### DIFF
--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -1,6 +1,6 @@
 const { Extractor } = require('./Extractor');
 const { BaseFHIRModule } = require('../modules');
-const { determineVersion, getBundleResourcesByType, isBundleEmpty, mapFHIRVersions } = require('../helpers/fhirUtils');
+const { determineVersion, mapFHIRVersions, isBundleEmpty, getBundleResourcesByType } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 function parseContextForPatientId(context) {

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -1,6 +1,12 @@
 const { Extractor } = require('./Extractor');
 const { BaseFHIRModule } = require('../modules');
-const { determineVersion, mapFHIRVersions, isBundleEmpty, getBundleResourcesByType } = require('../helpers/fhirUtils');
+const {
+  determineVersion,
+  getBundleResourcesByType,
+  isBundleEmpty,
+  logOperationOutcomeInfo,
+  mapFHIRVersions,
+} = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 function parseContextForPatientId(context) {
@@ -40,6 +46,10 @@ class BaseFHIRExtractor extends Extractor {
     // 1. Get data
     logger.debug(`Getting ${this.resourceType} FHIR resource`);
     const fhirResponseBundle = await this.baseFHIRModule.search(this.resourceType, params);
+    const operationOutcomeEntry = getBundleResourcesByType(fhirResponseBundle, 'OperationOutcome', {}, true);
+    if (operationOutcomeEntry) {
+      logOperationOutcomeInfo(operationOutcomeEntry);
+    }
     if (isBundleEmpty(fhirResponseBundle)) {
       logger.warn(`${this.resourceType} bundle that was supposed to have entries had 0`);
       return fhirResponseBundle;

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -1,12 +1,6 @@
 const { Extractor } = require('./Extractor');
 const { BaseFHIRModule } = require('../modules');
-const {
-  determineVersion,
-  getBundleResourcesByType,
-  isBundleEmpty,
-  logOperationOutcomeInfo,
-  mapFHIRVersions,
-} = require('../helpers/fhirUtils');
+const { determineVersion, getBundleResourcesByType, isBundleEmpty, mapFHIRVersions } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 function parseContextForPatientId(context) {
@@ -46,10 +40,6 @@ class BaseFHIRExtractor extends Extractor {
     // 1. Get data
     logger.debug(`Getting ${this.resourceType} FHIR resource`);
     const fhirResponseBundle = await this.baseFHIRModule.search(this.resourceType, params);
-    const operationOutcomeEntry = getBundleResourcesByType(fhirResponseBundle, 'OperationOutcome', {}, true);
-    if (operationOutcomeEntry) {
-      logOperationOutcomeInfo(operationOutcomeEntry);
-    }
     if (isBundleEmpty(fhirResponseBundle)) {
       logger.warn(`${this.resourceType} bundle that was supposed to have entries had 0`);
       return fhirResponseBundle;

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -98,6 +98,7 @@ const getBundleEntriesByResourceType = (bundle, type, context = {}, first = fals
 };
 
 const logOperationOutcomeInfo = (operationOutcome) => {
+  logger.info('An OperationOutcome was returned with the following issue(s):');
   operationOutcome.issue.forEach((issue) => {
     let issueMessage = `Severity: ${issue.severity}. Code: ${issue.code}`;
     let detailsMessage = '';
@@ -118,7 +119,6 @@ const logOperationOutcomeInfo = (operationOutcome) => {
     } else if (issue.severity === 'warning') {
       logLevel = 'warn';
     }
-    logger.log(logLevel, 'An OperationOutcome was returned with the following issue(s):');
     logger.log(logLevel, issueMessage);
     if (detailsMessage) {
       // If there were any codes, log them

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -98,7 +98,6 @@ const getBundleEntriesByResourceType = (bundle, type, context = {}, first = fals
 };
 
 const logOperationOutcomeInfo = (operationOutcome) => {
-  logger.warn('An OperationOutcome was returned with the following issue(s):');
   operationOutcome.issue.forEach((issue) => {
     let issueMessage = `Severity: ${issue.severity}. Code: ${issue.code}`;
     let detailsMessage = '';
@@ -119,6 +118,7 @@ const logOperationOutcomeInfo = (operationOutcome) => {
     } else if (issue.severity === 'warning') {
       logLevel = 'warn';
     }
+    logger.log(logLevel, 'An OperationOutcome was returned with the following issue(s):');
     logger.log(logLevel, issueMessage);
     if (detailsMessage) {
       // If there were any codes, log them

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -97,6 +97,36 @@ const getBundleEntriesByResourceType = (bundle, type, context = {}, first = fals
   return first ? null : [];
 };
 
+const logOperationOutcomeInfo = (operationOutcome) => {
+  logger.warn('An OperationOutcome was returned with the following issue(s):');
+  operationOutcome.issue.forEach((issue) => {
+    let issueMessage = `Severity: ${issue.severity}. Code: ${issue.code}`;
+    let detailsMessage = '';
+    if (issue.diagnostics) issueMessage += `. Diagnostics: ${issue.diagnostics}`;
+    if (issue.expression) issueMessage += `. Related FHIRPath: ${issue.expression}`;
+    if (issue.details) {
+      if (issue.details.text) issueMessage += `. Details: ${issue.details.text}`;
+      if (issue.details.coding.length > 0) detailsMessage += 'Codings: ';
+      issue.details.coding.forEach((coding) => {
+        detailsMessage += `Code: ${coding.code}, System: ${coding.system}, Display: ${coding.display}. `;
+      });
+    }
+
+    // Log with the same severity as the issue
+    let logLevel = 'info'; // issue.severity === 'information'
+    if (issue.severity === 'fatal' || issue.severity === 'error') {
+      logLevel = 'error';
+    } else if (issue.severity === 'warning') {
+      logLevel = 'warn';
+    }
+    logger.log(logLevel, issueMessage);
+    if (detailsMessage) {
+      // If there were any codes, log them
+      logger.debug(detailsMessage);
+    }
+  });
+};
+
 module.exports = {
   getQuantityUnit,
   quantityCodeToUnitLookup,
@@ -108,5 +138,6 @@ module.exports = {
   getBundleResourcesByType,
   getEmptyBundle,
   isBundleEmpty,
+  logOperationOutcomeInfo,
   mapFHIRVersions,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ const {
   getBundleResourcesByType,
   getEmptyBundle,
   isBundleEmpty,
+  logOperationOutcomeInfo,
 } = require('./helpers/fhirUtils');
 const { generateMcodeResources } = require('./templates');
 const {
@@ -95,5 +96,6 @@ module.exports = {
   isConditionSecondary,
   isConditionCodeCancer,
   isConditionCancer,
+  logOperationOutcomeInfo,
   mEpochToDate,
 };

--- a/src/modules/BaseFHIRModule.js
+++ b/src/modules/BaseFHIRModule.js
@@ -1,5 +1,6 @@
 const { FHIRClient } = require('fhir-crud-client');
 const logger = require('../helpers/logger');
+const { getBundleResourcesByType, logOperationOutcomeInfo } = require('../helpers/fhirUtils');
 
 class BaseFHIRModule {
   constructor(baseUrl, requestHeaders) {
@@ -13,7 +14,12 @@ class BaseFHIRModule {
 
   async search(resourceType, params) {
     logger.debug(`GET ${this.baseUrl}/${resourceType}`);
-    return this.client.search({ resourceType, params });
+    const result = await this.client.search({ resourceType, params });
+    const operationOutcomeEntry = getBundleResourcesByType(result, 'OperationOutcome', {}, true);
+    if (operationOutcomeEntry) {
+      logOperationOutcomeInfo(operationOutcomeEntry);
+    }
+    return result;
   }
 }
 

--- a/test/modules/BaseFHIRModule.test.js
+++ b/test/modules/BaseFHIRModule.test.js
@@ -1,4 +1,6 @@
+const nock = require('nock');
 const { BaseFHIRModule } = require('../../src/modules');
+const operationOutcomeBundle = require('./fixtures/operation-outcome-bundle.json');
 
 const MOCK_URL = 'http://localhost';
 const MOCK_REQUEST_HEADERS = {};
@@ -6,16 +8,30 @@ const MOCK_REQUEST_HEADERS = {};
 // Instantiate module with mocks
 const baseFHIRModule = new BaseFHIRModule(MOCK_URL, MOCK_REQUEST_HEADERS);
 
-test('updateHeaders fn should update the headers variable and the clients headers', () => {
-  // Ensure that the request headers are as expected initially
-  const newHeaders = {
-    ...MOCK_REQUEST_HEADERS,
-    Authorization: 'Bearer tokenGoesHere',
-  };
-  baseFHIRModule.updateRequestHeaders(newHeaders);
+describe('BaseFHIRModule', () => {
+  test('updateHeaders fn should update the headers variable and the clients headers', () => {
+    // Ensure that the request headers are as expected initially
+    const newHeaders = {
+      ...MOCK_REQUEST_HEADERS,
+      Authorization: 'Bearer tokenGoesHere',
+    };
+    baseFHIRModule.updateRequestHeaders(newHeaders);
 
-  Object.keys(newHeaders).forEach((key) => {
-    const val = newHeaders[key];
-    expect(baseFHIRModule.client.httpClient.defaults.headers).toHaveProperty(key, val);
+    Object.keys(newHeaders).forEach((key) => {
+      const val = newHeaders[key];
+      expect(baseFHIRModule.client.httpClient.defaults.headers).toHaveProperty(key, val);
+    });
+  });
+
+  test('search should make call for specified resourceType', async () => {
+    const resourceType = 'Patient';
+    nock(baseFHIRModule.baseUrl)
+      .get(`/${resourceType}`)
+      .reply(200, operationOutcomeBundle);
+
+    const searchResults = await baseFHIRModule.search('Patient', {});
+    expect(searchResults).toEqual(operationOutcomeBundle);
+    // TODO: Check that the `logOperationOutcomeInfo` function in fhirUtils was called.
+    // Having issues correctly spying on the function, so that test is not yet implemented.
   });
 });

--- a/test/modules/fixtures/operation-outcome-bundle.json
+++ b/test/modules/fixtures/operation-outcome-bundle.json
@@ -1,0 +1,114 @@
+{
+  "resourceType": "Bundle",
+  "type": "searchset",
+  "total": 1,
+  "link": [
+    {
+      "relation": "self"
+    }
+  ],
+  "entry": [
+    {
+      "link": [
+        {
+          "relation": "self"
+        }
+      ],
+      "resource": {
+        "resourceType": "Patient",
+        "id": "patient-id",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "urn:oid:2.16.840.1.113883.5.104",
+                  "code": "UNK",
+                  "display": "Unknown"
+                }
+              ],
+              "text": "Unknown"
+            }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-ethnicity",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "urn:oid:2.16.840.1.113883.5.50",
+                  "code": "UNK",
+                  "display": "Unknown"
+                }
+              ],
+              "text": "Unknown"
+            }
+          },
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/us-core-birth-sex",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://hl7.org/fhir/v3/AdministrativeGender",
+                  "code": "F",
+                  "display": "Female"
+                }
+              ],
+              "text": "Female"
+            }
+          }
+        ],
+        "active": true,
+        "name": [
+          {
+            "use": "usual",
+            "text": "Elizabeth-Test Smith-Mitre",
+            "family": [
+            "Smith-Mitre"
+            ],
+            "given": [
+              "Elizabeth-Test"
+            ]
+          }
+        ],
+        "gender": "female",
+        "birthDate": "1942-01-07",
+        "deceasedBoolean": false
+      },
+      "search": {
+        "mode": "match"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "issue": [
+          {
+            "severity": "warning",
+            "code": "invalid",
+            "details": {
+              "coding": [
+                {
+                  "system": "urn:oid:1.2.840.114350.1.13.0.1.7.2.657369",
+                  "code": "59101",
+                  "display": "Content invalid against the specification or a profile."
+                }
+              ],
+              "text": "Content invalid against the specification or a profile."
+            },
+            "diagnostics": "The provided status is not valid and has been ignored",
+            "location": [
+              "/f:status"
+            ],
+            "expression": [
+              "status"
+            ]
+          }
+        ]
+      },
+      "search": {
+        "mode": "outcome"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
When an `OperationOutcome` is present, we now log more detailed information from that resource.

## New behavior
Right now, I think the only time we could get an `OperationOutcome` is from a `search` from the BaseFHIRModule. When we get the bundle back from the search, we should look to see if there is an [OperationOutcome](https://www.hl7.org/fhir/operationoutcome.html) resource on it. If there is, we log the information on that resource. Severity and code are required on the resource, so I assume those are always present. If other information is present, it is added. I thought the list of codes was a lot of information in the log statements, so I put that list in a `debug` so it is only logged if we use `--debug`.

## Code changes
Added a helper function to do the logging for OperationOutcome information.

# Testing guidance
Test to make sure the information logged is helpful and formatted in an appropriate way. (It is basically a long sentence right now based on a brief discussion last week.) In order to get get search results with an OperationOutcome when using the ICARE Client, you can either include the Procedure Extractor in your config file or include the MedicationRequest Extractor and change the default status to an invalid value [here](https://github.com/mcode/mcode-extraction-framework/blob/master/src/extractors/FHIRMedicationRequestExtractor.js#L3).

I had difficulty writing a test for the new addition to the `search` in BaseFHIRModule. I had tried to spy on `logOperationOutcomeInfo` to see if it was called but was never able to spy on it correctly. I've added a note to the test in case we learn how to do this in the future. I also added a task to the backlog to consider checking the statements that get logged, which could be another way to test the function in the future.
