### PR TITLE
Fixed hasChanged check within carePlanChangeReasonExtensionTemplate

### DIFF
--- a/src/templates/CarePlanWithReviewTemplate.js
+++ b/src/templates/CarePlanWithReviewTemplate.js
@@ -30,7 +30,7 @@ function carePlanReasonTemplate({ reasonCode, reasonDisplayText }) {
 }
 
 function carePlanChangeReasonExtensionTemplate({ hasChanged, reasonCode, reasonDisplayText, effectiveDate }) {
-  if (hasChanged === undefined || !effectiveDate) {
+  if (hasChanged === null || !effectiveDate) {
     const errorMessage = 'Trying to render a CarePlanWithReviewTemplate, but a review was missing required fields; '
       + 'ensure that hasChanged and effectiveDate are present on all reviews';
     throw new Error(errorMessage);

--- a/test/templates/carePlanWithReview.test.js
+++ b/test/templates/carePlanWithReview.test.js
@@ -103,11 +103,17 @@ describe('JavaScript render CarePlan template', () => {
       mrn: 'abc-def',
       reviews: [{
         effectiveDate: '2020-01-23',
-        haschanged: null,
+        hasChanged: null,
       }],
     };
 
     expect(() => carePlanWithReviewTemplate(INVALID_DATA)).toThrow(Error);
-    expect(() => carePlanWithReviewTemplate(INVALID_REVIEW_DATA)).toThrow(Error);
+
+    // A null hasChanged value should cause a specific error to be thrown, an undefined hasChanged value should not
+    const hasChangedError = 'Trying to render a CarePlanWithReviewTemplate, but a review was missing required fields; ensure that hasChanged and effectiveDate are present on all reviews';
+    expect(() => carePlanWithReviewTemplate(INVALID_REVIEW_DATA)).toThrowError(hasChangedError);
+
+    INVALID_REVIEW_DATA.reviews[0].hasChanged = undefined;
+    expect(() => carePlanWithReviewTemplate(INVALID_REVIEW_DATA)).not.toThrowError(hasChangedError);
   });
 });


### PR DESCRIPTION
# Summary
The conditional which throws an error if the `hasChanged` element is missing from a review now checks for a `null` value rather than an `undefined` value. 
## New behavior
No new behavior.
## Code changes
1. The conditional within the `carePlanChangeReasonExtensionTemplate` has been updated to check for a `null` value.
2. The missing data test within the carePlanWithReview template test file has been updated to check for the relevant `hasChanged` error explicitly, rather than checking that an error was thrown generally.
# Testing guidance
Ensure that the change to the care plan template tests make sense, as no new behavior should be introduced in this PR.