### PR TITLE
Parsing of 'not evaluated' status value in CDS extractor

### DIFF
--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -16,15 +16,14 @@ class CSVCancerDiseaseStatusExtractor {
     logger.debug('Reformatting disease status data from CSV into template format');
     // Check the shape of the data
     arrOfDiseaseStatusData.forEach((record) => {
-      if (!record.mrn || !record.conditionId || (!record.diseaseStatusCode && record.observationStatus !== 'not evaluated') || !record.dateOfObservation) {
+      if (!record.mrn || !record.conditionId || !record.diseaseStatusCode || !record.dateOfObservation) {
         throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, and dateOfObservation are required.');
       }
     });
     const evidenceDelimiter = '|';
     return arrOfDiseaseStatusData.map((record) => ({
       status: record.observationStatus || 'final',
-      // If the Disease Status was not evaluated, there will be no value to make a record of and this property will be null
-      value: record.observationStatus === 'not evaluated' ? null : {
+      value: {
         code: record.diseaseStatusCode,
         system: 'http://snomed.info/sct',
         display: record.diseaseStatusText ? record.diseaseStatusText : getDiseaseStatusDisplay(record.diseaseStatusCode, this.implementation),

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -16,7 +16,7 @@ class CSVCancerDiseaseStatusExtractor {
     logger.debug('Reformatting disease status data from CSV into template format');
     // Check the shape of the data
     arrOfDiseaseStatusData.forEach((record) => {
-      if (!(record.mrn && record.conditionId && record.diseaseStatusCode && record.dateOfObservation)) {
+      if (!record.mrn || !record.conditionId || (!record.diseaseStatusCode && record.observationStatus !== 'not-evaluated') || !record.dateOfObservation) {
         throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, and dateOfObservation are required.');
       }
     });

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -23,7 +23,7 @@ class CSVCancerDiseaseStatusExtractor {
     const evidenceDelimiter = '|';
     return arrOfDiseaseStatusData.map((record) => ({
       status: record.observationStatus || 'final',
-      value: {
+      value: record.observationStatus === 'not-evaluated' ? null : {
         code: record.diseaseStatusCode,
         system: 'http://snomed.info/sct',
         display: record.diseaseStatusText ? record.diseaseStatusText : getDiseaseStatusDisplay(record.diseaseStatusCode, this.implementation),

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -16,7 +16,7 @@ class CSVCancerDiseaseStatusExtractor {
     logger.debug('Reformatting disease status data from CSV into template format');
     // Check the shape of the data
     arrOfDiseaseStatusData.forEach((record) => {
-      if (!record.mrn || !record.conditionId || (!record.diseaseStatusCode && record.observationStatus !== 'not-evaluated') || !record.dateOfObservation) {
+      if (!record.mrn || !record.conditionId || (!record.diseaseStatusCode && record.observationStatus !== 'not evaluated') || !record.dateOfObservation) {
         throw new Error('DiseaseStatusData missing an expected property: mrn, conditionId, diseaseStatusCode, and dateOfObservation are required.');
       }
     });
@@ -24,7 +24,7 @@ class CSVCancerDiseaseStatusExtractor {
     return arrOfDiseaseStatusData.map((record) => ({
       status: record.observationStatus || 'final',
       // If the Disease Status was not evaluated, there will be no value to make a record of and this property will be null
-      value: record.observationStatus === 'not-evaluated' ? null : {
+      value: record.observationStatus === 'not evaluated' ? null : {
         code: record.diseaseStatusCode,
         system: 'http://snomed.info/sct',
         display: record.diseaseStatusText ? record.diseaseStatusText : getDiseaseStatusDisplay(record.diseaseStatusCode, this.implementation),

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -23,6 +23,7 @@ class CSVCancerDiseaseStatusExtractor {
     const evidenceDelimiter = '|';
     return arrOfDiseaseStatusData.map((record) => ({
       status: record.observationStatus || 'final',
+      // If the Disease Status was not evaluated, there will be no value to make a record of and this property will be null
       value: record.observationStatus === 'not-evaluated' ? null : {
         code: record.diseaseStatusCode,
         system: 'http://snomed.info/sct',

--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -29,9 +29,9 @@ function subjectTemplate({ subject }) {
   };
 }
 
-function valueTemplate(valueObj) {
-  if (valueObj === null) return { valueCodeableConcept: extensionArr(dataAbsentReasonExtension('not-asked')) };
-  return valueX(valueObj, 'valueCodeableConcept');
+function valueTemplate({ code, display, system }) {
+  if (code === '709137006') return { valueCodeableConcept: extensionArr(dataAbsentReasonExtension('not-asked')) };
+  return valueX({ code, display, system }, 'valueCodeableConcept');
 }
 
 function cancerDiseaseStatusTemplate({
@@ -43,7 +43,7 @@ function cancerDiseaseStatusTemplate({
   value,
   evidence,
 }) {
-  if (!id || !status || !effectiveDateTime || !condition || !subject || (!value && status !== 'not evaluated')) {
+  if (!id || !status || !effectiveDateTime || !condition || !subject || !value) {
     throw Error('Trying to render a CancerDiseaseStatusTemplate, but a required argument is missing; ensure that id, status, effectiveDateTime, condition, subject, and value are all present');
   }
 
@@ -56,7 +56,7 @@ function cancerDiseaseStatusTemplate({
       ],
     },
     ...extensionArr(...evidenceTemplate({ evidence })),
-    status: status === 'not evaluated' ? 'final' : status,
+    status,
     category: [
       {
         coding: [

--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -43,7 +43,7 @@ function cancerDiseaseStatusTemplate({
   value,
   evidence,
 }) {
-  if (!id || !status || !effectiveDateTime || !condition || !subject || (!value && status !== 'not-evaluated')) {
+  if (!id || !status || !effectiveDateTime || !condition || !subject || (!value && status !== 'not evaluated')) {
     throw Error('Trying to render a CancerDiseaseStatusTemplate, but a required argument is missing; ensure that id, status, effectiveDateTime, condition, subject, and value are all present');
   }
 
@@ -56,7 +56,7 @@ function cancerDiseaseStatusTemplate({
       ],
     },
     ...extensionArr(...evidenceTemplate({ evidence })),
-    status: status === 'not-evaluated' ? 'final' : status,
+    status: status === 'not evaluated' ? 'final' : status,
     category: [
       {
         coding: [

--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -1,4 +1,10 @@
-const { coding, extensionArr, reference, valueX, dataAbsentReasonExtension } = require('./snippets');
+const {
+  coding,
+  extensionArr,
+  reference,
+  valueX,
+  dataAbsentReasonExtension,
+} = require('./snippets');
 
 function evidenceTemplate({ evidence }) {
   if (!evidence || evidence.length === 0) return [];

--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -1,4 +1,4 @@
-const { coding, extensionArr, reference, valueX } = require('./snippets');
+const { coding, extensionArr, reference, valueX, dataAbsentReasonExtension } = require('./snippets');
 
 function evidenceTemplate({ evidence }) {
   if (!evidence || evidence.length === 0) return [];
@@ -23,6 +23,11 @@ function subjectTemplate({ subject }) {
   };
 }
 
+function valueTemplate(valueObj) {
+  if (valueObj === null) return { valueCodeableConcept: extensionArr(dataAbsentReasonExtension('not-asked')) };
+  return valueX(valueObj, 'valueCodeableConcept');
+}
+
 function cancerDiseaseStatusTemplate({
   id,
   status,
@@ -32,7 +37,7 @@ function cancerDiseaseStatusTemplate({
   value,
   evidence,
 }) {
-  if (!(id && status && effectiveDateTime && condition && subject && value)) {
+  if (!id || !status || !effectiveDateTime || !condition || !subject || (!value && status !== 'not-evaluated')) {
     throw Error('Trying to render a CancerDiseaseStatusTemplate, but a required argument is missing; ensure that id, status, effectiveDateTime, condition, subject, and value are all present');
   }
 
@@ -45,7 +50,7 @@ function cancerDiseaseStatusTemplate({
       ],
     },
     ...extensionArr(...evidenceTemplate({ evidence })),
-    status,
+    status: status === 'not-evaluated' ? 'final' : status,
     category: [
       {
         coding: [
@@ -70,7 +75,7 @@ function cancerDiseaseStatusTemplate({
     effectiveDateTime,
     ...focusTemplate({ condition }),
     ...subjectTemplate({ subject }),
-    ...valueX(value, 'valueCodeableConcept'),
+    ...valueTemplate(value),
   };
 }
 

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -36,13 +36,6 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       // Only including required properties is valid
       expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
 
-      // Excluding diseaseStatusCode with an obseervationStatus of 'not evaluated' should be valid
-      localData[0].observationStatus = 'not evaluated';
-      localData[0].diseaseStatusCode = '';
-      expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
-
-      localData[0].observationStatus = '';
-
       const requiredProperties = ['mrn', 'conditionId', 'diseaseStatusCode', 'dateOfObservation'];
 
       // Removing each required property should throw an error

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -36,8 +36,8 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       // Only including required properties is valid
       expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
 
-      // Excluding diseaseStatusCode with an obseervationStatus of 'not-evaluated' should be valid
-      localData[0].observationStatus = 'not-evaluated';
+      // Excluding diseaseStatusCode with an obseervationStatus of 'not evaluated' should be valid
+      localData[0].observationStatus = 'not evaluated';
       localData[0].diseaseStatusCode = '';
       expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
 

--- a/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
+++ b/test/extractors/CSVCancerDiseaseStatusExtractor.test.js
@@ -36,6 +36,13 @@ describe('CSVCancerDiseaseStatusExtractor', () => {
       // Only including required properties is valid
       expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
 
+      // Excluding diseaseStatusCode with an obseervationStatus of 'not-evaluated' should be valid
+      localData[0].observationStatus = 'not-evaluated';
+      localData[0].diseaseStatusCode = '';
+      expect(csvCancerDiseaseStatusExtractor.joinAndReformatData(localData)).toEqual(expect.anything());
+
+      localData[0].observationStatus = '';
+
       const requiredProperties = ['mrn', 'conditionId', 'diseaseStatusCode', 'dateOfObservation'];
 
       // Removing each required property should throw an error

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -44,8 +44,12 @@ describe('test CancerDiseaseStatus template', () => {
     const MINIMAL_DATA = {
       // Minimal amount of data to be accepted, evidence is excluded
       id: 'CancerDiseaseStatus-fixture',
-      status: 'not evaluated',
-      value: null,
+      status: 'final',
+      value: {
+        code: '709137006',
+        system: 'http://snomed.info/sct',
+        display: 'not evaluated',
+      },
       subject: {
         id: '123-example-patient',
         name: 'Mr. Patient Example',

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -44,12 +44,8 @@ describe('test CancerDiseaseStatus template', () => {
     const MINIMAL_DATA = {
       // Minimal amount of data to be accepted, evidence is excluded
       id: 'CancerDiseaseStatus-fixture',
-      status: 'final',
-      value: {
-        code: '385633008',
-        system: 'http://snomed.info/sct',
-        display: 'Improving',
-      },
+      status: 'not-evaluated',
+      value: null,
       subject: {
         id: '123-example-patient',
         name: 'Mr. Patient Example',

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -44,7 +44,7 @@ describe('test CancerDiseaseStatus template', () => {
     const MINIMAL_DATA = {
       // Minimal amount of data to be accepted, evidence is excluded
       id: 'CancerDiseaseStatus-fixture',
-      status: 'not-evaluated',
+      status: 'not evaluated',
       value: null,
       subject: {
         id: '123-example-patient',

--- a/test/templates/fixtures/minimal-disease-status-resource.json
+++ b/test/templates/fixtures/minimal-disease-status-resource.json
@@ -41,11 +41,10 @@
     },
     "effectiveDateTime" : "1994-12-09T09:07:00Z",
     "valueCodeableConcept": {
-      "coding": [
+      "extension": [
         {
-          "system": "http://snomed.info/sct",
-          "code": "385633008",
-          "display": "Improving"
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "not-asked"
         }
       ]
     }


### PR DESCRIPTION
# Summary
The CancerDiseaseStatusExtractor now excludes a `valueCodeableConcept` value from the resulting resource when a value corresponding to `not evaluated` is included in the diseaseStatusCode field.
## New behavior
When `709137006` (the code corresponding to `not evaluated`) is included in the diseaseStatusCode column of a CDS csv file, the CancerDiseaseStatusExtractor now populates the valueCodeableConcept element with a `dataAbsentReason` extension with a value of `not-asked`.
## Code changes
1. If the `value` object that is passed into the CancerDiseaseStatusTemplate from the extractor includes a `code` value of `709137006`, the template generates the `valueCodeableConcept` property with a `dataAbsentReason` extension.
2. The minimal extraction test case within the CancerDiseaseStatus template test file has been updated to test this new extraction scenario, with the `value` object corresponding to `not evaluated` and the resulting bundle having the `dataAbsentReason` extension.
# Testing guidance
Ensure that the updates to the CancerDiseaseStatusTemplate and its test file make sense. Also test that when including a `diseaseStatusCode` of '709137006' in the sample csv file, the resulting resource looks correct to you. Happy testing! 