### PR TITLE
Removes commented out blocks of code

### DIFF
--- a/src/extractors/MCODERadiationProcedureExtractor.js
+++ b/src/extractors/MCODERadiationProcedureExtractor.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { Extractor } = require('./Extractor');
 const { FHIRProcedureExtractor } = require('./FHIRProcedureExtractor');
-// const { getBundleEntriesByResourceType } = require('../helpers/fhirUtils');
 const { checkCodeInVs } = require('../helpers/valueSetUtils');
 const logger = require('../helpers/logger');
 
@@ -24,13 +23,6 @@ class MCODERadiationProcedureExtractor extends Extractor {
   }
 
   async getFHIRProcedures(mrn, context) {
-    // NOTE: This is commented out while we discuss the future of Context moving forward
-    // const proceduresInContext = getBundleEntriesByResourceType(context, 'Procedure', {});
-    // if (proceduresInContext.length !== 0) {
-    //   logger.debug('Procedure resources found in context.');
-    //   return proceduresInContext;
-    // }
-
     logger.debug('Getting procedures available for patient');
     const procedureBundle = await this.fhirProcedureExtractor.get({ mrn, context });
 

--- a/src/extractors/MCODESurgicalProcedureExtractor.js
+++ b/src/extractors/MCODESurgicalProcedureExtractor.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const { Extractor } = require('./Extractor');
 const { FHIRProcedureExtractor } = require('./FHIRProcedureExtractor');
-// const { getBundleEntriesByResourceType } = require('../helpers/fhirUtils');
 const { checkCodeInVs } = require('../helpers/valueSetUtils');
 const logger = require('../helpers/logger');
 
@@ -24,13 +23,6 @@ class MCODESurgicalProcedureExtractor extends Extractor {
   }
 
   async getFHIRProcedures(mrn, context) {
-    // NOTE: This is commented out while we discuss the future of Context moving forward
-    // const proceduresInContext = getBundleEntriesByResourceType(context, 'Procedure', {});
-    // if (proceduresInContext.length !== 0) {
-    //   logger.debug('Procedure resources found in context.');
-    //   return proceduresInContext;
-    // }
-
     logger.debug('Getting procedures available for patient');
     const procedureBundle = await this.fhirProcedureExtractor.get({ mrn, context });
 


### PR DESCRIPTION
Removes a number of commented out blocks of code that leveraged the previous context strategy. Until we decide how Context ought to be used, I'm removing that commented out code. 