### PR TITLE
Removed default value for trialResearchSystem in ClinicalTrialInformationExtractor

### DIFF
--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -27,8 +27,6 @@ class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
     const {
       trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem,
     } = clinicalTrialData;
-    // since trialResearchSystem is optional, check for blank value and replace with default value
-    // const trialResearchSystem = (clinicalTrialData.trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : clinicalTrialData.trialResearchSystem;
     const { clinicalSiteID } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -24,9 +24,11 @@ class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
     logger.debug('Reformatting clinical trial data from CSV into template format');
-    const { trialSubjectID, enrollmentStatus, trialResearchID, trialStatus } = clinicalTrialData;
+    const {
+      trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem,
+    } = clinicalTrialData;
     // since trialResearchSystem is optional, check for blank value and replace with default value
-    const trialResearchSystem = (clinicalTrialData.trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : clinicalTrialData.trialResearchSystem;
+    // const trialResearchSystem = (clinicalTrialData.trialResearchSystem === '') ? 'http://example.com/clinicaltrialids' : clinicalTrialData.trialResearchSystem;
     const { clinicalSiteID } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {


### PR DESCRIPTION
# Summary
trialResearchSystem will no longer default to an "example.com" value when not provided in the CSV
## New behavior
When no trialResearchSystem is provided in the CSV, the 'system' field will be omitted instead of given a default value
## Code changes
CSVClinicalTrialInformationExtractor.js no longer assigns an 'example.com' default value to trialResearchSystem
# Testing guidance
- Make sure that when no trialResearchSystem is provided, the resulting ResearchStudy has an identifier with no 'system' field
- Make sure the extractor still works as expected otherwise and tests still pass