### PR TITLE
Fixes the CDS lookup to distinguish between `undetermined` and `not evaluated`

### DIFF
--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -17,7 +17,7 @@ function mEpochToDate(date) {
 
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
- * @param {string} text - limited to keys in the DiseaseStatusTextToCodeLookup's above
+ * @param {string} text - limited to keys in the DiseaseStatusTextToCodeLookups above
  * @return {code} corresponding DiseaseStatus code
  */
 function getDiseaseStatusCode(text, implementation) {
@@ -31,7 +31,7 @@ function getDiseaseStatusCode(text, implementation) {
 
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
- * @param {string} code - limited to keys in the DiseaseStatusCodeToTextLookup's above
+ * @param {string} code - limited to keys in the DiseaseStatusCodeToTextLookups above
  * @return {string} corresponding DiseaseStatus display text
  */
 function getDiseaseStatusDisplay(code, implementation) {

--- a/src/helpers/diseaseStatusUtils.js
+++ b/src/helpers/diseaseStatusUtils.js
@@ -17,7 +17,7 @@ function mEpochToDate(date) {
 
 /**
  * Converts Text Value to code in mCODE's ConditionStatusTrendVS
- * @param {string} text, limited to 'no evidence of disease', Responding, Stable, Progressing, or 'not evaluated'
+ * @param {string} text - limited to keys in the DiseaseStatusTextToCodeLookup's above
  * @return {code} corresponding DiseaseStatus code
  */
 function getDiseaseStatusCode(text, implementation) {
@@ -31,7 +31,7 @@ function getDiseaseStatusCode(text, implementation) {
 
 /**
  * Converts code in mCODE's ConditionStatusTrendVS to Text Value
- * @param {string} code - limited to codes in the diseaseStatusTextToCodeLookup above
+ * @param {string} code - limited to keys in the DiseaseStatusCodeToTextLookup's above
  * @return {string} corresponding DiseaseStatus display text
  */
 function getDiseaseStatusDisplay(code, implementation) {
@@ -45,7 +45,7 @@ function getDiseaseStatusDisplay(code, implementation) {
 
 /**
  * Converts Text Value to code in mCODE's CancerDiseaseStatusEvidenceTypeVS
- * @param {string} text - limited to imaging, pathology, symptoms, 'physical exam', 'lab results'
+ * @param {string} text - limited to keys in the evidenceTextToCodeLookup
  * @return {string} corresponding Evidence code
  */
 function getDiseaseStatusEvidenceCode(text) {
@@ -54,7 +54,7 @@ function getDiseaseStatusEvidenceCode(text) {
 
 /**
  * Converts code in mCODE's CancerDiseaseStatusEvidenceTypeVS to Text Value
- * @param {string} code - limited to codes in the evidenceTextToCodeLookup above
+ * @param {string} code - limited to keys in the evidenceTextToCodeLookup above
  * @return {string} corresponding Evidence display text
  */
 function getDiseaseStatusEvidenceDisplay(code) {

--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -17,7 +17,8 @@ const icareDiseaseStatusTextToCodeLookup = {
   responding: '268910001',
   stable: '359746009',
   progressing: '271299001',
-  'not evaluated': '709137006',
+  'undetermined': '709137006',
+  'not evaluated': 'not-asked',
 };
 const icareDiseaseStatusCodeToTextLookup = createInvertedLookup(icareDiseaseStatusTextToCodeLookup);
 

--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -17,7 +17,7 @@ const icareDiseaseStatusTextToCodeLookup = {
   responding: '268910001',
   stable: '359746009',
   progressing: '271299001',
-  'undetermined': '709137006',
+  undetermined: '709137006',
   'not evaluated': 'not-asked',
 };
 const icareDiseaseStatusCodeToTextLookup = createInvertedLookup(icareDiseaseStatusTextToCodeLookup);

--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -30,7 +30,8 @@ function subjectTemplate({ subject }) {
 }
 
 function valueTemplate({ code, display, system }) {
-  if (code === '709137006') return { valueCodeableConcept: extensionArr(dataAbsentReasonExtension('not-asked')) };
+  // not-asked indicates absent data
+  if (code === 'not-asked') return { valueCodeableConcept: extensionArr(dataAbsentReasonExtension(code)) };
   return valueX({ code, display, system }, 'valueCodeableConcept');
 }
 

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -22,7 +22,8 @@ const icareDiseaseStatusTextToCodeLookup = {
   responding: '268910001',
   stable: '359746009',
   progressing: '271299001',
-  'not evaluated': '709137006',
+  undetermined: '709137006',
+  'not evaluated': 'not-asked',
 };
 
 // Code mapping is based on http://standardhealthrecord.org/guides/icare/mapping_guidance.html

--- a/test/sample-client-data/cancer-disease-status-information.csv
+++ b/test/sample-client-data/cancer-disease-status-information.csv
@@ -2,3 +2,4 @@ mrn,conditionId,diseaseStatusCode,diseaseStatusText,dateOfObservation,evidence,o
 123,conditionId-1,268910001,responding,2019-12-02,363679005|252416005,preliminary,2020-01-10
 456,conditionId-2,359746009,stable,2020-01-12,363679005,amended,2020-01-12
 789,conditionId-2,709137006,not evaluated,2020-04-22,,final,2020-06-10
+123,conditionId-1,not-asked,,2020-01-12,,,

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -48,7 +48,7 @@ describe('test CancerDiseaseStatus template', () => {
       value: {
         code: '709137006',
         system: 'http://snomed.info/sct',
-        display: 'not evaluated',
+        display: 'undetermined',
       },
       subject: {
         id: '123-example-patient',
@@ -66,6 +66,38 @@ describe('test CancerDiseaseStatus template', () => {
 
     // Relevant fields should match the valid FHIR
     expect(generatedDiseaseStatus).toEqual(minimalCancerDiseaseStatus);
+    expect(isValidFHIR(generatedDiseaseStatus)).toBeTruthy();
+  });
+
+  test('valid data where cds-status is not not-asked generates a dataAbsentReason', () => {
+    const MINIMAL_DATA = {
+      // Minimal amount of data to be accepted, evidence is excluded
+      id: 'CancerDiseaseStatus-fixture',
+      status: 'final',
+      value: {
+        code: 'not-asked',
+      },
+      subject: {
+        id: '123-example-patient',
+        name: 'Mr. Patient Example',
+      },
+      condition: {
+        id: '123-Walking-Corpse-Syndrome',
+        name: 'Walking Corpse Syndrome',
+      },
+      effectiveDateTime: '1994-12-09T09:07:00Z',
+      evidence: null,
+    };
+
+    const generatedDiseaseStatus = cancerDiseaseStatusTemplate(MINIMAL_DATA);
+
+    // CDS should have an extension
+    expect(generatedDiseaseStatus).toHaveProperty('valueCodeableConcept.extension');
+    // CDS should have an extension url of dataAbsentReason
+    expect(generatedDiseaseStatus).toHaveProperty(['valueCodeableConcept', 'extension', 0, 'url'], 'http://hl7.org/fhir/StructureDefinition/data-absent-reason');
+    // CDS should have an extension valueCode of not-asked
+    expect(generatedDiseaseStatus).toHaveProperty(['valueCodeableConcept', 'extension', 0, 'valueCode'], 'not-asked');
+    // CDS should be valid
     expect(isValidFHIR(generatedDiseaseStatus)).toBeTruthy();
   });
 

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -69,7 +69,7 @@ describe('test CancerDiseaseStatus template', () => {
     expect(isValidFHIR(generatedDiseaseStatus)).toBeTruthy();
   });
 
-  test('valid data where cds-status is not not-asked generates a dataAbsentReason', () => {
+  test('when provided data where cds-status value is `not-asked`, the template generates a dataAbsentReason', () => {
     const MINIMAL_DATA = {
       // Minimal amount of data to be accepted, evidence is excluded
       id: 'CancerDiseaseStatus-fixture',

--- a/test/templates/cancerDiseaseStatus.test.js
+++ b/test/templates/cancerDiseaseStatus.test.js
@@ -93,11 +93,11 @@ describe('test CancerDiseaseStatus template', () => {
 
     // CDS should have an extension
     expect(generatedDiseaseStatus).toHaveProperty('valueCodeableConcept.extension');
-    // CDS should have an extension url of dataAbsentReason
+    // CDS should have an extension url pointing to the FHIR DataAbsentReason structure def
     expect(generatedDiseaseStatus).toHaveProperty(['valueCodeableConcept', 'extension', 0, 'url'], 'http://hl7.org/fhir/StructureDefinition/data-absent-reason');
     // CDS should have an extension valueCode of not-asked
     expect(generatedDiseaseStatus).toHaveProperty(['valueCodeableConcept', 'extension', 0, 'valueCode'], 'not-asked');
-    // CDS should be valid
+    // CDS should be valid FHIR
     expect(isValidFHIR(generatedDiseaseStatus)).toBeTruthy();
   });
 

--- a/test/templates/fixtures/minimal-disease-status-resource.json
+++ b/test/templates/fixtures/minimal-disease-status-resource.json
@@ -1,52 +1,52 @@
 {
-    "resourceType": "Observation",
-    "id": "CancerDiseaseStatus-fixture",
-    "meta": {
-      "profile": [
-        "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
-      ]
-    },
-    "category": [
-      {
-        "coding": [
-          {
-            "system": "http://terminology.hl7.org/CodeSystem/observation-category",
-            "code": "therapy",
-            "display": "Therapy"
-          }
-        ]
-      }
-    ],
-    "status": "final",
-    "code": {
+  "resourceType": "Observation",
+  "id": "CancerDiseaseStatus-fixture",
+  "meta": {
+    "profile": [
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
+    ]
+  },
+  "category": [
+    {
       "coding": [
         {
-          "system": "http://loinc.org",
-          "code": "88040-1",
-          "display": "Response to cancer treatment"
-        }
-      ]
-    },
-    "focus" : [
-      {
-        "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
-        "display": "Walking Corpse Syndrome",
-        "type": "Condition"
-      }
-    ],
-    "subject": {
-      "reference": "urn:uuid:123-example-patient",
-      "display": "Mr. Patient Example",
-      "type": "Patient"
-    },
-    "effectiveDateTime" : "1994-12-09T09:07:00Z",
-    "valueCodeableConcept": {
-      "extension": [
-        {
-          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
-          "valueCode": "not-asked"
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "code": "therapy",
+          "display": "Therapy"
         }
       ]
     }
+  ],
+  "status": "final",
+  "code": {
+    "coding": [
+      {
+        "system": "http://loinc.org",
+        "code": "88040-1",
+        "display": "Response to cancer treatment"
+      }
+    ]
+  },
+  "focus": [
+    {
+      "reference": "urn:uuid:123-Walking-Corpse-Syndrome",
+      "display": "Walking Corpse Syndrome",
+      "type": "Condition"
+    }
+  ],
+  "subject": {
+    "reference": "urn:uuid:123-example-patient",
+    "display": "Mr. Patient Example",
+    "type": "Patient"
+  },
+  "effectiveDateTime": "1994-12-09T09:07:00Z",
+  "valueCodeableConcept": {
+    "coding": [
+      {
+        "code": "709137006",
+        "display": "undetermined",
+        "system": "http://snomed.info/sct"
+      }
+    ]
   }
-  
+}


### PR DESCRIPTION
Pretty straightforward. This work fixes a previous oversight in our CDS lookup object, fixing one of our k-v pairs and adding a new one for `not evaluated: not-asked`. I had to make minor adjustments to our CDS-dataAbsentReason logic, so that our Template managed these new. codes appropriately. I've also added a new test to check for dataAbsentReason specific properties.

Addl changes: 
- Changed a few comments in `diseaseStatusUtils.js`, but those are tangentially related to the main task. 


Note: Also looks like more changes were made to `minimal-disease-status-resource.json` then actually were because of linting disparities. C'est la vie. 

**One Assignee should be sufficient**