### PR TITLE
resourceType parameter added to reference snippet

### DIFF
--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -12,14 +12,14 @@ function evidenceTemplate({ evidence }) {
 function focusTemplate({ condition }) {
   return {
     focus: [
-      reference(condition),
+      reference({ ...condition, resourceType: 'Condition' }),
     ],
   };
 }
 
 function subjectTemplate({ subject }) {
   return {
-    subject: reference(subject),
+    subject: reference({ ...subject, resourceType: 'Patient' }),
   };
 }
 

--- a/src/templates/CancerRelatedMedicationTemplate.js
+++ b/src/templates/CancerRelatedMedicationTemplate.js
@@ -25,7 +25,7 @@ function medicationTemplate({ code, codeSystem, displayText }) {
 
 function subjectTemplate({ id }) {
   return {
-    subject: reference({ id }),
+    subject: reference({ id, resourceType: 'Patient' }),
   };
 }
 

--- a/src/templates/CarePlanWithReviewTemplate.js
+++ b/src/templates/CarePlanWithReviewTemplate.js
@@ -60,7 +60,7 @@ function carePlanChangeReasonExtensionTemplate({ hasChanged, reasonCode, reasonD
 
 function subjectTemplate(subject) {
   return {
-    subject: reference(subject),
+    subject: reference({ ...subject, resourceType: 'Patient' }),
   };
 }
 

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -86,7 +86,7 @@ function bodySiteTemplate({ bodySite, laterality }) {
 
 function subjectTemplate({ subject }) {
   return {
-    subject: reference(subject),
+    subject: reference({ ...subject, resourceType: 'Patient' }),
   };
 }
 

--- a/src/templates/ObservationTemplate.js
+++ b/src/templates/ObservationTemplate.js
@@ -47,7 +47,7 @@ function codeTemplate({ code, system, display }) {
 
 function subjectTemplate({ subjectId }) {
   return {
-    subject: reference({ id: subjectId }),
+    subject: reference({ id: subjectId, resourceType: 'Patient' }),
   };
 }
 

--- a/src/templates/ProcedureTemplate.js
+++ b/src/templates/ProcedureTemplate.js
@@ -26,7 +26,7 @@ function reasonTemplate({ reasonCode, reasonCodeSystem, reasonDisplayName }) {
 function reasonReference(conditionId) {
   return {
     reasonReference: [
-      reference({ id: conditionId }),
+      reference({ id: conditionId, resourceType: 'Condition' }),
     ],
   };
 }
@@ -68,7 +68,7 @@ function procedureTemplate({
         coding({ code, system, display }),
       ],
     },
-    subject: reference({ id: subjectId }),
+    subject: reference({ id: subjectId, resourceType: 'Patient' }),
     performedDateTime: effectiveDateTime,
     ...ifSomeArgsObj(reasonTemplate)({ reasonCode, reasonCodeSystem, reasonDisplayName }),
     ...(conditionId && reasonReference(conditionId)),

--- a/src/templates/ResearchSubjectTemplate.js
+++ b/src/templates/ResearchSubjectTemplate.js
@@ -14,7 +14,7 @@ function studyTemplate(trialResearchID) {
 function individualTemplate(patientId) {
   return {
     individual: {
-      ...reference({ id: patientId }),
+      ...reference({ id: patientId, resourceType: 'Patient' }),
     },
   };
 }

--- a/src/templates/StagingTemplate.js
+++ b/src/templates/StagingTemplate.js
@@ -25,7 +25,7 @@ function hasMemberTemplate(categoryIds) {
   if (!categoryIds || categoryIds.length === 0) return {};
 
   return {
-    hasMember: categoryIds.map((id) => reference({ id })),
+    hasMember: categoryIds.map((id) => reference({ id, resourceType: 'Observation' })),
   };
 }
 
@@ -75,10 +75,10 @@ function stagingTemplate({
       ],
     },
     ...stagingMethodTemplate({ code: stagingSystem, system: stagingCodeSystem }),
-    subject: reference({ id: subjectId }),
+    subject: reference({ id: subjectId, resourceType: 'Patient' }),
     effectiveDateTime,
     ...valueX({ code: stageGroup, system: 'http://cancerstaging.org' }, 'valueCodeableConcept'),
-    focus: [reference({ id: conditionId })],
+    focus: [reference({ id: conditionId, resourceType: 'Condition' })],
     ...hasMemberTemplate(categoryIds),
   };
 }

--- a/src/templates/TNMCategoryTemplate.js
+++ b/src/templates/TNMCategoryTemplate.js
@@ -98,11 +98,11 @@ function tnmCategoryTemplate({
         }),
       ],
     },
-    subject: reference({ id: subjectId }),
+    subject: reference({ id: subjectId, resourceType: 'Patient' }),
     ...stagingMethodTemplate({ code: stagingSystem, system: stagingCodeSystem }),
     effectiveDateTime,
     ...valueX({ code: valueCode, system: 'http://cancerstaging.org' }, 'valueCodeableConcept'),
-    focus: [reference({ id: conditionId })],
+    focus: [reference({ id: conditionId, resourceType: 'Condition' })],
   };
 }
 

--- a/src/templates/snippets/reference.js
+++ b/src/templates/snippets/reference.js
@@ -1,9 +1,10 @@
-function reference({ id, name }) {
+function reference({ id, name, resourceType }) {
   if (!id) throw Error('Trying to render a reference snippet, but the id argument is missing.');
 
   return {
     reference: `urn:uuid:${id}`,
     ...(name && { display: name }),
+    ...(resourceType && { type: resourceType }),
   };
 }
 

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -35,11 +35,13 @@
         },
         "focus": [
           {
-            "reference": "urn:uuid:cond-1"
+            "reference": "urn:uuid:cond-1",
+            "type": "Condition"
           }
         ],
         "subject": {
-          "reference": "urn:uuid:pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1",
+          "type": "Patient"
         },
         "effectiveDateTime": "2019-12-02",
         "valueCodeableConcept": {

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -21,7 +21,7 @@
             "value": "example-researchId"
           }
         },
-        "individual": { "reference": "urn:uuid:EXAMPLE-MRN" }
+        "individual": { "reference": "urn:uuid:EXAMPLE-MRN", "type": "Patient" }
       }
     },
     {

--- a/test/extractors/fixtures/csv-condition-bundle.json
+++ b/test/extractors/fixtures/csv-condition-bundle.json
@@ -91,7 +91,8 @@
           }
         ],
         "subject": {
-          "reference": "urn:uuid:mrn-1"
+          "reference": "urn:uuid:mrn-1",
+          "type": "Patient"
         }
       }
     }

--- a/test/extractors/fixtures/csv-medication-bundle.json
+++ b/test/extractors/fixtures/csv-medication-bundle.json
@@ -36,7 +36,8 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:mrn-1"
+          "reference": "urn:uuid:mrn-1",
+          "type": "Patient"
         },
         "effectivePeriod": {
           "start": "YYYY-MM-DD",

--- a/test/extractors/fixtures/csv-observation-bundle.json
+++ b/test/extractors/fixtures/csv-observation-bundle.json
@@ -27,7 +27,8 @@
           ]
         },
         "subject" : {
-          "reference": "urn:uuid:example-patient"
+          "reference": "urn:uuid:example-patient",
+          "type": "Patient"
         },
         "effectiveDateTime" : "2020-01-02",
         "valueCodeableConcept": {

--- a/test/extractors/fixtures/csv-procedure-bundle.json
+++ b/test/extractors/fixtures/csv-procedure-bundle.json
@@ -17,7 +17,7 @@
             }
           ]
         },
-        "subject": { "reference": "urn:uuid:mrn-1" },
+        "subject": { "reference": "urn:uuid:mrn-1", "type": "Patient" },
         "performedDateTime": "2020-01-01",
         "reasonCode": [
           {
@@ -30,7 +30,7 @@
             ]
           }
         ],
-        "reasonReference": [{ "reference": "urn:uuid:condition-id" }],
+        "reasonReference": [{ "reference": "urn:uuid:condition-id", "type": "Condition" }],
         "extension": [
           {
             "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent",

--- a/test/extractors/fixtures/csv-staging-bundle.json
+++ b/test/extractors/fixtures/csv-staging-bundle.json
@@ -32,7 +32,8 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1",
+          "type": "Patient"
         },
         "method": {
           "coding": [
@@ -53,7 +54,8 @@
         },
         "focus": [
           {
-            "reference": "urn:uuid:cond-1"
+            "reference": "urn:uuid:cond-1",
+            "type": "Condition"
           }
         ]
       }
@@ -88,7 +90,8 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1",
+          "type": "Patient"
         },
         "method": {
           "coding": [
@@ -109,7 +112,8 @@
         },
         "focus": [
           {
-            "reference": "urn:uuid:cond-1"
+            "reference": "urn:uuid:cond-1",
+            "type": "Condition"
           }
         ]
       }
@@ -144,7 +148,8 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1",
+          "type": "Patient"
         },
         "method": {
           "coding": [
@@ -165,7 +170,8 @@
         },
         "focus": [
           {
-            "reference": "urn:uuid:cond-1"
+            "reference": "urn:uuid:cond-1",
+            "type": "Condition"
           }
         ]
       }
@@ -208,7 +214,8 @@
           ]
         },
         "subject": {
-          "reference": "urn:uuid:pat-mrn-1"
+          "reference": "urn:uuid:pat-mrn-1",
+          "type": "Patient"
         },
         "effectiveDateTime": "2020-01-01",
         "valueCodeableConcept": {
@@ -221,18 +228,22 @@
         },
         "focus": [
           {
-            "reference": "urn:uuid:cond-1"
+            "reference": "urn:uuid:cond-1",
+            "type": "Condition"
           }
         ],
         "hasMember": [
           {
-            "reference": "urn:uuid:ed5faf7f2a1cef061d7584afd463e60eb7202104700647e92fbb7c9419eb7897"
+            "reference": "urn:uuid:ed5faf7f2a1cef061d7584afd463e60eb7202104700647e92fbb7c9419eb7897",
+            "type": "Observation"
           },
           {
-            "reference": "urn:uuid:88992af10e3a822f2a946628de91012d5afae49a25d1641db09e9d6ed4ca24c3"
+            "reference": "urn:uuid:88992af10e3a822f2a946628de91012d5afae49a25d1641db09e9d6ed4ca24c3",
+            "type": "Observation"
           },
           {
-            "reference": "urn:uuid:1373d3fb234cad0b03912cfbba16bdc4eabbd6217d83b838f6d9c1343bc9b394"
+            "reference": "urn:uuid:1373d3fb234cad0b03912cfbba16bdc4eabbd6217d83b838f6d9c1343bc9b394",
+            "type": "Observation"
           }
         ]
       }

--- a/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
+++ b/test/extractors/fixtures/csv-treatment-plan-change-bundle.json
@@ -49,7 +49,7 @@
             ]
           }
         ],
-        "subject": { "reference": "urn:uuid:mrn-1" },
+        "subject": { "reference": "urn:uuid:mrn-1", "type": "Patient" },
         "status": "draft",
         "intent": "proposal",
         "category": [

--- a/test/templates/fixtures/cancer-condition-resource.json
+++ b/test/templates/fixtures/cancer-condition-resource.json
@@ -28,6 +28,7 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-subject-id"
+    "reference": "urn:uuid:example-subject-id",
+    "type": "Patient"
   }
 }

--- a/test/templates/fixtures/disease-status-resource.json
+++ b/test/templates/fixtures/disease-status-resource.json
@@ -30,12 +30,14 @@
   "focus" : [
     {
       "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
-      "display": "Walking Corpse Syndrome"
+      "display": "Walking Corpse Syndrome",
+      "type": "Condition"
     }
   ],
   "subject": {
     "reference": "urn:uuid:123-example-patient",
-    "display": "Mr. Patient Example"
+    "display": "Mr. Patient Example",
+    "type": "Patient"
   },
   "effectiveDateTime" : "1994-12-09T09:07:00Z",
   "valueCodeableConcept": {

--- a/test/templates/fixtures/maximal-careplan-resource.json
+++ b/test/templates/fixtures/maximal-careplan-resource.json
@@ -66,7 +66,8 @@
   ],
   "subject": {
     "reference": "urn:uuid:abc-def",
-    "display": "Sample Text"
+    "display": "Sample Text",
+    "type": "Patient"
   },
   "status": "draft",
   "intent": "proposal",

--- a/test/templates/fixtures/maximal-condition-resource.json
+++ b/test/templates/fixtures/maximal-condition-resource.json
@@ -77,6 +77,7 @@
     }
   ],
   "subject": {
-    "reference": "urn:uuid:example-subject-id"
+    "reference": "urn:uuid:example-subject-id",
+    "type": "Patient"
   }
 }

--- a/test/templates/fixtures/maximal-medication-resource.json
+++ b/test/templates/fixtures/maximal-medication-resource.json
@@ -30,7 +30,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:mrn-1"
+    "reference": "urn:uuid:mrn-1",
+    "type": "Patient"
   },
   "effectivePeriod": {
     "start": "2020-01-01",

--- a/test/templates/fixtures/maximal-observation-resource.json
+++ b/test/templates/fixtures/maximal-observation-resource.json
@@ -24,7 +24,8 @@
     ]
   },
   "subject" : {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime" : "2020-01-01",
   "valueQuantity": {

--- a/test/templates/fixtures/maximal-procedure-resource.json
+++ b/test/templates/fixtures/maximal-procedure-resource.json
@@ -11,7 +11,7 @@
       }
     ]
   },
-  "subject": { "reference": "urn:uuid:example-mrn" },
+  "subject": { "reference": "urn:uuid:example-mrn", "type": "Patient" },
   "performedDateTime": "2020-01-01",
   "reasonCode": [
     {
@@ -24,7 +24,7 @@
       ]
     }
   ],
-  "reasonReference": [{ "reference": "urn:uuid:example-condition-id" }],
+  "reasonReference": [{ "reference": "urn:uuid:example-condition-id", "type": "Condition" }],
   "extension": [
     {
       "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-treatment-intent",

--- a/test/templates/fixtures/maximal-reference-object.json
+++ b/test/templates/fixtures/maximal-reference-object.json
@@ -1,4 +1,5 @@
 {
   "reference": "urn:uuid:example-id",
-  "display": "example-name"
+  "display": "example-name",
+  "type": "ExampleType"
 }

--- a/test/templates/fixtures/maximal-staging-resource.json
+++ b/test/templates/fixtures/maximal-staging-resource.json
@@ -34,7 +34,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -47,18 +48,22 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ],
   "hasMember": [
     {
-      "reference": "urn:uuid:t-category-id"
+      "reference": "urn:uuid:t-category-id",
+      "type": "Observation"
     },
     {
-      "reference": "urn:uuid:n-category-id"
+      "reference": "urn:uuid:n-category-id",
+      "type": "Observation"
     },
     {
-      "reference": "urn:uuid:m-category-id"
+      "reference": "urn:uuid:m-category-id",
+      "type": "Observation"
     }
   ]
 }

--- a/test/templates/fixtures/metastases-category-clinical-resource.json
+++ b/test/templates/fixtures/metastases-category-clinical-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/metastases-category-pathologic-resource.json
+++ b/test/templates/fixtures/metastases-category-pathologic-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/minimal-careplan-resource.json
+++ b/test/templates/fixtures/minimal-careplan-resource.json
@@ -26,7 +26,8 @@
     }
   ],
   "subject": {
-    "reference": "urn:uuid:abc-def"
+    "reference": "urn:uuid:abc-def",
+    "type": "Patient"
   },
   "status": "draft",
   "intent": "proposal",

--- a/test/templates/fixtures/minimal-condition-resource.json
+++ b/test/templates/fixtures/minimal-condition-resource.json
@@ -20,6 +20,7 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-subject-id"
+    "reference": "urn:uuid:example-subject-id",
+    "type": "Patient"
   }
 }

--- a/test/templates/fixtures/minimal-disease-status-resource.json
+++ b/test/templates/fixtures/minimal-disease-status-resource.json
@@ -30,12 +30,14 @@
     "focus" : [
       {
         "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
-        "display": "Walking Corpse Syndrome"
+        "display": "Walking Corpse Syndrome",
+        "type": "Condition"
       }
     ],
     "subject": {
       "reference": "urn:uuid:123-example-patient",
-      "display": "Mr. Patient Example"
+      "display": "Mr. Patient Example",
+      "type": "Patient"
     },
     "effectiveDateTime" : "1994-12-09T09:07:00Z",
     "valueCodeableConcept": {

--- a/test/templates/fixtures/minimal-medication-resource.json
+++ b/test/templates/fixtures/minimal-medication-resource.json
@@ -15,7 +15,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:mrn-1"
+    "reference": "urn:uuid:mrn-1",
+    "type": "Patient"
   },
   "effectivePeriod": {
     "extension": [

--- a/test/templates/fixtures/minimal-observation-resource.json
+++ b/test/templates/fixtures/minimal-observation-resource.json
@@ -23,7 +23,8 @@
     ]
   },
   "subject" : {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime" : "2020-01-01",
   "valueQuantity": {

--- a/test/templates/fixtures/minimal-procedure-resource.json
+++ b/test/templates/fixtures/minimal-procedure-resource.json
@@ -5,6 +5,6 @@
   "code": {
     "coding": [{ "system": "http://snomed.info/sct", "code": "152198000" }]
   },
-  "subject": { "reference": "urn:uuid:example-mrn" },
+  "subject": { "reference": "urn:uuid:example-mrn", "type": "Patient" },
   "performedDateTime": "2020-01-01"
 }

--- a/test/templates/fixtures/minimal-staging-clinical-resource.json
+++ b/test/templates/fixtures/minimal-staging-clinical-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/minimal-staging-pathologic-resource.json
+++ b/test/templates/fixtures/minimal-staging-pathologic-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/nodes-category-clinical-resource.json
+++ b/test/templates/fixtures/nodes-category-clinical-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/nodes-category-pathologic-resource.json
+++ b/test/templates/fixtures/nodes-category-pathologic-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/tumor-category-clinical-resource.json
+++ b/test/templates/fixtures/tumor-category-clinical-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/fixtures/tumor-category-pathologic-resource.json
+++ b/test/templates/fixtures/tumor-category-pathologic-resource.json
@@ -26,7 +26,8 @@
     ]
   },
   "subject": {
-    "reference": "urn:uuid:example-mrn"
+    "reference": "urn:uuid:example-mrn",
+    "type": "Patient"
   },
   "effectiveDateTime": "2020-01-01",
   "valueCodeableConcept": {
@@ -39,7 +40,8 @@
   },
   "focus": [
     {
-      "reference": "urn:uuid:example-condition-id"
+      "reference": "urn:uuid:example-condition-id",
+      "type": "Condition"
     }
   ]
 }

--- a/test/templates/snippets/reference.test.js
+++ b/test/templates/snippets/reference.test.js
@@ -24,6 +24,7 @@ describe('Reference Snippet', () => {
     const MAXIMAL_DATA = {
       id: 'example-id',
       name: 'example-name',
+      resourceType: 'ExampleType',
     };
 
     expect(reference(MAXIMAL_DATA)).toEqual(maximalReference);


### PR DESCRIPTION
# Summary
This PR adds an optional `resourceType` parameter to the reference snippet.
## New behavior
Reference-based elements on generated FHIR jsons now include the `type` property, specifying the resourceType of the artifact being referenced.
## Code changes
1. A `resourceType` parameter has been added to the reference snippet which maps directly to the `type` property on the generated reference.
2. All templates that use the reference snippet have been updated to include the `resourceType` argument. 
3. All test fixtures with a reference-based element have been updated to include the `type` property within the reference.
4. The new `resourceType` argument has been added to the `MAXIMAL_DATA` object within `reference.test.js`.
# Testing guidance
Run the MEF and review the output, ensuring that each `reference` element has a `type` property and that the value is appropriate.   