### PR TITLE
Added tests for getResourceCountInBundle

### DIFF
--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -1,70 +1,111 @@
 const {
-  getQuantityUnit, isBundleEmpty, firstEntryInBundle, firstResourceInBundle, allResourcesInBundle, quantityCodeToUnitLookup,
+  getQuantityUnit,
+  isBundleEmpty,
+  firstEntryInBundle,
+  firstResourceInBundle,
+  allResourcesInBundle,
+  quantityCodeToUnitLookup,
+  getResourceCountInBundle,
 } = require('../../src/helpers/fhirUtils.js');
 const emptyBundle = require('./fixtures/emptyBundle.json');
 const bundleWithOneEntry = require('./fixtures/searchsetBundleWithOneEntry.json');
 const bundleWithMultipleEntries = require('./fixtures/searchsetBundleWithMultipleEntries.json');
+const countBundle5Unique = require('./fixtures/count-bundle-5-unique.json');
+const countBundle5Same = require('./fixtures/count-bundle-5-same.json');
+const countBundle5Nested = require('./fixtures/count-bundle-5-nested.json');
 
-test('getQuantityUnit', () => {
-  // Should return unit text if provided in lookup table
-  Object.keys(quantityCodeToUnitLookup).forEach((unitCode) => {
-    const unitText = quantityCodeToUnitLookup[unitCode];
-    expect(getQuantityUnit(unitCode)).toEqual(unitText);
+describe('getQuantityUnit', () => {
+  test('Should return unit text if provided in lookup table', () => {
+    Object.keys(quantityCodeToUnitLookup).forEach((unitCode) => {
+      const unitText = quantityCodeToUnitLookup[unitCode];
+      expect(getQuantityUnit(unitCode)).toEqual(unitText);
+    });
   });
 
-  // Should return unit code if unit text is not provided
-  expect(getQuantityUnit('foo')).toEqual('foo');
+  test('Should return unit code if unit text is not provided', () => {
+    expect(getQuantityUnit('foo')).toEqual('foo');
+  });
 });
 
-test('isBundleEmpty', () => {
-  // Empty bundle return true
-  expect(isBundleEmpty(emptyBundle))
-    .toBeTruthy();
+describe('isBundleEmpty', () => {
+  test('Empty bundle return true', () => {
+    expect(isBundleEmpty(emptyBundle))
+      .toBeTruthy();
+  });
 
-  // Bundles with >=1 entry should return false
-  expect(isBundleEmpty(bundleWithOneEntry))
-    .toBeFalsy();
-  expect(isBundleEmpty(bundleWithMultipleEntries))
-    .toBeFalsy();
+  test('Bundles with >=1 entry should return false', () => {
+    expect(isBundleEmpty(bundleWithOneEntry))
+      .toBeFalsy();
+    expect(isBundleEmpty(bundleWithMultipleEntries))
+      .toBeFalsy();
+  });
 });
 
-test('firstEntryInBundle', () => {
-  // Empty bundle should return undefined
+describe('firstEntryInBundle', () => {
+  test('Empty bundle should return undefined', () => {
+  });
   expect(firstEntryInBundle(emptyBundle)).toBeUndefined();
 
-  // Bundles with entries should always return the first
-  expect(firstEntryInBundle(bundleWithOneEntry))
-    .toEqual(bundleWithOneEntry.entry[0]);
-  expect(firstEntryInBundle(bundleWithMultipleEntries))
-    .toEqual(bundleWithMultipleEntries.entry[0]);
+  test('Bundles with entries should always return the first', () => {
+    expect(firstEntryInBundle(bundleWithOneEntry))
+      .toEqual(bundleWithOneEntry.entry[0]);
+    expect(firstEntryInBundle(bundleWithMultipleEntries))
+      .toEqual(bundleWithMultipleEntries.entry[0]);
+  });
 });
 
-test('firstResourceInBundle', () => {
-  // Empty bundle should throw an error
-  expect(() => firstResourceInBundle(emptyBundle))
-    .toThrow(TypeError("Cannot read property 'resource' of undefined"));
+describe('firstResourceInBundle', () => {
+  test('Empty bundle should throw an error', () => {
+    expect(() => firstResourceInBundle(emptyBundle))
+      .toThrow(TypeError("Cannot read property 'resource' of undefined"));
+  });
 
-  // Bundles with entries should always return the first
-  expect(firstResourceInBundle(bundleWithOneEntry))
-    .toEqual(bundleWithOneEntry.entry[0].resource);
-  expect(firstResourceInBundle(bundleWithMultipleEntries))
-    .toEqual(bundleWithMultipleEntries.entry[0].resource);
+  test('Bundles with entries should always return the first', () => {
+    expect(firstResourceInBundle(bundleWithOneEntry))
+      .toEqual(bundleWithOneEntry.entry[0].resource);
+    expect(firstResourceInBundle(bundleWithMultipleEntries))
+      .toEqual(bundleWithMultipleEntries.entry[0].resource);
+  });
 });
 
-test('allResourcesInBundle', () => {
-  // Empty bundle should return an empty array
-  expect(allResourcesInBundle(emptyBundle))
-    .toEqual([]);
+describe('allResourcesInBundle', () => {
+  test('Empty bundle should return an empty array', () => {
+    expect(allResourcesInBundle(emptyBundle))
+      .toEqual([]);
+  });
 
-  // Bundles with entries should always return an array of each resource on each entry
-  expect(allResourcesInBundle(bundleWithOneEntry))
-    .toEqual([bundleWithOneEntry.entry[0].resource]);
-  expect(allResourcesInBundle(bundleWithMultipleEntries))
-    .toEqual(bundleWithMultipleEntries.entry.map((e) => e.resource));
+
+  test('Bundles with entries should always return an array of each resource on each entry', () => {
+    expect(allResourcesInBundle(bundleWithOneEntry))
+      .toEqual([bundleWithOneEntry.entry[0].resource]);
+    expect(allResourcesInBundle(bundleWithMultipleEntries))
+      .toEqual(bundleWithMultipleEntries.entry.map((e) => e.resource));
+  });
 });
 
+describe('getResourceCountInBundle', () => {
+  test('Counts five different resources, all at the same depth', () => {
+    const counts = {
+      'Resource-1': [1],
+      'Resource-2': [1],
+      'Resource-3': [1],
+      'Resource-4': [1],
+      'Resource-5': [1],
+    };
+    expect(getResourceCountInBundle(countBundle5Unique)).toEqual(counts);
+  });
 
-test('getResourceCountInBundle', () => {
-  // TODO: MAKE TESTS HERE
-  // getResourceCountInBundle;
+  test('Counts five of the same resources, all at the same depth', () => {
+    const counts = {
+      'Resource-1': [5],
+    };
+    expect(getResourceCountInBundle(countBundle5Same)).toEqual(counts);
+  });
+
+  test('Counts five of the same resources at various depths', () => {
+    const counts = {
+      'Resource-1': [5],
+    };
+    expect(getResourceCountInBundle(countBundle5Nested)).toEqual(counts);
+  });
 });

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -84,6 +84,11 @@ describe('allResourcesInBundle', () => {
 });
 
 describe('getResourceCountInBundle', () => {
+  test('Returns an empty object when given an empty object', () => {
+    const emptyCounts = {};
+    expect(getResourceCountInBundle({})).toEqual(emptyCounts);
+  });
+
   test('Counts five different resources, all at the same depth', () => {
     const counts = {
       'Resource-1': [1],

--- a/test/helpers/fixtures/count-bundle-5-nested.json
+++ b/test/helpers/fixtures/count-bundle-5-nested.json
@@ -1,0 +1,38 @@
+{
+  "resourceType": "Bundle",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      },
+      "contained": [
+        {
+          "resource": {
+            "resourceType": "Resource-1"
+          },
+          "contained": [
+            {
+              "resource": {
+                "resourceType": "Resource-1"
+              },
+              "contained": [
+                {
+                  "resource": {
+                    "resourceType": "Resource-1"
+                  },
+                  "contained": [
+                    {
+                      "resource": {
+                        "resourceType": "Resource-1"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/test/helpers/fixtures/count-bundle-5-same.json
+++ b/test/helpers/fixtures/count-bundle-5-same.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Bundle",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    }
+  ]
+}

--- a/test/helpers/fixtures/count-bundle-5-unique.json
+++ b/test/helpers/fixtures/count-bundle-5-unique.json
@@ -1,0 +1,30 @@
+{
+  "resourceType": "Bundle",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Resource-1"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-2"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-3"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-4"
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Resource-5"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Tests the `getResourceCountInBundle` function now. Also reorganized the tests in`fhirUtils.test.js` to better use describe blocks where appropriate. 

Not a whole lot happening here, so this should be good to merge with one approval.
