### PR TITLE
Updated Context Management in BaseFHIRExtractor

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -39,6 +39,7 @@ class BaseClient {
     });
   }
 
+  // NOTE: Async because in other clients that extend this, we need async helper functions (ex. auth)
   async init() {
     return this.initializeExtractors(this.extractorConfig, this.commonExtractorArgs);
   }

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -20,19 +20,18 @@ class BaseFHIRExtractor extends Extractor {
     this.baseFHIRModule.updateRequestHeaders(newHeaders);
   }
 
-  // Use mrn to get PatientId by default; common need across almost all extractors
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
+  /* eslint-disable class-methods-use-this */
+  // Use context to get PatientId by default; common need across almost all extractors
+  async parametrizeArgsForFHIRModule({ context }) {
     const idFromContext = parseContextForPatientId(context);
-    if (idFromContext) return { patient: idFromContext };
-
-    logger.debug('No patient ID in context; fetching with baseFHIRModule');
-    const patientResponseBundle = await this.baseFHIRModule.search('Patient', { identifier: `MRN|${mrn}` });
-    if (!patientResponseBundle || !patientResponseBundle.entry || !patientResponseBundle.entry[0] || !patientResponseBundle.entry[0].resource) {
-      logger.error(`Could not get a patient ID to cross-reference for ${this.resourceType}`);
-      return {};
+    if (idFromContext) {
+      logger.debug('Patient found in context');
+      return { patient: idFromContext };
     }
-    return { patient: patientResponseBundle.entry[0].resource.id };
+
+    throw new Error('BaseFHIRExtractor could not find Patient resource in context. Use an extractor to get a Patient resource first.');
   }
+  /* eslint-enable class-methods-use-this */
 
   // Since different superclasses of the baseFHIRExtractor will parse the `get`
   // arguments differently, all pass to this function which interfaces with the baseFHIRModule

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -1,12 +1,8 @@
 const { Extractor } = require('./Extractor');
 const { BaseFHIRModule } = require('../modules');
-const { determineVersion, mapFHIRVersions, isBundleEmpty, getBundleResourcesByType } = require('../helpers/fhirUtils');
+const { determineVersion, mapFHIRVersions, isBundleEmpty } = require('../helpers/fhirUtils');
+const { getPatientFromContext } = require('../helpers/contextUtils');
 const logger = require('../helpers/logger');
-
-function parseContextForPatientId(context) {
-  const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
-  return patientInContext ? patientInContext.id : undefined;
-}
 
 class BaseFHIRExtractor extends Extractor {
   constructor({ baseFhirUrl, requestHeaders, version, resourceType }) {
@@ -22,14 +18,9 @@ class BaseFHIRExtractor extends Extractor {
 
   /* eslint-disable class-methods-use-this */
   // Use context to get PatientId by default; common need across almost all extractors
-  async parametrizeArgsForFHIRModule({ context }) {
-    const idFromContext = parseContextForPatientId(context);
-    if (idFromContext) {
-      logger.debug('Patient found in context');
-      return { patient: idFromContext };
-    }
-
-    throw new Error('BaseFHIRExtractor could not find Patient resource in context. Use an extractor to get a Patient resource first.');
+  async parametrizeArgsForFHIRModule({ mrn, context }) {
+    const patient = getPatientFromContext(mrn, context);
+    return { patient: patient.id };
   }
   /* eslint-enable class-methods-use-this */
 

--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -18,6 +18,7 @@ class BaseFHIRExtractor extends Extractor {
 
   /* eslint-disable class-methods-use-this */
   // Use context to get PatientId by default; common need across almost all extractors
+  // NOTE: Async because other extractors that extend this may need to make async lookups in the future
   async parametrizeArgsForFHIRModule({ mrn, context }) {
     const patient = getPatientFromContext(mrn, context);
     return { patient: patient.id };

--- a/src/extractors/MCODERadiationProcedureExtractor.js
+++ b/src/extractors/MCODERadiationProcedureExtractor.js
@@ -15,6 +15,7 @@ function getMCODERadiationProcedures(fhirProcedures) {
 class MCODERadiationProcedureExtractor extends Extractor {
   constructor({ baseFhirUrl, requestHeaders }) {
     super({ baseFhirUrl, requestHeaders });
+    logger.debug('Note that MCODERadiationProcedureExtractor uses FHIR to get FHIR Procedures.');
     this.fhirProcedureExtractor = new FHIRProcedureExtractor({ baseFhirUrl, requestHeaders });
   }
 

--- a/src/extractors/MCODESurgicalProcedureExtractor.js
+++ b/src/extractors/MCODESurgicalProcedureExtractor.js
@@ -15,6 +15,7 @@ function getMCODESurgicalProcedures(fhirProcedures) {
 class MCODESurgicalProcedureExtractor extends Extractor {
   constructor({ baseFhirUrl, requestHeaders }) {
     super({ baseFhirUrl, requestHeaders });
+    logger.debug('Note that MCODESurgicalProcedureExtractor uses FHIR to get FHIR Procedures.');
     this.fhirProcedureExtractor = new FHIRProcedureExtractor({ baseFhirUrl, requestHeaders });
   }
 

--- a/test/extractors/BaseFHIRExtractor.test.js
+++ b/test/extractors/BaseFHIRExtractor.test.js
@@ -31,9 +31,6 @@ const { baseFHIRModule } = baseFHIRExtractor;
 const baseFHIRModuleSearchSpy = jest.spyOn(baseFHIRModule, 'search');
 const moduleRequestHeadersSpy = jest.spyOn(baseFHIRModule, 'updateRequestHeaders');
 
-when(baseFHIRModuleSearchSpy)
-  .calledWith('Patient', { identifier: `MRN|${MOCK_PATIENT_MRN}` })
-  .mockReturnValue(examplePatientBundle);
 // Ensure that data is returned for condition
 when(baseFHIRModuleSearchSpy)
   .calledWith('Condition', { patient: examplePatientBundle.entry[0].resource.id })
@@ -60,7 +57,7 @@ describe('BaseFhirExtractor', () => {
 
   test('parametrizeArgsForFHIRModule parses data off of context if available', async () => {
     baseFHIRModuleSearchSpy.mockClear();
-    const paramsBasedOnContext = await baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN, context: MOCK_CONTEXT });
+    const paramsBasedOnContext = await baseFHIRExtractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
     expect(baseFHIRModuleSearchSpy).not.toHaveBeenCalled();
     expect(paramsBasedOnContext).toHaveProperty('patient');
     expect(paramsBasedOnContext.patient).toEqual(MOCK_CONTEXT.entry[0].resource.id);
@@ -68,12 +65,12 @@ describe('BaseFhirExtractor', () => {
 
   test('parametrizeArgsForFHIRModule throws an error if context has no relevant ID', async () => {
     baseFHIRModuleSearchSpy.mockClear();
-    await expect(baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN })).rejects.toThrowError('BaseFHIRExtractor could not find Patient resource in context.');
+    await expect(baseFHIRExtractor.parametrizeArgsForFHIRModule({})).rejects.toThrowError('BaseFHIRExtractor could not find Patient resource in context.');
     expect(baseFHIRModuleSearchSpy).not.toHaveBeenCalled();
   });
 
   test('get should return a condition resource', async () => {
-    const data = await baseFHIRExtractor.get({ mrn: MOCK_PATIENT_MRN, context: MOCK_CONTEXT });
+    const data = await baseFHIRExtractor.get({ context: MOCK_CONTEXT });
     expect(data.resourceType).toEqual('Bundle');
     expect(data.entry).toBeDefined();
     expect(data.entry.length).toBeGreaterThan(0);

--- a/test/extractors/BaseFHIRExtractor.test.js
+++ b/test/extractors/BaseFHIRExtractor.test.js
@@ -18,7 +18,7 @@ const MOCK_CONTEXT = {
   entry: [
     {
       fullUrl: 'context-url',
-      resource: { resourceType: 'Patient', id: 'MOCK-ID' },
+      resource: { resourceType: 'Patient', id: MOCK_PATIENT_MRN },
     },
   ],
 };
@@ -66,16 +66,14 @@ describe('BaseFhirExtractor', () => {
     expect(paramsBasedOnContext.patient).toEqual(MOCK_CONTEXT.entry[0].resource.id);
   });
 
-  test('parametrizeArgsForFHIRModule makes Patient call if context has no relevant ID', async () => {
+  test('parametrizeArgsForFHIRModule throws an error if context has no relevant ID', async () => {
     baseFHIRModuleSearchSpy.mockClear();
-    const paramsBasedOnContext = await baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN });
-    expect(baseFHIRModuleSearchSpy).toHaveBeenCalled();
-    expect(paramsBasedOnContext).toHaveProperty('patient');
-    expect(paramsBasedOnContext.patient).toEqual(examplePatientBundle.entry[0].resource.id);
+    await expect(baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN })).rejects.toThrowError('BaseFHIRExtractor could not find Patient resource in context.');
+    expect(baseFHIRModuleSearchSpy).not.toHaveBeenCalled();
   });
 
   test('get should return a condition resource', async () => {
-    const data = await baseFHIRExtractor.get({ mrn: MOCK_PATIENT_MRN });
+    const data = await baseFHIRExtractor.get({ mrn: MOCK_PATIENT_MRN, context: MOCK_CONTEXT });
     expect(data.resourceType).toEqual('Bundle');
     expect(data.entry).toBeDefined();
     expect(data.entry.length).toBeGreaterThan(0);

--- a/test/extractors/FHIRAdverseEventExtractor.test.js
+++ b/test/extractors/FHIRAdverseEventExtractor.test.js
@@ -1,14 +1,22 @@
 const rewire = require('rewire');
 const { FHIRAdverseEventExtractor } = require('../../src/extractors/FHIRAdverseEventExtractor');
-const examplePatientBundle = require('./fixtures/patient-bundle.json');
 
 const FHIRAdverseEventExtractorRewired = rewire('../../src/extractors/FHIRAdverseEventExtractor.js');
 const MOCK_URL = 'http://example.com';
 const MOCK_HEADERS = {};
 const MOCK_MRN = '123456789';
 const MOCK_STUDIES = 'study1,study2';
+const MOCK_CONTEXT = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      fullUrl: 'context-url',
+      resource: { resourceType: 'Patient', id: MOCK_MRN },
+    },
+  ],
+};
 
-// Construct extractor and create sppies for mocking responses
+// Construct extractor and create spies for mocking responses
 const extractor = new FHIRAdverseEventExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
 const extractorWithStudy = new FHIRAdverseEventExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS, study: MOCK_STUDIES });
 const baseStudy = FHIRAdverseEventExtractorRewired.__get__('BASE_STUDY');
@@ -28,33 +36,19 @@ describe('FHIRAdverseEventExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should not add study when not set to param values', async () => {
-      // Create spy
-      const { baseFHIRModule } = extractor;
-      const baseFHIRModuleSearchSpy = jest.spyOn(baseFHIRModule, 'search');
-      baseFHIRModuleSearchSpy
-        .mockReturnValue(examplePatientBundle);
-
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
       expect(params).not.toHaveProperty('study');
     });
 
     describe('pass in optional study parameter', () => {
-      beforeEach(() => {
-        // Create spy
-        const { baseFHIRModule } = extractorWithStudy;
-        const baseFHIRModuleSearchSpy = jest.spyOn(baseFHIRModule, 'search');
-        baseFHIRModuleSearchSpy
-          .mockReturnValue(examplePatientBundle);
-      });
-
       test('should add study when set to param values', async () => {
-        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
         expect(params).toHaveProperty('study');
         expect(params.study).toEqual(extractorWithStudy.study);
       });
 
       test('should delete patient after its value is moved to subject', async () => {
-        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
         expect(params).not.toHaveProperty('patient');
       });
     });

--- a/test/extractors/FHIRAllergyIntoleranceExtractor.test.js
+++ b/test/extractors/FHIRAllergyIntoleranceExtractor.test.js
@@ -1,12 +1,20 @@
 const rewire = require('rewire');
 const { FHIRAllergyIntoleranceExtractor } = require('../../src/extractors/FHIRAllergyIntoleranceExtractor.js');
-const examplePatientBundle = require('./fixtures/patient-bundle.json');
 
 const FHIRAllergyIntoleranceExtractorRewired = rewire('../../src/extractors/FHIRAllergyIntoleranceExtractor.js');
 const MOCK_URL = 'http://example.com';
 const MOCK_HEADERS = {};
 const MOCK_MRN = '123456789';
 const MOCK_CLINICAL_STATUS = 'status1,status2';
+const MOCK_CONTEXT = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      fullUrl: 'context-url',
+      resource: { resourceType: 'Patient', id: MOCK_MRN },
+    },
+  ],
+};
 
 const extractor = new FHIRAllergyIntoleranceExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
 const extractorWithClinicalStatus = new FHIRAllergyIntoleranceExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS, clinicalStatus: MOCK_CLINICAL_STATUS });
@@ -29,12 +37,7 @@ describe('FHIRAllergyIntoleranceExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      // Create spy
-      const { baseFHIRModule } = extractor;
-      const baseFHIRModuleSearchSpy = jest.spyOn(baseFHIRModule, 'search');
-      baseFHIRModuleSearchSpy.mockReturnValue(examplePatientBundle);
-
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
       expect(params).toHaveProperty('clinical-status');
       expect(params['clinical-status']).toEqual(baseClinicalStatus);
     });

--- a/test/extractors/FHIRConditionExtractor.test.js
+++ b/test/extractors/FHIRConditionExtractor.test.js
@@ -1,12 +1,20 @@
 const rewire = require('rewire');
 const { FHIRConditionExtractor } = require('../../src/extractors/FHIRConditionExtractor.js');
-const examplePatientBundle = require('./fixtures/patient-bundle.json');
 
 const FHIRConditionExtractorRewired = rewire('../../src/extractors/FHIRConditionExtractor');
 const MOCK_URL = 'http://example.com';
 const MOCK_HEADERS = {};
 const MOCK_MRN = '123456789';
 const MOCK_CATEGORIES = 'category1,category2';
+const MOCK_CONTEXT = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      fullUrl: 'context-url',
+      resource: { resourceType: 'Patient', id: MOCK_MRN },
+    },
+  ],
+};
 
 const extractor = new FHIRConditionExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
 const extractorWithCategories = new FHIRConditionExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS, category: MOCK_CATEGORIES });
@@ -29,12 +37,7 @@ describe('FHIRConditionExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      // Create spy
-      const { baseFHIRModule } = extractor;
-      const baseFHIRModuleSpy = jest.spyOn(baseFHIRModule, 'search');
-      baseFHIRModuleSpy.mockReturnValue(examplePatientBundle);
-
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
       expect(params).toHaveProperty('category');
       expect(params.category).toEqual(baseCategories);
     });

--- a/test/extractors/FHIRObservationExtractor.test.js
+++ b/test/extractors/FHIRObservationExtractor.test.js
@@ -1,12 +1,20 @@
 const rewire = require('rewire');
 const { FHIRObservationExtractor } = require('../../src/extractors/FHIRObservationExtractor.js');
-const examplePatientBundle = require('./fixtures/patient-bundle.json');
 
 const FHIRObservationExtractorRewired = rewire('../../src/extractors/FHIRObservationExtractor.js');
 const MOCK_URL = 'http://example.com';
 const MOCK_HEADERS = {};
 const MOCK_MRN = '123456789';
 const MOCK_CATEGORIES = 'category1,category2';
+const MOCK_CONTEXT = {
+  resourceType: 'Bundle',
+  entry: [
+    {
+      fullUrl: 'context-url',
+      resource: { resourceType: 'Patient', id: MOCK_MRN },
+    },
+  ],
+};
 
 // Construct extractor and create spies for mocking responses
 const extractor = new FHIRObservationExtractor({ baseFhirUrl: MOCK_URL, requestHeaders: MOCK_HEADERS });
@@ -28,13 +36,7 @@ describe('FHIRObservationExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      // Create spy
-      const { baseFHIRModule } = extractor;
-      const baseFHIRModuleSearchSpy = jest.spyOn(baseFHIRModule, 'search');
-      baseFHIRModuleSearchSpy
-        .mockReturnValue(examplePatientBundle);
-
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN });
+      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
       expect(params).toHaveProperty('category');
       expect(params.category).toEqual(baseCategories);
     });

--- a/test/extractors/MCODERadiationProcedureExtractor.test.js
+++ b/test/extractors/MCODERadiationProcedureExtractor.test.js
@@ -18,44 +18,6 @@ const fhirProcedureExtractorSpy = jest.spyOn(fhirProcedureExtractor, 'get');
 
 describe('MCODERadiationProcedureExtractor', () => {
   describe('getFHIRProcedures', () => {
-    // it('should return procedure entries for patient from context', async () => {
-    //   const contextPatient = {
-    //     resourceType: 'Patient',
-    //     id: 'context-patient-id',
-    //   };
-    //   const contextProcedure1 = {
-    //     resourceType: 'Procedure',
-    //     id: 'context-procedure-1-id',
-    //   };
-    //   const contextProcedure2 = {
-    //     resourceType: 'Procedure',
-    //     id: 'context-procedure-2-id',
-    //   };
-    //   const context = {
-    //     resourceType: 'Bundle',
-    //     type: 'collection',
-    //     entry: [
-    //       {
-    //         fullUrl: 'context-patient-url',
-    //         resource: contextPatient,
-    //       },
-    //       {
-    //         fullUrl: 'context-procedure-1-url',
-    //         resource: contextProcedure1,
-    //       },
-    //       {
-    //         fullUrl: 'context-procedure-2-url',
-    //         resource: contextProcedure2,
-    //       },
-    //     ],
-    //   };
-    //   const procedures = await extractor.getFHIRProcedures(MOCK_PATIENT_MRN, context);
-    //   expect(fhirProcedureExtractorSpy).not.toHaveBeenCalled();
-    //   expect(procedures).toHaveLength(2);
-    //   expect(procedures[0].resource.id).toEqual(contextProcedure1.id);
-    //   expect(procedures[1].resource.id).toEqual(contextProcedure2.id);
-    // });
-
     it('should return procedure entries for patient from FHIR search if no context', async () => {
       fhirProcedureExtractorSpy.mockClear();
       when(fhirProcedureExtractorSpy).calledWith({ mrn: MOCK_PATIENT_MRN, context: {} }).mockReturnValue(exampleProcedureBundle);

--- a/test/extractors/MCODESurgicalProcedureExtractor.test.js
+++ b/test/extractors/MCODESurgicalProcedureExtractor.test.js
@@ -18,44 +18,6 @@ const fhirProcedureExtractorSpy = jest.spyOn(fhirProcedureExtractor, 'get');
 
 describe('MCODESurgicalProcedureExtractor', () => {
   describe('getFHIRProcedures', () => {
-    // it('should return procedure entries for patient from context', async () => {
-    //   const contextPatient = {
-    //     resourceType: 'Patient',
-    //     id: 'context-patient-id',
-    //   };
-    //   const contextProcedure1 = {
-    //     resourceType: 'Procedure',
-    //     id: 'context-procedure-1-id',
-    //   };
-    //   const contextProcedure2 = {
-    //     resourceType: 'Procedure',
-    //     id: 'context-procedure-2-id',
-    //   };
-    //   const context = {
-    //     resourceType: 'Bundle',
-    //     type: 'collection',
-    //     entry: [
-    //       {
-    //         fullUrl: 'context-patient-url',
-    //         resource: contextPatient,
-    //       },
-    //       {
-    //         fullUrl: 'context-procedure-1-url',
-    //         resource: contextProcedure1,
-    //       },
-    //       {
-    //         fullUrl: 'context-procedure-2-url',
-    //         resource: contextProcedure2,
-    //       },
-    //     ],
-    //   };
-    //   const procedures = await extractor.getFHIRProcedures(MOCK_PATIENT_MRN, context);
-    //   expect(fhirProcedureExtractorSpy).not.toHaveBeenCalled();
-    //   expect(procedures).toHaveLength(2);
-    //   expect(procedures[0].resource.id).toEqual(contextProcedure1.id);
-    //   expect(procedures[1].resource.id).toEqual(contextProcedure2.id);
-    // });
-
     it('should return procedure entries for patient from FHIR search if no context', async () => {
       fhirProcedureExtractorSpy.mockClear();
       when(fhirProcedureExtractorSpy).calledWith({ mrn: MOCK_PATIENT_MRN, context: {} }).mockReturnValue(exampleProcedureBundle);

--- a/test/extractors/fixtures/patient-bundle.json
+++ b/test/extractors/fixtures/patient-bundle.json
@@ -16,7 +16,7 @@
       ],
       "resource": {
         "resourceType": "Patient",
-        "id": "patient-id",
+        "id": "EXAMPLE-MRN",
         "extension": [
           {
             "url": "http://hl7.org/fhir/StructureDefinition/us-core-race",


### PR DESCRIPTION
# Summary
This PR updates the `BaseFHIRExtractor` to require the `Patient` resource to be in context when it is used to search for other resource types.

## New behavior
When any of the generic FHIR resource extractors are run before the `FHIRPatientExtractor`, an error will be thrown and that resource will not be extracted. When the `FHIRPatientExtractor` is run first, the behavior is unchanged.

## Code changes
Removed the `BaseFHIRModule` search for `Patient` when the `Patient` resource was not on the context bundle. Instead, throw an error.

Added a test in `BaseFHIRExtractor` to test for this new error. Also updated the other FHIR extractors that now needed a `Patient` on context. I did not add a test on each of the FHIR extractors to show that an error would be thrown if `Patient` was missing from context because I felt that was covered by the `BaseFHIRExtractor` test, but I can add it if reviewers feel it's helpful.

# Testing guidance
Test that the changes to the tests make sense and that the new tests cover the new context requirement. You can also manually run extraction using the E-MEF to test that everything runs the same if `FHIRPatientExtractor` is used first and that errors are thrown if it is used after other FHIR extractors in your config.

**Note**: This PR will need to be udpated if #78 is merged first.
