### PR TITLE
Improve error message on unsuccessful extractor initialization 

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -30,7 +30,12 @@ class BaseClient {
       const { label, type, constructorArgs } = curExtractorConfig;
       logger.debug(`Initializing ${label} extractor with type ${type}`);
       const ExtractorClass = this.extractorClasses[type];
-      this.extractors.push(new ExtractorClass({ ...commonExtractorArgs, ...constructorArgs }));
+      try {
+        const newExtractor = new ExtractorClass({ ...commonExtractorArgs, ...constructorArgs });
+        this.extractors.push(newExtractor);
+      } catch (e) {
+        throw new Error(`Unable to initialize ${label} extractor with type ${type}`);
+      }
     });
   }
 


### PR DESCRIPTION
Added try catch block for better error management in the case of extractor initialization. 

Test that the error is helpful by 1) changing the type of an extractor in your config file to be nonsense, and 2) reviewing the error message for quality. 

Also test that normal extraction works as expected. 

**_only needs one reviewer_**