### PR TITLE
Update careplan to create multiple extensions

### DIFF
--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const _ = require('lodash');
 const { Extractor } = require('./Extractor');
 const { CSVModule } = require('../modules');
 const { formatDate, formatDateTime } = require('../helpers/dateUtils');
@@ -8,23 +9,36 @@ const logger = require('../helpers/logger');
 
 // Formats data to be passed into template-friendly format
 function formatData(tpcData) {
-  logger.debug('Reformatting disease status data from CSV into template format');
-  return tpcData.map((data) => {
-    const { mrn, dateOfCarePlan, changed, reasonCode } = data;
-    if (!mrn || !dateOfCarePlan || !changed) {
+  logger.debug('Reformatting treatment plan change data from CSV into template format');
+
+  // If there are multiple entries, combine them into one object with multiple reviews
+  const combinedData = _.reduce(tpcData, (res, n) => {
+    if (!n.mrn || !n.dateOfCarePlan || !n.changed) {
       throw new Error('Treatment Plan Change Data missing an expected property: mrn, dateOfCarePlan, changed are required');
     }
 
     // reasonCode is required if changed flag is true
-    if (changed === 'true' && !reasonCode) {
+    if (n.changed === 'true' && !n.reasonCode) {
       throw new Error('reasonCode is required when changed flag is true');
     }
+
+    if (!res.mrn) res.mrn = n.mrn;
+    (res.reviews || (res.reviews = [])).push({
+      dateOfCarePlan: n.dateOfCarePlan,
+      reasonCode: n.reasonCode,
+      changed: n.changed,
+    });
+    return res;
+  }, {});
+
+  // Format each entry in the reviews array
+  combinedData.reviews = combinedData.reviews.map((reviews) => {
+    const { dateOfCarePlan, changed, reasonCode } = reviews;
 
     const formattedData = {
       effectiveDate: formatDate(dateOfCarePlan),
       effectiveDateTime: formatDateTime(dateOfCarePlan),
       hasChanged: changed,
-      mrn,
     };
 
     // Add reasonCode to formattedData if available
@@ -34,6 +48,9 @@ function formatData(tpcData) {
 
     return formattedData;
   });
+
+  // Array will contain one element to generate one FHIR resource with multiple extensions for reviews
+  return [combinedData];
 }
 
 class CSVTreatmentPlanChangeExtractor extends Extractor {

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -68,13 +68,12 @@ describe('CSVTreatmentPlanChangeExtractor', () => {
           reviews: [
             {
               effectiveDate: '2020-04-15',
-              effectiveDateTime: '2020-04-15',
               hasChanged: 'true',
               reasonCode: '281647001',
+              reasonDisplayText: 'Adverse reaction (disorder)',
             },
             {
               effectiveDate: '2020-04-30',
-              effectiveDateTime: '2020-04-30',
               reasonCode: '405613005',
               hasChanged: 'true',
             },

--- a/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
+++ b/test/extractors/CSVTreatmentPlanChangeExtractor.test.js
@@ -26,6 +26,12 @@ describe('CSVTreatmentPlanChangeExtractor', () => {
         changed: 'false',
         mrn: 'id',
       },
+      {
+        dateOfCarePlan: '2020-04-30',
+        changed: 'true',
+        reasonCode: 'example code',
+        mrn: 'id',
+      },
     ];
 
     test('should join data appropriately and throw errors when missing required properties', () => {
@@ -53,6 +59,30 @@ describe('CSVTreatmentPlanChangeExtractor', () => {
       // No error should be throw when reasonCode is provided
       exampleData[0].reasonCode = 'example code';
       expect(() => formatData(exampleData)).not.toThrowError();
+    });
+
+    test('should join multiple entries into one', () => {
+      const expectedFormattedData = [
+        {
+          mrn: 'mrn-1',
+          reviews: [
+            {
+              effectiveDate: '2020-04-15',
+              effectiveDateTime: '2020-04-15',
+              hasChanged: 'true',
+              reasonCode: '281647001',
+            },
+            {
+              effectiveDate: '2020-04-30',
+              effectiveDateTime: '2020-04-30',
+              reasonCode: '405613005',
+              hasChanged: 'true',
+            },
+          ],
+        },
+      ];
+
+      expect(formatData(exampleCSVTPCModuleResponse)).toEqual(expectedFormattedData);
     });
   });
 

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:a66c9b6d0c06506e28dcaac8fc2ef9126b1039507761c79c6e04f606b5c7b054",
+      "fullUrl": "urn:uuid:3005b559bb913fdfb23756a442645c6c37bbdafa42ad4be0bd1a6b698274f466",
       "resource": {
         "resourceType": "CarePlan",
-        "id": "a66c9b6d0c06506e28dcaac8fc2ef9126b1039507761c79c6e04f606b5c7b054",
+        "id": "3005b559bb913fdfb23756a442645c6c37bbdafa42ad4be0bd1a6b698274f466",
         "meta": {
           "profile": [
             "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-with-review"
@@ -24,8 +24,9 @@
                 "url": "CarePlanChangeReason",
                 "valueCodeableConcept": {
                   "coding": [
-                    { "system": "http://snomed.info/sct", "code": "281647001" }
-                  ]
+                    { "system": "http://snomed.info/sct", "code": "281647001", "display": "Adverse reaction (disorder)" }
+                  ],
+                  "text": "Adverse reaction (disorder)"
                 }
               },
               { "url": "ReviewDate", "valueDate": "2020-04-15" },

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:4d2afb8f74b6950922b0ae5979edbcaf59cecf959ddf80cce63940b45597a29c",
+      "fullUrl": "urn:uuid:a66c9b6d0c06506e28dcaac8fc2ef9126b1039507761c79c6e04f606b5c7b054",
       "resource": {
         "resourceType": "CarePlan",
-        "id": "4d2afb8f74b6950922b0ae5979edbcaf59cecf959ddf80cce63940b45597a29c",
+        "id": "a66c9b6d0c06506e28dcaac8fc2ef9126b1039507761c79c6e04f606b5c7b054",
         "meta": {
           "profile": [
             "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-with-review"
@@ -31,12 +31,26 @@
               { "url": "ReviewDate", "valueDate": "2020-04-15" },
               { "url": "ChangedFlag", "valueBoolean": true }
             ]
+          },
+          {
+            "url": "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review",
+            "extension": [
+              {
+                "url": "CarePlanChangeReason",
+                "valueCodeableConcept": {
+                  "coding": [
+                    { "system": "http://snomed.info/sct", "code": "405613005" }
+                  ]
+                }
+              },
+              { "url": "ReviewDate", "valueDate": "2020-04-30" },
+              { "url": "ChangedFlag", "valueBoolean": true }
+            ]
           }
         ],
         "subject": { "reference": "urn:uuid:mrn-1" },
         "status": "draft",
         "intent": "proposal",
-        "created": "2020-04-15",
         "category": [
           {
             "coding": [

--- a/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
@@ -4,5 +4,11 @@
     "dateOfCarePlan": "2020-04-15",
     "reasonCode": "281647001",
     "changed": "true"
+  },
+  {
+    "mrn": "mrn-1",
+    "dateOfCarePlan": "2020-04-30",
+    "reasonCode": "405613005",
+    "changed": "true"
   }
 ]

--- a/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-module-response.json
@@ -3,6 +3,7 @@
     "mrn": "mrn-1",
     "dateOfCarePlan": "2020-04-15",
     "reasonCode": "281647001",
+    "reasonDisplayText": "Adverse reaction (disorder)",
     "changed": "true"
   },
   {

--- a/test/templates/carePlanWithReview.test.js
+++ b/test/templates/carePlanWithReview.test.js
@@ -8,13 +8,16 @@ describe('JavaScript render CarePlan template', () => {
   test('minimal required data passed into template should generate FHIR resource', () => {
     const CARE_PLAN_VALID_DATA = {
       id: 'test-id',
-      effectiveDateTime: '2020-01-23T09:07:00Z',
-      effectiveDate: '2020-01-23',
-      hasChanged: 'false',
       mrn: 'abc-def',
-      reasonCode: null,
-      reasonDisplayText: null,
       name: null,
+      reviews: [
+        {
+          effectiveDate: '2020-01-23',
+          hasChanged: 'false',
+          reasonCode: null,
+          reasonDisplayText: null,
+        },
+      ],
     };
 
     const generatedCarePlan = carePlanWithReviewTemplate(CARE_PLAN_VALID_DATA);
@@ -25,13 +28,22 @@ describe('JavaScript render CarePlan template', () => {
   test('maximal data passed into template should generate FHIR resource', () => {
     const MAX_CARE_PLAN_DATA = {
       id: 'test-id',
-      effectiveDateTime: '2020-01-23T09:07:00Z',
-      effectiveDate: '2020-01-23',
-      hasChanged: 'true',
-      reasonCode: '281647001',
-      reasonDisplayText: 'Adverse reaction (disorder)',
       mrn: 'abc-def',
       name: 'Sample Text',
+      reviews: [
+        {
+          effectiveDate: '2020-01-23',
+          hasChanged: 'true',
+          reasonCode: '281647001',
+          reasonDisplayText: 'Adverse reaction (disorder)',
+        },
+        {
+          effectiveDate: '2020-01-30',
+          hasChanged: 'true',
+          reasonCode: '405613005',
+          reasonDisplayText: 'Planned Procedure (situation)',
+        },
+      ],
     };
 
     const generatedCarePlan = carePlanWithReviewTemplate(MAX_CARE_PLAN_DATA);
@@ -39,34 +51,63 @@ describe('JavaScript render CarePlan template', () => {
     expect(isValidFHIR(generatedCarePlan)).toBeTruthy();
   });
 
-  test('missing non-required data should not throw an error', () => {
+  test('missing non-required data at care plan object level should not throw an error', () => {
     const NECESSARY_DATA = {
       id: 'test-id',
-      effectiveDateTime: '2020-01-23T09:07:00Z',
-      effectiveDate: '2020-01-23',
-      hasChanged: 'false',
       mrn: 'abc-def',
+      reviews: [],
     };
 
     const OPTIONAL_DATA = {
-      reasonCode: '281647001',
-      reasonDisplayText: 'Adverse reaction (disorder)',
       name: 'Sample Text',
     };
 
     allOptionalKeyCombinationsNotThrow(OPTIONAL_DATA, carePlanWithReviewTemplate, NECESSARY_DATA);
   });
 
+  test('missing non-required data at review object level should not throw an error', () => {
+    const NECESSARY_DATA = {
+      id: 'test-id',
+      mrn: 'abc-def',
+      reviews: [
+        {
+          effectiveDate: '2020-01-23',
+          hasChanged: 'false',
+        },
+      ],
+    };
+
+    const OPTIONAL_DATA = ['reasonCode', 'reasonDisplayText'];
+
+    // Test presence of each optional key individually
+    OPTIONAL_DATA.forEach((key) => {
+      const r = NECESSARY_DATA.reviews[0];
+      r[key] = 'sample value';
+
+      expect(() => carePlanWithReviewTemplate(NECESSARY_DATA)).not.toThrow();
+
+      delete r[key];
+    });
+  });
+
   test('missing required data should throw a reference error', () => {
     const INVALID_DATA = {
-      // Omitting 'hasChanged' field which is a required property
+      // omitting 'mrn' field which is a required property
       id: 'test-id',
-      effectiveDateTime: '2020-01-23T09:07:00Z',
-      effectiveDate: '2020-01-23',
+      reviews: [],
+    };
+
+    const INVALID_REVIEW_DATA = {
+      // Omitting 'hasChanged' field on the review which is a required property
+      id: 'test-id',
       mrn: 'abc-def',
-      haschanged: null,
+      reviews: [{
+        effectiveDate: '2020-01-23',
+        haschanged: null,
+      }],
     };
 
     expect(() => carePlanWithReviewTemplate(INVALID_DATA)).toThrow(Error);
+    expect(() => carePlanWithReviewTemplate(INVALID_REVIEW_DATA)).toThrow(Error);
   });
 });

--- a/test/templates/fixtures/maximal-careplan-resource.json
+++ b/test/templates/fixtures/maximal-careplan-resource.json
@@ -36,6 +36,32 @@
           "valueBoolean": true
         }
       ]
+    },
+    {
+      "url": "http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review",
+      "extension": [
+        {
+          "url": "CarePlanChangeReason",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "code": "405613005",
+                "system": "http://snomed.info/sct",
+                "display": "Planned Procedure (situation)"
+              }
+            ],
+            "text": "Planned Procedure (situation)"
+          }
+        },
+        {
+          "url": "ReviewDate",
+          "valueDate": "2020-01-30"
+        },
+        {
+          "url": "ChangedFlag",
+          "valueBoolean": true
+        }
+      ]
     }
   ],
   "subject": {
@@ -44,7 +70,6 @@
   },
   "status": "draft",
   "intent": "proposal",
-  "created": "2020-01-23T09:07:00Z",
   "category": [
     {
       "coding": [ { "code": "assess-plan", "system": "http://argonaut.hl7.org"}]

--- a/test/templates/fixtures/minimal-careplan-resource.json
+++ b/test/templates/fixtures/minimal-careplan-resource.json
@@ -30,7 +30,6 @@
   },
   "status": "draft",
   "intent": "proposal",
-  "created": "2020-01-23T09:07:00Z",
   "category": [
     {
       "coding": [ { "code": "assess-plan", "system": "http://argonaut.hl7.org"}]


### PR DESCRIPTION
# Summary

He's back baby.

Updates Care plan extractor/template to create multiple extension entries rather than multiple CarePlan resources when provided >1 entry to the extractor.

## New behavior

Multiple CarePlan data entries now appear as multiple `http://mcodeinitiative.org/codex/us/icare/StructureDefinition/icare-care-plan-review` extensions in the outputted CarePlan resource

## Code changes

* Update joinAndReformat function to produce a new type of data (each "review" maps to a new extension)
``` Javascript
        {
          mrn: 'mrn-1',
          reviews: [
            {
              effectiveDate: '2020-04-15',
              hasChanged: 'true',
              reasonCode: '281647001',
            },
            ...
          ],
        }
```
* Update tests/fixtures accordingly
* Removed the usage of the `created` property for now as it is not required and we want to avoid inferring its value based on the multiple dates that could now be present for 1 CarePlan resource

# Testing guidance

Run CLI and tests and inspect the output. The unit tests cover multiple extensions, but to see this in action, you can add a row to `test/sample-client-data/treatment-plan-change-information.csv` for one of the patients:

e.g.

``` csv
mrn,reasonCode,changed,dateOfCarePlan,dateRecorded
123,281647001,true,2020-04-15,2020-04-15
123,281647001,true,2020-04-30,2020-04-30
456,405613005,true,2020-03-30,2020-04-15
789,266721009,true,2020-04-22,2020-06-17
```

For patient 123, this will now have 1 CarePlan resource with 2 extensions rather than 2 resources in the output bundle.
