### PR TITLE
Creates a getConditionsFromContext function for parsing Condition resources off Context

### DIFF
--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -1,5 +1,17 @@
+const _ = require('lodash');
 const logger = require('./logger');
 const { getBundleEntriesByResourceType, getBundleResourcesByType } = require('./fhirUtils');
+
+
+function getConditionsFromContext(mrn, context) {
+  logger.debug('Getting conditions from context');
+  const conditionsInContext = getBundleResourcesByType(context, 'Condition', {}, false);
+  if (_.isEmpty(conditionsInContext)) {
+    throw Error('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
+  }
+  logger.debug('Condition resources found in context.');
+  return conditionsInContext;
+}
 
 function getPatientFromContext(mrn, context) {
   logger.debug('Getting patient from context');
@@ -38,6 +50,7 @@ function getEncountersFromContext(context) {
 
 module.exports = {
   getConditionEntriesFromContext,
+  getConditionsFromContext,
   getEncountersFromContext,
   getPatientFromContext,
 };

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -2,17 +2,6 @@ const _ = require('lodash');
 const logger = require('./logger');
 const { getBundleEntriesByResourceType, getBundleResourcesByType } = require('./fhirUtils');
 
-
-function getConditionsFromContext(mrn, context) {
-  logger.debug('Getting conditions from context');
-  const conditionsInContext = getBundleResourcesByType(context, 'Condition', {}, false);
-  if (_.isEmpty(conditionsInContext)) {
-    throw Error('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
-  }
-  logger.debug('Condition resources found in context.');
-  return conditionsInContext;
-}
-
 function getPatientFromContext(mrn, context) {
   logger.debug('Getting patient from context');
   const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
@@ -23,14 +12,34 @@ function getPatientFromContext(mrn, context) {
   return patientInContext;
 }
 
-function getConditionEntriesFromContext(mrn, context) {
+/**
+* Parses context for Condition entries, which themselves contain resources
+* @param {Object} context - Context object consisting of a FHIR Bundle
+* @return {Array} All the conditions entries found in context
+*/
+function getConditionEntriesFromContext(context) {
   logger.debug('Getting conditions from context');
-  const conditionsInContext = getBundleEntriesByResourceType(context, 'Condition', {}, false);
-  if (conditionsInContext.length === 0) {
+  const conditionEntriesInContext = getBundleEntriesByResourceType(context, 'Condition', {}, false);
+  if (conditionEntriesInContext.length === 0) {
     throw Error('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   }
-  logger.debug(`Condition resources found in context. Found ${conditionsInContext.length} condition resources.`);
-  return conditionsInContext;
+  logger.debug(`Condition resources found in context. Found ${conditionEntriesInContext.length} condition resources.`);
+  return conditionEntriesInContext;
+}
+
+/**
+* Parses context for Condition resources
+* @param {Object} context - Context object consisting of a FHIR Bundle
+* @return {Array} All the conditions resources found in context
+*/
+function getConditionsFromContext(context) {
+  logger.debug('Getting conditions from context');
+  const conditionsResourcesInContext = getBundleResourcesByType(context, 'Condition', {}, false);
+  if (_.isEmpty(conditionsResourcesInContext)) {
+    throw Error('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
+  }
+  logger.debug('Condition resources found in context.');
+  return conditionsResourcesInContext;
 }
 
 /**

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -2,14 +2,19 @@ const _ = require('lodash');
 const logger = require('./logger');
 const { getBundleEntriesByResourceType, getBundleResourcesByType } = require('./fhirUtils');
 
+/**
+* Parses context a Patient resource
+* @param {Object} context - Context object consisting of a FHIR Bundle
+* @return {Object} The first Patient resource found in the bundle
+*/
 function getPatientFromContext(mrn, context) {
   logger.debug('Getting patient from context');
-  const patientInContext = getBundleResourcesByType(context, 'Patient', {}, true);
-  if (!patientInContext) {
+  const patientResourceInContext = getBundleResourcesByType(context, 'Patient', {}, true);
+  if (!patientResourceInContext) {
     throw Error('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
   }
   logger.debug('Patient resource found in context.');
-  return patientInContext;
+  return patientResourceInContext;
 }
 
 /**
@@ -49,12 +54,12 @@ function getConditionsFromContext(context) {
 */
 function getEncountersFromContext(context) {
   logger.debug('Getting encounter resources from context');
-  const encountersInContext = getBundleResourcesByType(context, 'Encounter');
-  if (encountersInContext.length === 0) {
+  const encounterResourcesInContext = getBundleResourcesByType(context, 'Encounter');
+  if (encounterResourcesInContext.length === 0) {
     throw Error('Could not find any encounter resources in context; ensure that an EncounterExtractor is used earlier in your extraction configuration');
   }
-  logger.debug(`Condition resources found in context. Found ${encountersInContext.length} condition resources.`);
-  return encountersInContext;
+  logger.debug(`Condition resources found in context. Found ${encounterResourcesInContext.length} condition resources.`);
+  return encounterResourcesInContext;
 }
 
 module.exports = {

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -18,12 +18,12 @@ function getPatientFromContext(mrn, context) {
 * @return {Array} All the conditions entries found in context
 */
 function getConditionEntriesFromContext(context) {
-  logger.debug('Getting conditions from context');
+  logger.debug('Getting condition entries from context');
   const conditionEntriesInContext = getBundleEntriesByResourceType(context, 'Condition', {}, false);
   if (conditionEntriesInContext.length === 0) {
     throw Error('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   }
-  logger.debug(`Condition resources found in context. Found ${conditionEntriesInContext.length} condition resources.`);
+  logger.debug(`Condition entries found in context. Found ${conditionEntriesInContext.length} condition resources.`);
   return conditionEntriesInContext;
 }
 
@@ -33,12 +33,12 @@ function getConditionEntriesFromContext(context) {
 * @return {Array} All the conditions resources found in context
 */
 function getConditionsFromContext(context) {
-  logger.debug('Getting conditions from context');
+  logger.debug('Getting condition resources from context');
   const conditionsResourcesInContext = getBundleResourcesByType(context, 'Condition', {}, false);
   if (_.isEmpty(conditionsResourcesInContext)) {
-    throw Error('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
+    throw Error('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   }
-  logger.debug('Condition resources found in context.');
+  logger.debug(`Condition resources found in context. Found ${conditionsResourcesInContext.length} condition resources.`);
   return conditionsResourcesInContext;
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ const {
 } = require('./helpers/conditionUtils');
 const { getDiseaseStatusCode, getDiseaseStatusEvidenceCode, mEpochToDate } = require('./helpers/diseaseStatusUtils');
 const { formatDate, formatDateTime } = require('./helpers/dateUtils');
-const { getConditionEntriesFromContext, getEncountersFromContext, getPatientFromContext } = require('./helpers/contextUtils');
+const { getConditionEntriesFromContext, getConditionsFromContext, getEncountersFromContext, getPatientFromContext } = require('./helpers/contextUtils');
 
 module.exports = {
   // CLI Related utilities
@@ -134,6 +134,7 @@ module.exports = {
   mEpochToDate,
   // Context operations
   getConditionEntriesFromContext,
+  getConditionsFromContext,
   getEncountersFromContext,
   getPatientFromContext,
 };

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -1,4 +1,4 @@
-const { getConditionEntriesFromContext, getEncountersFromContext, getPatientFromContext } = require('../../src/helpers/contextUtils');
+const { getConditionEntriesFromContext, getConditionsFromContext, getEncountersFromContext, getPatientFromContext } = require('../../src/helpers/contextUtils');
 
 const MOCK_PATIENT_MRN = '123';
 
@@ -24,6 +24,41 @@ describe('getPatientFromContext', () => {
 
   test('Should throw an error if there is no patient in context', () => {
     expect(() => getPatientFromContext(MOCK_PATIENT_MRN, {})).toThrow('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
+  });
+});
+
+describe('getConditionsFromContext', () => {
+  const conditionResource = {
+    resourceType: 'Condition',
+    id: 'mCODEConditionExample01',
+  };
+  const conditionResource2 = {
+    resourceType: 'Condition',
+    id: 'mCODEConditionExample02',
+  };
+  const conditionContext = {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        fullUrl: 'context-url-1',
+        resource: conditionResource,
+      },
+      {
+        fullUrl: 'context-url-2',
+        resource: conditionResource2,
+      },
+    ],
+  };
+  test('Should return Patient resource in context', () => {
+    const conditions = getConditionsFromContext(MOCK_PATIENT_MRN, conditionContext);
+    expect(conditions).toContain(conditionResource);
+    expect(conditions).toContain(conditionResource2);
+  });
+
+  test('Should throw an error if there is no patient in context', () => {
+    expect(() => getConditionsFromContext(MOCK_PATIENT_MRN, {}))
+      .toThrow('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   });
 });
 

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -50,19 +50,19 @@ describe('getConditionsFromContext', () => {
       },
     ],
   };
-  test('Should return Patient resource in context', () => {
-    const conditions = getConditionsFromContext(MOCK_PATIENT_MRN, conditionContext);
+  test('Should return Condition resource in context', () => {
+    const conditions = getConditionsFromContext(conditionContext);
     expect(conditions).toContain(conditionResource);
     expect(conditions).toContain(conditionResource2);
   });
 
   test('Should throw an error if there is no patient in context', () => {
-    expect(() => getConditionsFromContext(MOCK_PATIENT_MRN, {}))
-      .toThrow('Could not find conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
+    expect(() => getConditionsFromContext({}))
+      .toThrow('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   });
 });
 
-describe('getConditionFromContext', () => {
+describe('getConditionEntriesFromContext', () => {
   const conditionResource = {
     resourceType: 'Condition',
     id: 'mCODEConditionExample01',
@@ -82,8 +82,8 @@ describe('getConditionFromContext', () => {
     ],
   };
 
-  test('Should return all Condition resources in context', () => {
-    const conditions = getConditionEntriesFromContext(MOCK_PATIENT_MRN, conditionContext);
+  test('Should return all Condition entries in context', () => {
+    const conditions = getConditionEntriesFromContext(conditionContext);
     expect(conditions).toHaveLength(2);
     expect(conditions[0]).toEqual({
       fullUrl: 'context-url-1',
@@ -92,7 +92,7 @@ describe('getConditionFromContext', () => {
   });
 
   test('Should throw an error if there are no conditions in context', () => {
-    expect(() => getConditionEntriesFromContext(MOCK_PATIENT_MRN, {}))
+    expect(() => getConditionEntriesFromContext({}))
       .toThrow('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   });
 });

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -56,7 +56,7 @@ describe('getConditionsFromContext', () => {
     expect(conditions).toContain(conditionResource2);
   });
 
-  test('Should throw an error if there is no patient in context', () => {
+  test('Should throw an error if there is no Condition resource in context', () => {
     expect(() => getConditionsFromContext({}))
       .toThrow('Could not find any conditions in context; ensure that a ConditionExtractor is used earlier in your extraction configuration');
   });


### PR DESCRIPTION
# Summary
This PR adds a util function for getting Condition resources from context.

## New behavior
Adds a new util function, but no new behavior since it is not yet used in this repo.

## Code changes
- Removes the MRN parameter from both ConditionContextUtils; it's late and I'd be happy to talk about reverting this tomorrow, but it felt right to avoid this habit of stubbing out variables we might get around to using in the future. Rob was right, as usual. 
- Add the function and tests for the function
- Added JS Docs for both condition functions in `contextUtils.js`
- Minor variable name changes in getConditionEntriesFromContext.

# Testing guidance
Check that the tests are sufficient for the function. The use of this function will really be tested in the related PR in the Epic-MEF (there are instructions in that PR).