### PR TITLE
Adding ability to mask fields in Patient resource

### DIFF
--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -63,7 +63,7 @@ class CSVPatientExtractor extends BaseCSVExtractor {
     const bundle = generateMcodeResources('Patient', packagedPatientData);
 
     // mask fields in the patient data if specified in mask array
-    maskPatientData(bundle, this.mask);
+    if (this.mask.length > 0) maskPatientData(bundle, this.mask);
     return bundle;
   }
 }

--- a/src/extractors/FHIRPatientExtractor.js
+++ b/src/extractors/FHIRPatientExtractor.js
@@ -18,7 +18,7 @@ class FHIRPatientExtractor extends BaseFHIRExtractor {
 
   async get(argumentObject) {
     const bundle = await super.get(argumentObject);
-    maskPatientData(bundle, this.mask);
+    if (this.mask.length > 0) maskPatientData(bundle, this.mask);
     return bundle;
   }
 }

--- a/src/extractors/FHIRPatientExtractor.js
+++ b/src/extractors/FHIRPatientExtractor.js
@@ -1,9 +1,11 @@
 const { BaseFHIRExtractor } = require('./BaseFHIRExtractor');
+const { maskPatientData } = require('../helpers/patientUtils.js');
 
 class FHIRPatientExtractor extends BaseFHIRExtractor {
-  constructor({ baseFhirUrl, requestHeaders, version }) {
+  constructor({ baseFhirUrl, requestHeaders, version, mask = [] }) {
     super({ baseFhirUrl, requestHeaders, version });
     this.resourceType = 'Patient';
+    this.mask = mask;
   }
 
   // Override default behavior for PatientExtractor; just use MRN directly
@@ -12,6 +14,12 @@ class FHIRPatientExtractor extends BaseFHIRExtractor {
     return {
       identifier: `MRN|${mrn}`,
     };
+  }
+
+  async get(argumentObject) {
+    const bundle = await super.get(argumentObject);
+    maskPatientData(bundle, this.mask);
+    return bundle;
   }
 }
 

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -91,8 +91,7 @@ function maskPatientData(bundle, mask) {
 
   mask.forEach((field) => {
     if (!validFields.includes(field)) {
-      throw Error(`'${field}' is not a field that can be masked. Patient will only be extracted if all mask fields are valid. \
-      Valid fields include: 'gender','mrn','name','address','birthDate','language','ethnicity','birthsex','race'`);
+      throw Error(`'${field}' is not a field that can be masked. Patient will only be extracted if all mask fields are valid. Valid fields include: Valid fields include: ${validFields.join(', ')}`);
     }
     // must check if the field exists in the patient resource, so we don't add unnecessary dataAbsent extensions
     if (field === 'gender' && 'gender' in patient) {

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -69,7 +69,7 @@ function getRaceDisplay(code) {
  * @return {string} concatenated string of name values
  */
 function getPatientName(name) {
-  return `${name[0].given.join(' ')} ${name[0].family}`;
+  return ('extension' in name[0]) ? 'masked' : `${name[0].given.join(' ')} ${name[0].family}`;
 }
 
 /**

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -91,7 +91,8 @@ function maskPatientData(bundle, mask) {
 
   mask.forEach((field) => {
     if (!validFields.includes(field)) {
-      throw Error(`'${field}' is not a field that can be masked. Valid fields include: 'gender','mrn','name','address','birthDate','language','ethnicity','birthsex','race'`);
+      throw Error(`'${field}' is not a field that can be masked. Patient will only be extracted if all mask fields are valid. \
+      Valid fields include: 'gender','mrn','name','address','birthDate','language','ethnicity','birthsex','race'`);
     }
     // must check if the field exists in the patient resource, so we don't add unnecessary dataAbsent extensions
     if (field === 'gender' && 'gender' in patient) {

--- a/test/helpers/fixtures/masked-patient-bundle.json
+++ b/test/helpers/fixtures/masked-patient-bundle.json
@@ -1,0 +1,138 @@
+{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:119147111821125",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "119147111821125",
+                "identifier": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                "valueCode": "masked"
+                            }
+                        ]
+                    }
+                ],
+                "name": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                "valueCode": "masked"
+                            }
+                        ]
+                    }
+                ],
+                "address": [
+                    {
+                        "extension": [
+                            {
+                                "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                "valueCode": "masked"
+                            }
+                        ]
+                    }
+                ],
+                "communication": [
+                    {
+                        "language": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                    "valueCode": "masked"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "extension": [
+                    {
+                        "extension": [
+                            {
+                                "url": "ombCategory",
+                                "valueCoding": {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                            "valueCode": "masked"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "text",
+                                "_valueString": {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                            "valueCode": "masked"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+                    },
+                    {
+                        "extension": [
+                            {
+                                "url": "ombCategory",
+                                "valueCoding": {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                            "valueCode": "masked"
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "url": "text",
+                                "_valueString": {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                            "valueCode": "masked"
+                                        }
+                                    ]
+                                }
+                            }
+                        ],
+                        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+                    },
+                    {
+                        "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+                        "_valueCode": {
+                            "extension": [
+                                {
+                                    "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                                    "valueCode": "masked"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "_gender": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                            "valueCode": "masked"
+                        }
+                    ]
+                },
+                "_birthDate": {
+                    "extension": [
+                        {
+                            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                            "valueCode": "masked"
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -1,5 +1,9 @@
-const { getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName } = require('../../src/helpers/patientUtils');
-
+const _ = require('lodash');
+const {
+  getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName, maskPatientData,
+} = require('../../src/helpers/patientUtils');
+const examplePatient = require('../extractors/fixtures/csv-patient-bundle.json');
+const exampleMaskedPatient = require('./fixtures/masked-patient-bundle.json');
 
 describe('PatientUtils', () => {
   describe('getEthnicityDisplay', () => {
@@ -77,6 +81,24 @@ describe('PatientUtils', () => {
       }];
       const expectedConcatenatedName = 'Peter Christen Asbjørnsen';
       expect(getPatientName(name)).toBe(expectedConcatenatedName);
+    });
+  });
+  describe('maskPatientData', () => {
+    test('bundle should remain the same if no fields are specified to be masked', () => {
+      const bundle = _.cloneDeep(examplePatient);
+      maskPatientData(bundle, []);
+      expect(bundle).toEqual(examplePatient);
+    });
+
+    test('bundle should be modified to have dataAbsentReason for all fields specified in mask', () => {
+      const bundle = _.cloneDeep(examplePatient);
+      maskPatientData(bundle, ['gender', 'mrn', 'name', 'address', 'birthDate', 'language', 'ethnicity', 'birthsex', 'race']);
+      expect(bundle).toEqual(exampleMaskedPatient);
+    });
+
+    test('should throw error when provided an invalid field to mask', () => {
+      const bundle = _.cloneDeep(examplePatient);
+      expect(() => maskPatientData(bundle, ['this is an invalid field', 'mrn'])).toThrowError();
     });
   });
 });


### PR DESCRIPTION
# Summary
A set number of fields can now be specified to be masked with dataAbsentReason extensions in a Patient resource

## New behavior
The CSV Patient Extractor and FHIR Patient Extractor can now take an optional constructor argument "mask", which is an array containing any number of fields that are capable of being masked. The specified fields will have their values replaced by dataAbsentReason extensions with the code 'masked'. The fields that can currently be masked are any values the CSV Patient Extractor can take as input (currently "gender", "mrn", "name", "address", "birthDate", "language", "ethnicity", "birthsex" and "race")

## Code changes
- `patientUtils.js` now has a function called `maskPatientData` that takes a FHIR bundle with a Patient resource and an array of fields to mask. maskPatientData will modify the bundle to have dataAbesentReason extensions where necessary 
- `CSVPatientExtractor.js` and `FHIRPatientExtractor.js` now take an optional argument of a 'mask' array and call `maskPatientData` with the mask array as the last step of the extraction process.
- `patientUtils.test.js` now contains tests for `maskPatientData`

# Testing guidance
- Ensure that maskPatientData masks specified fields with proper extensions
- Ensure the output is still a valid FHIR bundle
- Test the functionality on both the MEF and E-MEF
- Check that the new tests pass and test a sufficient number of cases

# Example config:
For mcode-extraction-framework:
`"extractors": [
    {
      "label": "patient",
      "type": "CSVPatientExtractor",
      "constructorArgs": {
        "filePath": "./test/sample-client-data/patient-information.csv",
        "mask": ["gender","mrn","name","address","birthDate","language","ethnicity","birthsex","race"]
      }
    }
  ]`
For epic-mcode-extraction-framework:
`"extractors": [
    {
      "label": "patientExtractor",
      "type": "FHIRPatientExtractor",
      "constructorArgs": {
        "mask": ["gender","mrn","name","address","birthDate","language","ethnicity","birthsex","race"]
      }
    }
  ]`
(In both configs `mask` contains all possible fields, feel free to try any combination)