### PR TITLE
Add identifier helper and update ResearchSubject template

### DIFF
--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -95,6 +95,13 @@ function mapFHIRVersions(resource, currentVersion, targetVersion) {
   return resource;
 }
 
+function firstIdentifierEntry(resource) {
+  if (resource.identifier && resource.identifier.length > 0) {
+    return resource.identifier[0];
+  }
+  return null;
+}
+
 // Utility function to get the resources of a type from our bundle
 // Optionally get only the first resource of that type via 'first' parameter
 const getBundleResourcesByType = (bundle, type, context = {}, first = false) => {
@@ -158,10 +165,12 @@ const logOperationOutcomeInfo = (operationOutcome) => {
 
 const isValidFHIR = (resource) => validator.validate('FHIR', resource);
 
+
 module.exports = {
   allResourcesInBundle,
   determineVersion,
   firstEntryInBundle,
+  firstIdentifierEntry,
   firstResourceInBundle,
   getBundleEntriesByResourceType,
   getBundleResourcesByType,

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ const { getEthnicityDisplay,
 const {
   allResourcesInBundle,
   firstEntryInBundle,
+  firstIdentifierEntry,
   firstResourceInBundle,
   getBundleEntriesByResourceType,
   getBundleResourcesByType,
@@ -104,6 +105,7 @@ module.exports = {
   // FHIR and resource helpers
   allResourcesInBundle,
   firstEntryInBundle,
+  firstIdentifierEntry,
   firstResourceInBundle,
   formatDate,
   formatDateTime,

--- a/src/templates/ResearchSubjectTemplate.js
+++ b/src/templates/ResearchSubjectTemplate.js
@@ -1,10 +1,10 @@
 const { reference, identifier, identifierArr } = require('./snippets');
 
-function studyTemplate(trialResearchID) {
+function studyTemplate(trialResearchID, trialResearchSystem) {
   return {
     study: {
       ...identifier({
-        system: 'http://example.com/clinicaltrialids',
+        system: trialResearchSystem,
         value: trialResearchID,
       }),
     },
@@ -37,6 +37,7 @@ function researchSubjectTemplate({
   trialSubjectID,
   trialResearchID,
   patientId,
+  trialResearchSystem = 'http://example.com/clinicaltrialids',
 }) {
   if (!(id && enrollmentStatus && trialSubjectID && trialResearchID && patientId)) {
     throw Error('Trying to render a ResearchStudyTemplate, but a required argument is missing; ensure that id, trialStatus, trialResearchID, clinicalSiteID are all present');
@@ -46,7 +47,7 @@ function researchSubjectTemplate({
     resourceType: 'ResearchSubject',
     id,
     status: enrollmentStatus,
-    ...studyTemplate(trialResearchID),
+    ...studyTemplate(trialResearchID, trialResearchSystem),
     ...individualTemplate(patientId),
     ...researchSubjectIdentifiersTemplate(trialSubjectID),
   };

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -2,6 +2,7 @@ const {
   getQuantityUnit,
   isBundleEmpty,
   firstEntryInBundle,
+  firstIdentifierEntry,
   firstResourceInBundle,
   allResourcesInBundle,
   quantityCodeToUnitLookup,
@@ -43,14 +44,36 @@ describe('isBundleEmpty', () => {
 
 describe('firstEntryInBundle', () => {
   test('Empty bundle should return undefined', () => {
+    expect(firstEntryInBundle(emptyBundle)).toBeUndefined();
   });
-  expect(firstEntryInBundle(emptyBundle)).toBeUndefined();
 
   test('Bundles with entries should always return the first', () => {
     expect(firstEntryInBundle(bundleWithOneEntry))
       .toEqual(bundleWithOneEntry.entry[0]);
     expect(firstEntryInBundle(bundleWithMultipleEntries))
       .toEqual(bundleWithMultipleEntries.entry[0]);
+  });
+});
+
+describe('firstIdentifierEntry', () => {
+  test('Resource with no identifier returns null', () => {
+    expect(firstIdentifierEntry({})).toBeNull();
+  });
+
+  test('Resource with identifier gives first value', () => {
+    const id1 = {
+      system: 'example',
+      value: 'example-value',
+    };
+    const id2 = {
+      system: 'example2',
+      value: 'example-value2',
+    };
+    const resourceWithIdentifier = {
+      identifier: [id1, id2],
+    };
+
+    expect(firstIdentifierEntry(resourceWithIdentifier)).toEqual(id1);
   });
 });
 


### PR DESCRIPTION
# Summary

The motivation for this was to include the system of the ResearchStudy identifier that now gets searched for in the Epic extractor. We were always defaulting this to an example.com system. Now that we will sometimes have the system from the actual resource we search for, we want to pass this through.

## New behavior

If using Epic extractor and find a ResearchStudy resource via an API call, the system will persist over to the `study` attribute of the corresponding  `ResearchSubject` resource that is generated using the template

## Code changes

* ResearchSubject template now includes a defaulted arg for the identifier system of the ResearchStudy.
* Add fn in fhirUtils that grabs first identifier (null if not present), and corresponding unit tests

# Testing guidance

Ensure current behavior in base MEF is unchanged. More thorough testing can be done on corresponding Epic-MEF PR.
