### PR TITLE
Added optional trialResearchSystem column to ClinicalTrialInformationExtractor

### DIFF
--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -26,7 +26,9 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
     logger.debug('Reformatting clinical trial data from CSV into template format');
-    const { trialSubjectID, enrollmentStatus, trialResearchID, trialStatus } = clinicalTrialData;
+    const {
+      trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem = '',
+    } = clinicalTrialData;
     const { clinicalSiteID } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
@@ -40,11 +42,13 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
         trialSubjectID,
         trialResearchID,
         patientId,
+        trialResearchSystem,
       },
       formattedDataStudy: {
         trialStatus,
         trialResearchID,
         clinicalSiteID,
+        trialResearchSystem,
       },
     };
   }

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -26,17 +26,14 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
     logger.debug('Reformatting clinical trial data from CSV into template format');
-    let {
-      trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem,
-    } = clinicalTrialData;
+    const { trialSubjectID, enrollmentStatus, trialResearchID, trialStatus } = clinicalTrialData;
+    // since trialResearchSystem is optional, check for blank value and replace with default value
+    const trialResearchSystem = (clinicalTrialData.trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : clinicalTrialData.trialResearchSystem;
     const { clinicalSiteID } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
       throw new Error('Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.');
     }
-
-    //since trialResearchSystem is optional, check for blank value and replace with default value
-    trialResearchSystem = (trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : trialResearchSystem;
 
     // Need separate data objects for ResearchSubject and ResearchStudy so that they get different resource ids
     return {

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -26,14 +26,17 @@ class CSVClinicalTrialInformationExtractor extends Extractor {
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
     logger.debug('Reformatting clinical trial data from CSV into template format');
-    const {
-      trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem = '',
+    let {
+      trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem,
     } = clinicalTrialData;
     const { clinicalSiteID } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
       throw new Error('Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.');
     }
+
+    //since trialResearchSystem is optional, check for blank value and replace with default value
+    trialResearchSystem = (trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : trialResearchSystem;
 
     // Need separate data objects for ResearchSubject and ResearchStudy so that they get different resource ids
     return {

--- a/src/templates/ResearchStudyTemplate.js
+++ b/src/templates/ResearchStudyTemplate.js
@@ -14,9 +14,9 @@ function siteTemplate(clinicalSiteID) {
   };
 }
 
-function researchStudyIdentifierTemplate(trialResearchID) {
+function researchStudyIdentifierTemplate(trialResearchID, trialResearchSystem) {
   return identifierArr({
-    system: 'http://example.com/clinicaltrialids',
+    system: trialResearchSystem,
     type: {
       text: 'Clinical Trial Research ID',
     },
@@ -26,7 +26,9 @@ function researchStudyIdentifierTemplate(trialResearchID) {
 
 
 // Based on https://www.hl7.org/fhir/researchstudy.html
-function researchStudyTemplate({ id, trialStatus, trialResearchID, clinicalSiteID }) {
+function researchStudyTemplate({
+  id, trialStatus, trialResearchID, clinicalSiteID, trialResearchSystem,
+}) {
   if (!(id && trialStatus && trialResearchID && clinicalSiteID)) {
     throw Error('Trying to render a ResearchStudyTemplate, but a required argument is missing; ensure that id, trialStatus, trialResearchID, clinicalSiteID are all present');
   }
@@ -36,7 +38,7 @@ function researchStudyTemplate({ id, trialStatus, trialResearchID, clinicalSiteI
     id,
     status: trialStatus,
     ...siteTemplate(clinicalSiteID),
-    ...researchStudyIdentifierTemplate(trialResearchID),
+    ...researchStudyIdentifierTemplate(trialResearchID, trialResearchSystem),
   };
 }
 

--- a/src/templates/ResearchSubjectTemplate.js
+++ b/src/templates/ResearchSubjectTemplate.js
@@ -37,7 +37,7 @@ function researchSubjectTemplate({
   trialSubjectID,
   trialResearchID,
   patientId,
-  trialResearchSystem = 'http://example.com/clinicaltrialids',
+  trialResearchSystem,
 }) {
   if (!(id && enrollmentStatus && trialSubjectID && trialResearchID && patientId)) {
     throw Error('Trying to render a ResearchStudyTemplate, but a required argument is missing; ensure that id, trialStatus, trialResearchID, clinicalSiteID are all present');

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -37,6 +37,7 @@ describe('CSVClinicalTrialInformationExtractor', () => {
         const clonedData = _.cloneDeep(firstClinicalTrialInfoResponse);
         expect(csvClinicalTrialInformationExtractor.joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toEqual(expect.anything());
         if (key === 'mrn') return; // MRN is not required from CSV
+        if (key === 'trialResearchSystem') return; // trialResearchSystem is an optional field
         delete clonedData[key];
         expect(() => csvClinicalTrialInformationExtractor.joinClinicalTrialData(MOCK_PATIENT_MRN, clonedData)).toThrow(new Error(expectedErrorString));
       });
@@ -51,11 +52,13 @@ describe('CSVClinicalTrialInformationExtractor', () => {
           trialSubjectID: firstClinicalTrialInfoResponse.trialSubjectID,
           trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
           patientId: MOCK_PATIENT_MRN,
+          trialResearchSystem: firstClinicalTrialInfoResponse.trialResearchSystem,
         },
         formattedDataStudy: {
           trialStatus: firstClinicalTrialInfoResponse.trialStatus,
           trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
           clinicalSiteID: MOCK_CLINICAL_SITE_ID,
+          trialResearchSystem: firstClinicalTrialInfoResponse.trialResearchSystem,
         },
       });
     });

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:d528f1b04f5d3588ef80ca680fbc0f82b93e7c05eb08d293f698c7b075fc0b25",
+      "fullUrl": "urn:uuid:f8acc19f44696eea31532ac9d3b658f1fea317eba9455eddc78de0857220d362",
       "resource": {
         "resourceType": "ResearchSubject",
-        "id": "d528f1b04f5d3588ef80ca680fbc0f82b93e7c05eb08d293f698c7b075fc0b25",
+        "id": "f8acc19f44696eea31532ac9d3b658f1fea317eba9455eddc78de0857220d362",
         "identifier": [
           {
             "system": "http://example.com/clinicaltrialsubjectids",
@@ -17,7 +17,7 @@
         "status": "example-enrollment-status",
         "study": {
           "identifier": {
-            "system": "http://example.com/clinicaltrialids",
+            "system": "example-system",
             "value": "example-researchId"
           }
         },
@@ -25,10 +25,10 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:1b04fc751b08fd0e0b89293a0ccb61e931e6eeed87d88100fb0c3b15d0cf7fbb",
+      "fullUrl": "urn:uuid:b245aa8a67b5f67263f5a688813c435ccfb364e0f7865885c512e3a5ca3c9093",
       "resource": {
         "resourceType": "ResearchStudy",
-        "id": "1b04fc751b08fd0e0b89293a0ccb61e931e6eeed87d88100fb0c3b15d0cf7fbb",
+        "id": "b245aa8a67b5f67263f5a688813c435ccfb364e0f7865885c512e3a5ca3c9093",
         "status": "example-trialStatus",
         "site": [
           {
@@ -41,7 +41,7 @@
         ],
         "identifier": [
           {
-            "system": "http://example.com/clinicaltrialids",
+            "system": "example-system",
             "type": { "text": "Clinical Trial Research ID" },
             "value": "example-researchId"
           }

--- a/test/extractors/fixtures/csv-clinical-trial-information-module-response.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-module-response.json
@@ -4,6 +4,7 @@
     "trialSubjectID": "example-subjectId",
     "enrollmentStatus": "example-enrollment-status",
     "trialResearchID": "example-researchId",
-    "trialStatus": "example-trialStatus"
+    "trialStatus": "example-trialStatus",
+    "trialResearchSystem":"example-system"
   }
 ]

--- a/test/sample-client-data/clinical-trial-information.csv
+++ b/test/sample-client-data/clinical-trial-information.csv
@@ -1,4 +1,4 @@
 mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,trialResearchSystem
 123,subjectId-1,potential-candidate,researchId-1,approved,system-1
 456,subjectId-2,on-study-intervention,researchId-1,completed,system-2
-789,subjectId-3,on-study-observation,researchId-2,active,system-3
+789,subjectId-3,on-study-observation,researchId-2,active,

--- a/test/sample-client-data/clinical-trial-information.csv
+++ b/test/sample-client-data/clinical-trial-information.csv
@@ -1,4 +1,4 @@
-mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus
-123,subjectId-1,potential-candidate,researchId-1,approved
-456,subjectId-2,on-study-intervention,researchId-1,completed
-789,subjectId-3,on-study-observation,researchId-2,active
+mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,trialResearchSystem
+123,subjectId-1,potential-candidate,researchId-1,approved,system-1
+456,subjectId-2,on-study-intervention,researchId-1,completed,system-2
+789,subjectId-3,on-study-observation,researchId-2,active,system-3

--- a/test/templates/fixtures/research-study-resource.json
+++ b/test/templates/fixtures/research-study-resource.json
@@ -14,7 +14,7 @@
   "identifier": [
     {
       "value": "AFT1235",
-      "system": "http://example.com/clinicaltrialids",
+      "system": "example-system",
       "type": {
         "text": "Clinical Trial Research ID"
       }

--- a/test/templates/researchStudy.test.js
+++ b/test/templates/researchStudy.test.js
@@ -7,6 +7,7 @@ const VALID_DATA = {
   trialStatus: 'active',
   trialResearchID: 'AFT1235',
   clinicalSiteID: 'EXAMPLE_SITE_ID',
+  trialResearchSystem: 'example-system',
 };
 
 const INVALID_DATA = {


### PR DESCRIPTION
# Summary
ClinicalTrialInformationExtractor can now take an optional column for trialResearchSystem
## New behavior
ClinicalTrialInformationExtractor can now take an extra column for trialResearchSystem in it's CSV input. If the column is omitted from the CSV, the "system" field in the resulting study resource will also be omitted. The value can also be blank in any individual row of the CSV and the "system" field in the study resource will also be omitted
## Code changes
1. Changed CSVClinicalTrialInformationExtractor.js to take the new field, defaulting to no value if it isn't provided. Since the field is optional, it won't throw an error if it is missing
2. Changed ResearchStudyTemplate.js and ResearchSubjectTemplate.js to take in trialReseachSystem as a parameter, previously they just had hard coded default values
3. Changed CSVClinicalTrialInformationExtractor.test.js and associated files to reflect changes described above
# Testing guidance
I've changed the sample data csv (clinical-trial-information.csv) to have values for trialResearchSystem for each sample patient, but as mentioned above, any row can have a blank value for this or the entire column can be omitted.