### PR TITLE
Added context utilities to the base-MEF

### DIFF
--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -4,7 +4,7 @@ const { getBundleResourcesByType } = require('./fhirUtils');
 async function getPatientFromContext(mrn, context) {
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   if (!patientInContext) {
-    throw Error('Could not find a patient in context');
+    throw Error('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
   }
   logger.debug('Patient resource found in context.');
   return patientInContext;

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -2,6 +2,7 @@ const logger = require('./logger');
 const { getBundleResourcesByType } = require('./fhirUtils');
 
 async function getPatientFromContext(mrn, context) {
+  logger.debug('Getting patient from context');
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   if (!patientInContext) {
     throw Error('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -1,0 +1,15 @@
+const logger = require('./logger');
+const { getBundleResourcesByType } = require('./fhirUtils');
+
+async function getPatient(mrn, context) {
+  const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
+  if (!patientInContext) {
+    throw Error('Could not find a patient in context');
+  }
+  logger.debug('Patient resource found in context.');
+  return patientInContext;
+}
+
+module.exports = {
+  getPatient,
+};

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -1,7 +1,7 @@
 const logger = require('./logger');
 const { getBundleResourcesByType } = require('./fhirUtils');
 
-async function getPatient(mrn, context) {
+async function getPatientFromContext(mrn, context) {
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   if (!patientInContext) {
     throw Error('Could not find a patient in context');
@@ -11,5 +11,5 @@ async function getPatient(mrn, context) {
 }
 
 module.exports = {
-  getPatient,
+  getPatientFromContext,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ const {
 } = require('./helpers/conditionUtils');
 const { getDiseaseStatusCode, getDiseaseStatusEvidenceCode, mEpochToDate } = require('./helpers/diseaseStatusUtils');
 const { formatDate, formatDateTime } = require('./helpers/dateUtils');
-const { getPatient } = require('./helpers/contextUtils');
+const { getPatientFromContext } = require('./helpers/contextUtils');
 
 module.exports = {
   // CLI Related utilities
@@ -127,5 +127,5 @@ module.exports = {
   logOperationOutcomeInfo,
   mEpochToDate,
   // Context operations
-  getPatient,
+  getPatientFromContext,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -61,6 +61,7 @@ const {
 } = require('./helpers/conditionUtils');
 const { getDiseaseStatusCode, getDiseaseStatusEvidenceCode, mEpochToDate } = require('./helpers/diseaseStatusUtils');
 const { formatDate, formatDateTime } = require('./helpers/dateUtils');
+const { getPatient } = require('./helpers/contextUtils');
 
 module.exports = {
   // CLI Related utilities
@@ -125,4 +126,6 @@ module.exports = {
   isConditionCancer,
   logOperationOutcomeInfo,
   mEpochToDate,
+  // Context operations
+  getPatient,
 };

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -1,0 +1,28 @@
+const { getPatient } = require('../../src/helpers/contextUtils');
+
+const MOCK_PATIENT_MRN = '123';
+
+describe('getPatient', () => {
+  const patientResource = {
+    resourceType: 'Patient',
+    id: 'mCODEPatientExample01',
+  };
+  const patientContext = {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        fullUrl: 'context-url-1',
+        resource: patientResource,
+      },
+    ],
+  };
+  test('Should return Patient resource in context', async () => {
+    const patient = await getPatient(MOCK_PATIENT_MRN, patientContext);
+    expect(patient.id).toEqual(patientResource.id);
+  });
+
+  test('Should throw an error if there is no patient in context', async () => {
+    await expect(getPatient(MOCK_PATIENT_MRN, {})).rejects.toThrow('Could not find a patient in context');
+  });
+});

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -1,8 +1,8 @@
-const { getPatient } = require('../../src/helpers/contextUtils');
+const { getPatientFromContext } = require('../../src/helpers/contextUtils');
 
 const MOCK_PATIENT_MRN = '123';
 
-describe('getPatient', () => {
+describe('getPatientFromContext', () => {
   const patientResource = {
     resourceType: 'Patient',
     id: 'mCODEPatientExample01',
@@ -18,11 +18,11 @@ describe('getPatient', () => {
     ],
   };
   test('Should return Patient resource in context', async () => {
-    const patient = await getPatient(MOCK_PATIENT_MRN, patientContext);
+    const patient = await getPatientFromContext(MOCK_PATIENT_MRN, patientContext);
     expect(patient.id).toEqual(patientResource.id);
   });
 
   test('Should throw an error if there is no patient in context', async () => {
-    await expect(getPatient(MOCK_PATIENT_MRN, {})).rejects.toThrow('Could not find a patient in context');
+    await expect(getPatientFromContext(MOCK_PATIENT_MRN, {})).rejects.toThrow('Could not find a patient in context');
   });
 });

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -23,6 +23,6 @@ describe('getPatientFromContext', () => {
   });
 
   test('Should throw an error if there is no patient in context', async () => {
-    await expect(getPatientFromContext(MOCK_PATIENT_MRN, {})).rejects.toThrow('Could not find a patient in context');
+    await expect(getPatientFromContext(MOCK_PATIENT_MRN, {})).rejects.toThrow('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
   });
 });


### PR DESCRIPTION
# Summary

After realizing how many extractors will depend on getting the patient from context, this PR moves the utility from the E-MEF to this repo.  

## New behavior

Minimal, as this PR doesn't concern itself with using the functionality anywhere in this repo. 

## Code changes

- Adds this utility;
- Adds tests for the utility;
- Exports the utility.

# Testing guidance

- Make sure tests pass, especially the new ones. 
- Connect this with the E-MEF repo and ensure that tests pass there too.