### PR TITLE
Create default log file if one does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If the `notificationInfo` object is provided in configuration, an email will be 
 
 ### Logging Successful Extractions
 
-Whenever the mCODE Extraction Client successfully runs with the `--entries-filter` flag, a log is kept of the given date range of the extraction. The default location of the log is in a `logs` directory in a file called `run-logs.json`. If there is no log file at that location, the file will be created the firt time the user runs the program with the `--entries-filter` flag.
+Whenever the mCODE Extraction Client successfully runs with the `--entries-filter` flag, a log is kept of the given date range of the extraction. The default location of the log is in a `logs` directory in a file called `run-logs.json`. If there is no log file at that location, the file will be created the first time the user runs the program with the `--entries-filter` flag.
 
 Users can specify a different location for the file by using the `--run-log-filepath <path>` CLI option. Users will need to create this file before running the mCODE Extraction Client with `--entries-filter` and a date range. Initially, this file's contents should be an empty array, `[]`. For example:
 

--- a/README.md
+++ b/README.md
@@ -120,12 +120,12 @@ If the `notificationInfo` object is provided in configuration, an email will be 
 
 ### Logging Successful Extractions
 
-Whenever the mCODE Extraction Client successfully runs, a log is kept of the given date range of the extraction. Users will need to specify the location of the file to save this information. The default location is in a `logs` directory in a file called `run-logs.json`. Initially, this file's contents should be an empty array, `[]`. Users will need to create this file before running the mCODE Extraction Client with `from-date` and/or `to-date` for the first time.
+Whenever the mCODE Extraction Client successfully runs with the `--entries-filter` flag, a log is kept of the given date range of the extraction. The default location of the log is in a `logs` directory in a file called `run-logs.json`. If there is no log file at that location, the file will be created the firt time the user runs the program with the `--entries-filter` flag.
 
-Users can specify a different location for the file by using the `--run-log-filepath <path>` CLI option. For example:
+Users can specify a different location for the file by using the `--run-log-filepath <path>` CLI option. Users will need to create this file before running the mCODE Extraction Client with `--entries-filter` and a date range. Initially, this file's contents should be an empty array, `[]`. For example:
 
 ```bash
-node src/cli/cli.js --run-log-filepath path/to/file.json
+node src/cli/cli.js --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --run-log-filepath path/to/file.json
 ```
 
 ### Masking Patient Data

--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -38,6 +38,12 @@ function checkInputAndConfig(config, fromDate, toDate) {
 }
 
 function checkLogFile(pathToLogs) {
+  // If no custom log file was specified and no default log file exists, create one
+  if (pathToLogs === path.join('logs', 'run-logs.json') && !fs.existsSync(pathToLogs)) {
+    logger.info(`No log file found. Creating default log file at ${pathToLogs}`);
+    if (!fs.existsSync('logs')) fs.mkdirSync('logs');
+    fs.appendFileSync(pathToLogs, '[]');
+  }
   // Check that the given log file exists
   try {
     const logFileContent = JSON.parse(fs.readFileSync(pathToLogs));


### PR DESCRIPTION
# Summary
If a log file does not exist and no custom log file is specified, a new file is created at the default location.
## New behavior
When running the program with the `--entries-filter` flag, if no log file exists at `logs/run-logs.json`, then the file is created and initialized with an empty array. This won't happen if a custom log file is specified.
## Code changes
- `checkLogFile` function in `app.js` now creates a default log file if one doesn't exist.
- `README.md` has been updated to better reflect the logging functionality
# Testing guidance
- Test that a log file is created when there is no file at `logs/run-logs.json`
- Example command to run: `node src/cli/cli.js -e -f 2019-01-01 -t 2021-01-01`
- Test that specifying a custom log file still works as it should
- Make sure the changes to the README accurately reflect how logging works