### PR TITLE
Removing the use of MRN in the parametrize function

### DIFF
--- a/src/extractors/BaseFHIRExtractor.js
+++ b/src/extractors/BaseFHIRExtractor.js
@@ -19,8 +19,8 @@ class BaseFHIRExtractor extends Extractor {
   /* eslint-disable class-methods-use-this */
   // Use context to get PatientId by default; common need across almost all extractors
   // NOTE: Async because other extractors that extend this may need to make async lookups in the future
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const patient = getPatientFromContext(mrn, context);
+  async parametrizeArgsForFHIRModule({ context }) {
+    const patient = getPatientFromContext(context);
     return { patient: patient.id };
   }
   /* eslint-enable class-methods-use-this */

--- a/src/extractors/FHIRAdverseEventExtractor.js
+++ b/src/extractors/FHIRAdverseEventExtractor.js
@@ -10,8 +10,8 @@ class FHIRAdverseEventExtractor extends BaseFHIRExtractor {
   }
 
   // In addition to default parametrization, add study if specified
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
+  async parametrizeArgsForFHIRModule({ context }) {
+    const paramsWithID = await super.parametrizeArgsForFHIRModule({ context });
     // The patient is referenced in the 'subject' field of an AdverseEvent
     paramsWithID.subject = paramsWithID.patient;
     delete paramsWithID.patient;

--- a/src/extractors/FHIRAllergyIntoleranceExtractor.js
+++ b/src/extractors/FHIRAllergyIntoleranceExtractor.js
@@ -10,8 +10,8 @@ class FHIRAllergyIntoleranceExtractor extends BaseFHIRExtractor {
   }
 
   // In addition to default parametrization, add clinical status
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
+  async parametrizeArgsForFHIRModule({ context }) {
+    const paramsWithID = await super.parametrizeArgsForFHIRModule({ context });
     return {
       ...paramsWithID,
       'clinical-status': this.clinicalStatus,

--- a/src/extractors/FHIRConditionExtractor.js
+++ b/src/extractors/FHIRConditionExtractor.js
@@ -10,8 +10,8 @@ class FHIRConditionExtractor extends BaseFHIRExtractor {
   }
 
   // In addition to default parametrization, add category
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
+  async parametrizeArgsForFHIRModule({ context }) {
+    const paramsWithID = await super.parametrizeArgsForFHIRModule({ context });
     return {
       ...paramsWithID,
       category: this.category,

--- a/src/extractors/FHIRMedicationRequestExtractor.js
+++ b/src/extractors/FHIRMedicationRequestExtractor.js
@@ -10,8 +10,8 @@ class FHIRMedicationRequestExtractor extends BaseFHIRExtractor {
   }
 
   // In addition to default parametrization, add status if specified
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
+  async parametrizeArgsForFHIRModule({ context }) {
+    const paramsWithID = await super.parametrizeArgsForFHIRModule({ context });
     // Only add status to parameters if it has been specified
     return {
       ...paramsWithID,

--- a/src/extractors/FHIRObservationExtractor.js
+++ b/src/extractors/FHIRObservationExtractor.js
@@ -10,8 +10,8 @@ class FHIRObservationExtractor extends BaseFHIRExtractor {
   }
 
   // In addition to default parametrization, add category
-  async parametrizeArgsForFHIRModule({ mrn, context }) {
-    const paramsWithID = await super.parametrizeArgsForFHIRModule({ mrn, context });
+  async parametrizeArgsForFHIRModule({ context }) {
+    const paramsWithID = await super.parametrizeArgsForFHIRModule({ context });
     return {
       ...paramsWithID,
       category: this.category,

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -7,7 +7,7 @@ const { getBundleEntriesByResourceType, getBundleResourcesByType } = require('./
 * @param {Object} context - Context object consisting of a FHIR Bundle
 * @return {Object} The first Patient resource found in the bundle
 */
-function getPatientFromContext(mrn, context) {
+function getPatientFromContext(context) {
   logger.debug('Getting patient from context');
   const patientResourceInContext = getBundleResourcesByType(context, 'Patient', {}, true);
   if (!patientResourceInContext) {

--- a/test/extractors/BaseFHIRExtractor.test.js
+++ b/test/extractors/BaseFHIRExtractor.test.js
@@ -43,7 +43,7 @@ describe('BaseFhirExtractor', () => {
 
   test('parametrizeArgsForFHIRModule parses data off of context if available', async () => {
     baseFHIRModuleSearchSpy.mockClear();
-    const paramsBasedOnContext = await baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN, context: MOCK_CONTEXT });
+    const paramsBasedOnContext = await baseFHIRExtractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
     expect(baseFHIRModuleSearchSpy).not.toHaveBeenCalled();
     expect(paramsBasedOnContext).toHaveProperty('patient');
     expect(paramsBasedOnContext.patient).toEqual(MOCK_CONTEXT.entry[0].resource.id);
@@ -51,7 +51,7 @@ describe('BaseFhirExtractor', () => {
 
   test('parametrizeArgsForFHIRModule throws an error if context has no relevant ID', async () => {
     baseFHIRModuleSearchSpy.mockClear();
-    await expect(baseFHIRExtractor.parametrizeArgsForFHIRModule({ mrn: MOCK_PATIENT_MRN, context: {} })).rejects.toThrow();
+    await expect(baseFHIRExtractor.parametrizeArgsForFHIRModule({ context: {} })).rejects.toThrow();
     expect(baseFHIRModuleSearchSpy).not.toHaveBeenCalled();
   });
 

--- a/test/extractors/BaseFHIRExtractor.test.js
+++ b/test/extractors/BaseFHIRExtractor.test.js
@@ -56,7 +56,7 @@ describe('BaseFhirExtractor', () => {
   });
 
   test('get should return a condition resource', async () => {
-    const data = await baseFHIRExtractor.get({ mrn: MOCK_PATIENT_MRN, context: MOCK_CONTEXT });
+    const data = await baseFHIRExtractor.get({ context: MOCK_CONTEXT });
     expect(data.resourceType).toEqual('Bundle');
     expect(data.entry).toBeDefined();
     expect(data.entry.length).toBeGreaterThan(0);

--- a/test/extractors/FHIRAdverseEventExtractor.test.js
+++ b/test/extractors/FHIRAdverseEventExtractor.test.js
@@ -36,19 +36,19 @@ describe('FHIRAdverseEventExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should not add study when not set to param values', async () => {
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).not.toHaveProperty('study');
     });
 
     describe('pass in optional study parameter', () => {
       test('should add study when set to param values', async () => {
-        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
         expect(params).toHaveProperty('study');
         expect(params.study).toEqual(extractorWithStudy.study);
       });
 
       test('should delete patient after its value is moved to subject', async () => {
-        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+        const params = await extractorWithStudy.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
         expect(params).not.toHaveProperty('patient');
       });
     });

--- a/test/extractors/FHIRAllergyIntoleranceExtractor.test.js
+++ b/test/extractors/FHIRAllergyIntoleranceExtractor.test.js
@@ -37,7 +37,7 @@ describe('FHIRAllergyIntoleranceExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).toHaveProperty('clinical-status');
       expect(params['clinical-status']).toEqual(baseClinicalStatus);
     });

--- a/test/extractors/FHIRConditionExtractor.test.js
+++ b/test/extractors/FHIRConditionExtractor.test.js
@@ -37,7 +37,7 @@ describe('FHIRConditionExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).toHaveProperty('category');
       expect(params.category).toEqual(baseCategories);
     });

--- a/test/extractors/FHIRMedicationRequestExtractor.test.js
+++ b/test/extractors/FHIRMedicationRequestExtractor.test.js
@@ -36,12 +36,12 @@ describe('FHIRMedicationRequestExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should not add status when not set to param values', async () => {
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).not.toHaveProperty('status');
     });
 
     test('should add status when set to param values', async () => {
-      const params = await extractorWithStatuses.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractorWithStatuses.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).toHaveProperty('status');
       expect(params.status).toEqual(extractorWithStatuses.status);
     });

--- a/test/extractors/FHIRObservationExtractor.test.js
+++ b/test/extractors/FHIRObservationExtractor.test.js
@@ -36,7 +36,7 @@ describe('FHIRObservationExtractor', () => {
 
   describe('parametrizeArgsForFHIRModule', () => {
     test('should add category to param values', async () => {
-      const params = await extractor.parametrizeArgsForFHIRModule({ mrn: MOCK_MRN, context: MOCK_CONTEXT });
+      const params = await extractor.parametrizeArgsForFHIRModule({ context: MOCK_CONTEXT });
       expect(params).toHaveProperty('category');
       expect(params.category).toEqual(baseCategories);
     });

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -18,12 +18,12 @@ describe('getPatientFromContext', () => {
     ],
   };
   test('Should return Patient resource in context', () => {
-    const patient = getPatientFromContext(MOCK_PATIENT_MRN, patientContext);
+    const patient = getPatientFromContext(patientContext);
     expect(patient.id).toEqual(patientResource.id);
   });
 
   test('Should throw an error if there is no patient in context', () => {
-    expect(() => getPatientFromContext(MOCK_PATIENT_MRN, {})).toThrow('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
+    expect(() => getPatientFromContext({})).toThrow('Could not find a patient in context; ensure that a PatientExtractor is used earlier in your extraction configuration');
   });
 });
 


### PR DESCRIPTION
**NOTE: I've made the base-branch the current staging-context PR for the sake of readability; this needs to change before merging**

PR should remove any references to the MRN in calls to the `parametrizeArgsForFHIRModule` function. 

Testing should CTRL+F around for any missed instances of vestigial MRN's, and testing should ensure that (you guessed it) tests pass.