### PR TITLE
WIP: mCODE Surgical Procedure Extractor

### DIFF
--- a/src/extractors/MCODESurgicalProcedureExtractor.js
+++ b/src/extractors/MCODESurgicalProcedureExtractor.js
@@ -1,0 +1,57 @@
+const path = require('path');
+const { Extractor } = require('./Extractor');
+const { FHIRProcedureExtractor } = require('./FHIRProcedureExtractor');
+const { getBundleEntriesByResourceType } = require('../helpers/fhirUtils');
+const { checkCodeInVs } = require('../helpers/valueSetUtils');
+const logger = require('../helpers/logger');
+
+function getMCODESurgicalProcedures(fhirProcedures) {
+  const surgicalProcedureVSFilepath = path.resolve(__dirname, '..', 'helpers', 'valueSets', 'ValueSet-mcode-cancer-related-surgical-procedure-vs.json');
+  return fhirProcedures.filter((procedure) => {
+    const coding = procedure.resource.code ? procedure.resource.code.coding : [];
+    // NOTE: Update when checkCodeInVS checks code and system (might be able to pass in the full Coding)
+    return coding.some((c) => checkCodeInVs(c.code, surgicalProcedureVSFilepath));
+  });
+}
+
+class MCODESurgicalProcedureExtractor extends Extractor {
+  constructor({ baseFhirUrl, requestHeaders }) {
+    super({ baseFhirUrl, requestHeaders });
+    this.fhirProcedureExtractor = new FHIRProcedureExtractor({ baseFhirUrl, requestHeaders });
+  }
+
+  updateRequestHeaders(newHeaders) {
+    this.fhirProcedureExtractor.updateRequestHeaders(newHeaders);
+  }
+
+  async getFHIRProcedures(mrn, context) {
+    const proceduresInContext = getBundleEntriesByResourceType(context, 'Procedure', {});
+    if (proceduresInContext.length !== 0) {
+      logger.debug('Procedure resources found in context.');
+      return proceduresInContext;
+    }
+
+    logger.debug('Getting procedures available for patient');
+    const procedureBundle = await this.fhirProcedureExtractor.get({ mrn, context });
+
+    logger.debug(`Found ${procedureBundle.entry.length} result(s) in Procedure search`);
+    return procedureBundle.entry;
+  }
+
+  async get({ mrn, context }) {
+    const fhirProcedures = await this.getFHIRProcedures(mrn, context);
+
+    // Filter to only include procedures that are from MCODE surgical procedure VS
+    const surgicalProcedures = getMCODESurgicalProcedures(fhirProcedures);
+
+    return {
+      resourceType: 'Bundle',
+      type: 'collection',
+      entry: surgicalProcedures,
+    };
+  }
+}
+
+module.exports = {
+  MCODESurgicalProcedureExtractor,
+};

--- a/src/extractors/index.js
+++ b/src/extractors/index.js
@@ -18,6 +18,7 @@ const { FHIRMedicationStatementExtractor } = require('./FHIRMedicationStatementE
 const { FHIRObservationExtractor } = require('./FHIRObservationExtractor');
 const { FHIRPatientExtractor } = require('./FHIRPatientExtractor');
 const { FHIRProcedureExtractor } = require('./FHIRProcedureExtractor');
+const { MCODESurgicalProcedureExtractor } = require('./MCODESurgicalProcedureExtractor');
 
 module.exports = {
   BaseFHIRExtractor,
@@ -40,4 +41,5 @@ module.exports = {
   FHIRObservationExtractor,
   FHIRPatientExtractor,
   FHIRProcedureExtractor,
+  MCODESurgicalProcedureExtractor,
 };

--- a/src/helpers/valueSets/ValueSet-mcode-cancer-related-surgical-procedure-vs.json
+++ b/src/helpers/valueSets/ValueSet-mcode-cancer-related-surgical-procedure-vs.json
@@ -1,0 +1,744 @@
+{
+  "resourceType": "ValueSet",
+  "id": "mcode-cancer-related-surgical-procedure-vs",
+  "url": "http://hl7.org/fhir/us/mcode/ValueSet/mcode-cancer-related-surgical-procedure-vs",
+  "version": "1.0.0",
+  "name": "CancerRelatedSurgicalProcedureVS",
+  "title": "Cancer-Related Surgical Procedure Value Set",
+  "status": "active",
+  "date": "2020-03-18T16:05:09+00:00",
+  "publisher": "HL7 International Clinical Interoperability Council",
+  "contact": [
+    {
+      "name": "HL7 International Clinical Interoperability Council",
+      "telecom": [
+        {
+          "system": "url",
+          "value": "http://www.hl7.org/Special/committees/cic"
+        },
+        {
+          "system": "email",
+          "value": "ciclist@lists.HL7.org"
+        }
+      ]
+    }
+  ],
+  "description": "Includes selected SNOMED CT codes that may be used in the treatment of cancer tumors. Codes from ICD-10-PCS and CPT are acceptable. CPT codes are not listed here due to intellectual property restrictions. ICD-10-PCS codes are not listed because of a limitation in the FHIR Implementation Guide publisher. For CPT and ICD-10-PCS, only codes representing surgical procedures should be used. \r\n\r\nConformance note: If an ICD-10-PCS code is used, and a semantically equivalent SNOMED CT code is available, the resulting FHIR Procedure instance will not be compliant with [US Core Profiles](http://hl7.org/fhir/us/core/index.html).",
+  "compose": {
+    "include": [
+      {
+        "system": "http://snomed.info/sct",
+        "concept": [
+          {
+            "code": "174337000",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "49264007",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "119894003",
+            "display": "Anus excision"
+          },
+          {
+            "code": "24265000",
+            "display": "Operation on anus [NOS]"
+          },
+          {
+            "code": "48185007",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "108034003",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "112902005",
+            "display": "Partial cystectomy"
+          },
+          {
+            "code": "63016009",
+            "display": "Total Cystectomy"
+          },
+          {
+            "code": "64063003",
+            "display": "Radical Cystectomy"
+          },
+          {
+            "code": "287716007",
+            "display": "Urinary bladder reconstruction"
+          },
+          {
+            "code": "52224004",
+            "display": "Pelvic exenteration"
+          },
+          {
+            "code": "149649000",
+            "display": "Cystectomy dome of bladder"
+          },
+          {
+            "code": "14861000",
+            "display": "Operation on bladder [NOS]"
+          },
+          {
+            "code": "18734000",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "68471001",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "112705001",
+            "display": "Amputation"
+          },
+          {
+            "code": "57168000",
+            "display": "Operation on bone [NOS]"
+          },
+          {
+            "code": "68829005",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "64368001",
+            "display": "Partial mastectomy"
+          },
+          {
+            "code": "70183006",
+            "display": "Subcutaneous mastectomy"
+          },
+          {
+            "code": "172043006",
+            "display": "Total mastectomy"
+          },
+          {
+            "code": "406505007",
+            "display": "Modified radical mastectomy"
+          },
+          {
+            "code": "384723003",
+            "display": "Radical mastectomy"
+          },
+          {
+            "code": "359740003",
+            "display": "Extended radical mastectomy"
+          },
+          {
+            "code": "69031006",
+            "display": "Mastectomy"
+          },
+          {
+            "code": "392090004",
+            "display": "Operation on breast [NOS]"
+          },
+          {
+            "code": "31197001",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "36384005",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "116140006",
+            "display": "Total hysterctomy"
+          },
+          {
+            "code": "236886002",
+            "display": "Hysterectomy"
+          },
+          {
+            "code": "116142003",
+            "display": "Radical hysterectomy"
+          },
+          {
+            "code": "406044008",
+            "display": "Pelvic exentration"
+          },
+          {
+            "code": "112916000",
+            "display": "Operation on cervix [NOS]"
+          },
+          {
+            "code": "176871003",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "236884004",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "387643005",
+            "display": "Partial hysterectomy"
+          },
+          {
+            "code": "116140006",
+            "display": "Total hysterctomy"
+          },
+          {
+            "code": "116142003",
+            "display": "Radical hysterectomy"
+          },
+          {
+            "code": "236886002",
+            "display": "Hysterectomy"
+          },
+          {
+            "code": "406044008",
+            "display": "Pelvic exentration"
+          },
+          {
+            "code": "79876008",
+            "display": "Operation on uterus  [NOS]"
+          },
+          {
+            "code": "18243008",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "386553005",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "3980006",
+            "display": "Partial esophagectomy"
+          },
+          {
+            "code": "14072009",
+            "display": "Total esophagectomy"
+          },
+          {
+            "code": "76443003",
+            "display": "Total esophagectomy with gastropharyngostomy"
+          },
+          {
+            "code": "45900003",
+            "display": "Esophagectomy"
+          },
+          {
+            "code": "48114000",
+            "display": "Operation on esophagus [NOS]"
+          },
+          {
+            "code": "52785004",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "69762004",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "81516001",
+            "display": "Partial nephrectomy"
+          },
+          {
+            "code": "175905003",
+            "display": "Total nephrectomy"
+          },
+          {
+            "code": "116033007",
+            "display": "Radical nephrectomy"
+          },
+          {
+            "code": "175898006",
+            "display": "Kidney operation  [NOS]"
+          },
+          {
+            "code": "78923006",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "88623004",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "80513001",
+            "display": "Partial laryngectomy"
+          },
+          {
+            "code": "66478002",
+            "display": "Total laryngectomy"
+          },
+          {
+            "code": "60041003",
+            "display": "Laryngopharyngectomy"
+          },
+          {
+            "code": "72791001",
+            "display": "Laryngectomy"
+          },
+          {
+            "code": "387636004",
+            "display": "Operation on larynx [NOS]"
+          },
+          {
+            "code": "5415002",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "174431000",
+            "display": "Wedge resecton of liver"
+          },
+          {
+            "code": "85946004",
+            "display": "Lobectomy of liver"
+          },
+          {
+            "code": "15257006",
+            "display": "Lobectomy w/ partial excision of adjacent lobes"
+          },
+          {
+            "code": "107963000",
+            "display": "Hepatectomy"
+          },
+          {
+            "code": "13580001000004101",
+            "display": "Excision of tumor of liver"
+          },
+          {
+            "code": "27280000",
+            "display": "Liver transplant w/recipient hepatectomy"
+          },
+          {
+            "code": "4974007",
+            "display": "Operation on liver [NOS]"
+          },
+          {
+            "code": "450608000",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "119746007",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "173170008",
+            "display": "Bilobectomy of lung"
+          },
+          {
+            "code": "359623004",
+            "display": "Total lobectomy of lung"
+          },
+          {
+            "code": "49795001",
+            "display": "Total pneumonectomy"
+          },
+          {
+            "code": "91596000",
+            "display": "Complete excision of lung with mediastinal dissection"
+          },
+          {
+            "code": "119746007",
+            "display": "Operation on lung [NOS]"
+          },
+          {
+            "code": "230859007",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "230810008",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "446103006",
+            "display": "Partial excision of lesion of brain"
+          },
+          {
+            "code": "17537007",
+            "display": "Resection of spinal cord"
+          },
+          {
+            "code": "447115003",
+            "display": "Total excision of lesion of brain"
+          },
+          {
+            "code": "67402009",
+            "display": "Partial lobectomy"
+          },
+          {
+            "code": "171443003",
+            "display": "Total lobectomy"
+          },
+          {
+            "code": "70586009",
+            "display": "Operation on brain [NOS]"
+          },
+          {
+            "code": "177018009",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "35887003",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "116028008",
+            "display": "Salpingo-oophorectomy"
+          },
+          {
+            "code": "29827000",
+            "display": "Bilateral salpingectomy w/oophorectomy"
+          },
+          {
+            "code": "78698008",
+            "display": "Unilateral salpingo-oophorectomy"
+          },
+          {
+            "code": "446526009",
+            "display": "Debulking of neoplasm of ovary"
+          },
+          {
+            "code": "55853002",
+            "display": "Pelvic exenteraion, female"
+          },
+          {
+            "code": "64887002",
+            "display": "Operation on ovary [NOS]"
+          },
+          {
+            "code": "414158004",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "287847009",
+            "display": "Partial pancreatectomy"
+          },
+          {
+            "code": "69036001",
+            "display": "Total pancreaticoduodenectomy"
+          },
+          {
+            "code": "9524002",
+            "display": "Total pancreatectomy"
+          },
+          {
+            "code": "265459006",
+            "display": "Total pancreaticodudoenectomy with distal gastrectomy"
+          },
+          {
+            "code": "33149006",
+            "display": "Pancreatectomy"
+          },
+          {
+            "code": "29630005",
+            "display": "Operation on pancreas [NOS]"
+          },
+          {
+            "code": "10522005",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "37804007",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "81870009",
+            "display": "Parotidectomy"
+          },
+          {
+            "code": "11150009",
+            "display": "Partial parotidectomy"
+          },
+          {
+            "code": "13358001",
+            "display": "Total parotidectomy"
+          },
+          {
+            "code": "173486005",
+            "display": "Radical parotidectomy"
+          },
+          {
+            "code": "58456002",
+            "display": "Operation on parotid gland [NOS]"
+          },
+          {
+            "code": "107923001",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "3786007",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "51265002",
+            "display": "Pharyngectomy"
+          },
+          {
+            "code": "232546000",
+            "display": "Total pharyngolaryngectomy w/ laryngectomy"
+          },
+          {
+            "code": "303621003",
+            "display": "Total pharyngectomy"
+          },
+          {
+            "code": "23136006",
+            "display": "Operation on pharynx [NOS]"
+          },
+          {
+            "code": "450514003",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "90199006",
+            "display": "Transurethral prostactomy"
+          },
+          {
+            "code": "30426000",
+            "display": "Subtotal prostactomy"
+          },
+          {
+            "code": "26294005",
+            "display": "Radical prostatectomy"
+          },
+          {
+            "code": "65111004",
+            "display": "Pelvic exenteration"
+          },
+          {
+            "code": "90470006",
+            "display": "Prostactomy"
+          },
+          {
+            "code": "741007",
+            "display": "Operation on prostate [NOS]"
+          },
+          {
+            "code": "177975003",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "87279008",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "43075005",
+            "display": "Segmental colectomy"
+          },
+          {
+            "code": "307656000",
+            "display": "Subtotal colectomy with ileosigmoid anastomosis"
+          },
+          {
+            "code": "26390003",
+            "display": "Total  colectomy"
+          },
+          {
+            "code": "174059005",
+            "display": "Proctocolectomy"
+          },
+          {
+            "code": "82874003",
+            "display": "Operation on colon [NOS]"
+          },
+          {
+            "code": "52838002",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "79764004",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "82035006",
+            "display": "Resection of polyp"
+          },
+          {
+            "code": "116237003",
+            "display": "Excision of lesion of rectum"
+          },
+          {
+            "code": "307009004",
+            "display": "Wedge resection"
+          },
+          {
+            "code": "86789002",
+            "display": "Abdominoperineal pull through"
+          },
+          {
+            "code": "235364003",
+            "display": "Total Proctectomy"
+          },
+          {
+            "code": "26390003",
+            "display": "Total  colectomy"
+          },
+          {
+            "code": "174059005",
+            "display": "Proctocolectomy"
+          },
+          {
+            "code": "118841000",
+            "display": "Operation on rectosigmoid [NOS]"
+          },
+          {
+            "code": "52838002",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "79764004",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "82035006",
+            "display": "Resection of polyp"
+          },
+          {
+            "code": "116237003",
+            "display": "Excision of lesion of rectum"
+          },
+          {
+            "code": "307009004",
+            "display": "Wedge resection"
+          },
+          {
+            "code": "86789002",
+            "display": "Abdominoperineal pull through"
+          },
+          {
+            "code": "235364003",
+            "display": "Total Proctectomy"
+          },
+          {
+            "code": "174059005",
+            "display": "Proctocolectomy"
+          },
+          {
+            "code": "74971002",
+            "display": "Operation on rectum [NOS]"
+          },
+          {
+            "code": "87031008",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "67373001",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "35646002",
+            "display": "Excision of lesion of skin"
+          },
+          {
+            "code": "177302005",
+            "display": "Wide excision of skin lesion"
+          },
+          {
+            "code": "81723002",
+            "display": "Amputaion"
+          },
+          {
+            "code": "392011001",
+            "display": "Operation on skin [NOS]"
+          },
+          {
+            "code": "31468007",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "67097003",
+            "display": "Partial splenectomy"
+          },
+          {
+            "code": "174776001",
+            "display": "Total splenectomy"
+          },
+          {
+            "code": "234319005",
+            "display": "Splenectomy"
+          },
+          {
+            "code": "59300005",
+            "display": "Operation on spleen [NOS]"
+          },
+          {
+            "code": "45189000",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "32327002",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "49209004",
+            "display": "Subtotal gastrectomy"
+          },
+          {
+            "code": "26452005",
+            "display": "Total gastrectomy"
+          },
+          {
+            "code": "24431004",
+            "display": "Esophagoduodenostomy w/complete gastrectomy"
+          },
+          {
+            "code": "287816003",
+            "display": "Radical gastrectomy"
+          },
+          {
+            "code": "438338008",
+            "display": "Total gastrecomy w/extended lymphadencectomy"
+          },
+          {
+            "code": "53442002",
+            "display": "Gastrectomy"
+          },
+          {
+            "code": "16453004",
+            "display": "Operation on stomach [NOS]"
+          },
+          {
+            "code": "12807004",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "176430002",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "120001005",
+            "display": "Testis excision"
+          },
+          {
+            "code": "396692006",
+            "display": "Radical Orchiectomy"
+          },
+          {
+            "code": "236334001",
+            "display": "Total Orchiectomy"
+          },
+          {
+            "code": "71657006",
+            "display": "Operation on testis [NOS]"
+          },
+          {
+            "code": "20470003",
+            "display": "Destruction of lesion"
+          },
+          {
+            "code": "171988007",
+            "display": "Excision of lesion"
+          },
+          {
+            "code": "13619001",
+            "display": "Thyroidectomy"
+          },
+          {
+            "code": "24443003",
+            "display": "Total thyroidectomy"
+          },
+          {
+            "code": "30956003",
+            "display": "Subtotal thyroidectomy"
+          },
+          {
+            "code": "15463004",
+            "display": "Operation on thyroid gland [NOS]"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const {
   FHIRObservationExtractor,
   FHIRPatientExtractor,
   FHIRProcedureExtractor,
+  MCODESurgicalProcedureExtractor,
 } = require('./extractors');
 const { BaseFHIRModule, CSVModule } = require('./modules');
 const { getEthnicityDisplay,
@@ -90,6 +91,7 @@ module.exports = {
   FHIRObservationExtractor,
   FHIRPatientExtractor,
   FHIRProcedureExtractor,
+  MCODESurgicalProcedureExtractor,
   logger,
   MCODEClient,
   // FHIR and resource helpers

--- a/test/extractors/MCODESurgicalProcedureExtractor.test.js
+++ b/test/extractors/MCODESurgicalProcedureExtractor.test.js
@@ -13,7 +13,7 @@ const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
 const extractor = new MCODESurgicalProcedureExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
 const { fhirProcedureExtractor } = extractor;
 
-// Spy on fhirProcedureExtractor
+// Spy on fhirProcedureExtractor.get
 const fhirProcedureExtractorSpy = jest.spyOn(fhirProcedureExtractor, 'get');
 
 describe('MCODESurgicalProcedureExtractor', () => {

--- a/test/extractors/MCODESurgicalProcedureExtractor.test.js
+++ b/test/extractors/MCODESurgicalProcedureExtractor.test.js
@@ -157,6 +157,10 @@ describe('MCODESurgicalProcedureExtractor', () => {
       const resultingProcedures = getMCODESurgicalProcedures(fhirProcedures);
       expect(resultingProcedures).toHaveLength(0);
     });
+    test('should return an empty list when provided an empty list of procedures', () => {
+      const resultingProcedures = getMCODESurgicalProcedures([]);
+      expect(resultingProcedures).toHaveLength(0);
+    });
   });
 
   describe('get', () => {

--- a/test/extractors/MCODESurgicalProcedureExtractor.test.js
+++ b/test/extractors/MCODESurgicalProcedureExtractor.test.js
@@ -1,0 +1,177 @@
+const { when } = require('jest-when');
+const rewire = require('rewire');
+const { MCODESurgicalProcedureExtractor } = require('../../src/extractors/MCODESurgicalProcedureExtractor.js');
+const exampleProcedureBundle = require('./fixtures/surgical-procedure-bundle.json');
+
+const surgicalProcedureExtractorRewired = rewire('../../src/extractors/MCODESurgicalProcedureExtractor.js');
+const getMCODESurgicalProcedures = surgicalProcedureExtractorRewired.__get__('getMCODESurgicalProcedures');
+
+const MOCK_URL = 'http://example.com';
+const MOCK_HEADERS = {};
+const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
+
+const extractor = new MCODESurgicalProcedureExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
+const { fhirProcedureExtractor } = extractor;
+
+// Spy on fhirProcedureExtractor
+const fhirProcedureExtractorSpy = jest.spyOn(fhirProcedureExtractor, 'get');
+
+describe('MCODESurgicalProcedureExtractor', () => {
+  describe('getFHIRProcedures', () => {
+    it('should return procedure entries for patient from context', async () => {
+      const contextPatient = {
+        resourceType: 'Patient',
+        id: 'context-patient-id',
+      };
+      const contextProcedure1 = {
+        resourceType: 'Procedure',
+        id: 'context-procedure-1-id',
+      };
+      const contextProcedure2 = {
+        resourceType: 'Procedure',
+        id: 'context-procedure-2-id',
+      };
+      const context = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [
+          {
+            fullUrl: 'context-patient-url',
+            resource: contextPatient,
+          },
+          {
+            fullUrl: 'context-procedure-1-url',
+            resource: contextProcedure1,
+          },
+          {
+            fullUrl: 'context-procedure-2-url',
+            resource: contextProcedure2,
+          },
+        ],
+      };
+      const procedures = await extractor.getFHIRProcedures(MOCK_PATIENT_MRN, context);
+      expect(fhirProcedureExtractorSpy).not.toHaveBeenCalled();
+      expect(procedures).toHaveLength(2);
+      expect(procedures[0].resource.id).toEqual(contextProcedure1.id);
+      expect(procedures[1].resource.id).toEqual(contextProcedure2.id);
+    });
+
+    it('should return procedure entries for patient from FHIR search if no context', async () => {
+      fhirProcedureExtractorSpy.mockClear();
+      when(fhirProcedureExtractorSpy).calledWith({ mrn: MOCK_PATIENT_MRN, context: {} }).mockReturnValue(exampleProcedureBundle);
+      const procedures = await extractor.getFHIRProcedures(MOCK_PATIENT_MRN, {});
+      expect(fhirProcedureExtractorSpy).toHaveBeenCalled();
+      expect(procedures).toEqual(exampleProcedureBundle.entry);
+    });
+
+    it('should return no procedures if search is empty', async () => {
+      const emptyCollectionBundle = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: [],
+      };
+      fhirProcedureExtractorSpy.mockClear();
+      when(fhirProcedureExtractorSpy).calledWith({ mrn: MOCK_PATIENT_MRN, context: {} }).mockReturnValue(emptyCollectionBundle);
+      const procedures = await extractor.getFHIRProcedures(MOCK_PATIENT_MRN, {});
+      expect(fhirProcedureExtractorSpy).toHaveBeenCalled();
+      expect(procedures).toEqual([]);
+    });
+  });
+
+  describe('getMCODESurgicalProcedures', () => {
+    const otherProcedureCoding = {
+      system: 'http://snomed.info/sct',
+      code: '152198000',
+      display: 'Brachytherapy (procedure)',
+    };
+    const surgicalProcedureCoding = {
+      system: 'http://snomed.info/sct',
+      code: '173170008',
+    };
+    let fhirProcedures;
+    beforeEach(() => {
+      fhirProcedures = [
+        {
+          fullUrl: 'urn:uuid:abc-123',
+          resource: {
+            resourceType: 'Procedure',
+            id: 'abc-123',
+            code: {
+              coding: [otherProcedureCoding],
+            },
+          },
+        },
+      ];
+    });
+    test('should return procedure that has single code in surgical procedure VS', () => {
+      const surgicalProcedure = {
+        fullUrl: 'urn:uuid:xyz-987',
+        resource: {
+          resourceType: 'Procedure',
+          id: 'xyz-987',
+          code: {
+            coding: [surgicalProcedureCoding],
+          },
+        },
+      };
+      fhirProcedures.push(surgicalProcedure);
+      const resultingProcedures = getMCODESurgicalProcedures(fhirProcedures);
+      expect(resultingProcedures).toHaveLength(1);
+      expect(resultingProcedures).toContain(surgicalProcedure);
+    });
+
+    test('should return procedure that has any code in surgical procedure VS', () => {
+      const surgicalProcedure = {
+        fullUrl: 'urn:uuid:xyz-987',
+        resource: {
+          resourceType: 'Procedure',
+          id: 'xyz-987',
+          code: {
+            coding: [otherProcedureCoding, surgicalProcedureCoding],
+          },
+        },
+      };
+      fhirProcedures.push(surgicalProcedure);
+      const resultingProcedures = getMCODESurgicalProcedures(fhirProcedures);
+      expect(resultingProcedures).toHaveLength(1);
+      expect(resultingProcedures).toContain(surgicalProcedure);
+    });
+
+    test('should not return procedure that has no code in surgical procedure VS', () => {
+      const resultingProcedures = getMCODESurgicalProcedures(fhirProcedures);
+      expect(resultingProcedures).toHaveLength(0);
+    });
+
+    test('should not return procedure that has no codes', () => {
+      const emptyProcedure = {
+        fullUrl: 'urn:uuid:xyz-987',
+        resource: {
+          resourceType: 'Procedure',
+          id: 'xyz-987',
+          code: {
+            coding: [],
+          },
+        },
+      };
+      fhirProcedures.push(emptyProcedure);
+      const resultingProcedures = getMCODESurgicalProcedures(fhirProcedures);
+      expect(resultingProcedures).toHaveLength(0);
+    });
+  });
+
+  describe('get', () => {
+    test('should return a bundle with only procedures that are MCODE cancer related surgical procedures', async () => {
+      const context = {
+        resourceType: 'Bundle',
+        type: 'collection',
+        entry: exampleProcedureBundle.entry,
+      };
+      const data = await extractor.get({ mrn: MOCK_PATIENT_MRN, context });
+      expect(data.resourceType).toEqual('Bundle');
+      expect(data.type).toEqual('collection');
+      expect(data.entry).toBeDefined();
+      expect(data.entry).toHaveLength(1);
+      expect(data.entry[0].resource.code.coding[0].code).toEqual('173170008'); // Bilobectomy of lung - is in MCODE Cancer Related Surgical Procedure VS
+    });
+  });
+});

--- a/test/extractors/fixtures/surgical-procedure-bundle.json
+++ b/test/extractors/fixtures/surgical-procedure-bundle.json
@@ -1,0 +1,141 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:procedure-1",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "procedure-1",
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "152198000",
+              "display": "Brachytherapy (procedure)"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:mrn-1"
+        },
+        "performedDateTime": "2020-01-01",
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "example-system",
+                "code": "example-code",
+                "display": "example-name"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "urn:uuid:condition-id"
+          }
+        ],
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "example-treatment-intent"
+                }
+              ]
+            }
+          }
+        ],
+        "bodySite": [
+          {
+            "extension": [
+              {
+                "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-laterality",
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://snomed.info/sct",
+                      "code": "example-laterality"
+                    }
+                  ]
+                }
+              }
+            ],
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "example-site"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "fullUrl": "urn:uuid:procedure-2",
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "procedure-2",
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent",
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "373808002"
+                }
+              ]
+            }
+          }
+        ],
+        "status": "completed",
+        "code": {
+          "coding": [
+            {
+              "system": "http://snomed.info/sct",
+              "code": "173170008"
+            }
+          ]
+        },
+        "subject": {
+          "reference": "urn:uuid:mrn-1"
+        },
+        "performedDateTime": "2020-01-01",
+        "asserter": {
+          "reference": "Practitioner/mCODEPractitionerExample01"
+        },
+        "bodySite": [
+          {
+            "coding": [
+              {
+                "system": "http://snomed.info/sct",
+                "code": "41224006"
+              }
+            ]
+          }
+        ],
+        "reasonCode": [
+          {
+            "coding": [
+              {
+                "system": "example-system",
+                "code": "example-code",
+                "display": "example-name"
+              }
+            ]
+          }
+        ],
+        "reasonReference": [
+          {
+            "reference": "urn:uuid:condition-id"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
This PR adds a new extractor for mCODE Cancer Related Surgical Procedures.

## New behavior
The approach I took for this extractor is similar to the Epic Conditions extractor. It will get all Procedure resources using the regular FHIR Procedure extractor and then will filter that list to only include ones that have a code in the mCODE VS for Cancer Related Surgical Procedures.

## Code changes
Adds the new extractor and adds tests for the new extractor.

# Testing guidance
Since this extractor uses the FHIR services to get procedures, you'll need to test it using the epic-MEF repo. There is a PR there to help set up your config and instructions to test it out.

Note: we have another task for extracting radiation procedures. If we continue working on that task next week while I'm out, I'm fine if this PR gets closed or changed in any way. There might be overlap where it makes sense to combine the two or the radiation procedure might take another approach that will change this approach. I'm happy to make changes when I'm back or anyone can change this PR.
