### PR TITLE
Data Absent Reason extension

### DIFF
--- a/src/templates/CancerRelatedMedicationTemplate.js
+++ b/src/templates/CancerRelatedMedicationTemplate.js
@@ -1,4 +1,10 @@
-const { coding, extensionArr, reference, valueX } = require('./snippets');
+const {
+  coding,
+  dataAbsentReasonExtension,
+  extensionArr,
+  reference,
+  valueX,
+} = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
 
 function treatmentIntentTemplate({ treatmentIntent }) {
@@ -24,6 +30,13 @@ function subjectTemplate({ id }) {
 }
 
 function periodTemplate({ startDate, endDate }) {
+  // If start and end date are not provided, indicate data absent with extension.
+  if (!startDate && !endDate) {
+    return {
+      effectivePeriod: extensionArr(dataAbsentReasonExtension('unknown')),
+    };
+  }
+
   return {
     effectivePeriod: {
       ...(startDate && { start: startDate }),

--- a/src/templates/snippets/extension.js
+++ b/src/templates/snippets/extension.js
@@ -8,6 +8,16 @@ function extensionArr(...extensions) { // 0. Spread since 1..n extensions
   )(...extensions); // 1. Spread to pass each extension individually
 }
 
+// See http://hl7.org/fhir/R4/extension-data-absent-reason.html
+// reasonCode is any code from Value Set http://hl7.org/fhir/R4/valueset-data-absent-reason.html
+function dataAbsentReasonExtension(reasonCode) {
+  return {
+    url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+    valueCode: reasonCode,
+  };
+}
+
 module.exports = {
+  dataAbsentReasonExtension,
   extensionArr,
 };

--- a/src/templates/snippets/index.js
+++ b/src/templates/snippets/index.js
@@ -2,7 +2,7 @@ const { coding } = require('./coding');
 const { valueX } = require('./valueX');
 const { reference } = require('./reference');
 const { meta, narrative } = require('./resource');
-const { extensionArr } = require('./extensionArr');
+const { extensionArr, dataAbsentReasonExtension } = require('./extension');
 const { effectiveX } = require('./effectiveX');
 const { identifier, identifierArr } = require('./identifier');
 const { bodySiteTemplate } = require('./bodySiteTemplate');
@@ -10,6 +10,7 @@ const { bodySiteTemplate } = require('./bodySiteTemplate');
 module.exports = {
   bodySiteTemplate,
   coding,
+  dataAbsentReasonExtension,
   effectiveX,
   extensionArr,
   identifier,

--- a/test/templates/fixtures/minimal-medication-resource.json
+++ b/test/templates/fixtures/minimal-medication-resource.json
@@ -17,5 +17,12 @@
   "subject": {
     "reference": "urn:uuid:mrn-1"
   },
-  "effectivePeriod": {}
+  "effectivePeriod": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  }
 }

--- a/test/templates/medication.test.js
+++ b/test/templates/medication.test.js
@@ -63,6 +63,17 @@ describe('test Medication template', () => {
     const generatedMedication = cancerRelatedMedicationTemplate(MEDICATION_MINIMAL_DATA);
 
     expect(generatedMedication).toEqual(minimalValidExampleMedication);
+
+    // If no start or end date is provided, use the data absent reason extension
+    expect(generatedMedication.effectivePeriod).toEqual({
+      extension: [
+        {
+          url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+          valueCode: 'unknown',
+        },
+      ],
+    });
+
     expect(isValidFHIR(generatedMedication)).toBeTruthy();
   });
 


### PR DESCRIPTION
# Summary

If both start and end date are not provided in the related medication CSV, the data absent reason extension is used in the `effectivePeriod` element.

## New behavior
The extension will be used in the `effectivePeriod` element if there is no start and no end date provided in the CSV. I decided to use "unknown" as the reason code because the description said "The value is expected to exist but is not known." which I thought was most applicable to the situation where we are missing dates.

## Code changes
I made the extension a snippet since I figured there may be other places we'd want to use it in the future. You can provide the specific reason code when using the snippet.

# Testing guidance
I tested using the VS Code FHIR Validator extension, but ensure that the output now validates (at least around the MedicationStatement effectivePeriod). Ensure tests and code make sense.
