### PR TITLE
Mask MRN when used as the ID of a Patient resource

### DIFF
--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -113,7 +113,7 @@ async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     // check if config specifies that MRN needs to be masked
     // if it does need to be masked, mask all references to MRN outside of the patient resource
     const patientConfig = config.extractors.find((e) => e.type === 'CSVPatientExtractor');
-    if ('constructorArgs' in patientConfig && 'mask' in patientConfig.constructorArgs) {
+    if (patientConfig && ('constructorArgs' in patientConfig && 'mask' in patientConfig.constructorArgs)) {
       if (patientConfig.constructorArgs.mask.includes('mrn')) {
         extractedData.forEach((bundle) => {
           maskMRN(bundle);

--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -112,7 +112,7 @@ async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
 
     // check if config specifies that MRN needs to be masked
     // if it does need to be masked, mask all references to MRN outside of the patient resource
-    const patientConfig = config.extractors.filter((e) => e.type === 'CSVPatientExtractor')[0];
+    const patientConfig = config.extractors.find((e) => e.type === 'CSVPatientExtractor');
     if ('constructorArgs' in patientConfig && 'mask' in patientConfig.constructorArgs) {
       if (patientConfig.constructorArgs.mask.includes('mrn')) {
         extractedData.forEach((bundle) => {

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -164,9 +164,9 @@ function maskMRN(bundle) {
   patient.resource.id = masked;
   const subjects = fhirpath.evaluate(bundle, `Bundle.entry.resource.subject.where(reference='urn:uuid:${mrn}')`);
   const individuals = fhirpath.evaluate(bundle, `Bundle.entry.resource.individual.where(reference='urn:uuid:${mrn}')`);
-  const mrnOccurances = subjects.concat(individuals);
-  for (let i = 0; i < mrnOccurances.length; i += 1) {
-    mrnOccurances[i].reference = `urn:uuid:${masked}`;
+  const mrnOccurrances = subjects.concat(individuals);
+  for (let i = 0; i < mrnOccurrances.length; i += 1) {
+    mrnOccurrances[i].reference = `urn:uuid:${masked}`;
   }
 }
 

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -164,9 +164,9 @@ function maskMRN(bundle) {
   patient.resource.id = masked;
   const subjects = fhirpath.evaluate(bundle, `Bundle.entry.resource.subject.where(reference='urn:uuid:${mrn}')`);
   const individuals = fhirpath.evaluate(bundle, `Bundle.entry.resource.individual.where(reference='urn:uuid:${mrn}')`);
-  const mrnOccurrances = subjects.concat(individuals);
-  for (let i = 0; i < mrnOccurrances.length; i += 1) {
-    mrnOccurrances[i].reference = `urn:uuid:${masked}`;
+  const mrnOccurrences = subjects.concat(individuals);
+  for (let i = 0; i < mrnOccurrences.length; i += 1) {
+    mrnOccurrences[i].reference = `urn:uuid:${masked}`;
   }
 }
 

--- a/test/helpers/fixtures/bundle-with-mrn-id.json
+++ b/test/helpers/fixtures/bundle-with-mrn-id.json
@@ -1,0 +1,30 @@
+{
+    "resourceType": "Bundle",
+    "type": "collection",
+    "entry": [
+        {
+            "fullUrl": "urn:uuid:123",
+            "resource": {
+                "resourceType": "Patient",
+                "id": "123"
+                
+            }
+        },
+        {
+            "resource": {
+                "subject": {
+                    "reference": "urn:uuid:123",
+                    "type": "Patient"
+                }
+            }
+        },
+        {
+            "resource": {
+                "individual": {
+                    "reference": "urn:uuid:123",
+                    "type": "Patient"
+                }
+            }
+        }
+    ]
+}

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -1,9 +1,11 @@
 const _ = require('lodash');
+const shajs = require('sha.js');
 const {
-  getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName, maskPatientData,
+  getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName, maskPatientData, maskMRN,
 } = require('../../src/helpers/patientUtils');
 const examplePatient = require('../extractors/fixtures/csv-patient-bundle.json');
 const exampleMaskedPatient = require('./fixtures/masked-patient-bundle.json');
+const exampleBundleWithMRN = require('./fixtures/bundle-with-mrn-id.json');
 
 describe('PatientUtils', () => {
   describe('getEthnicityDisplay', () => {
@@ -99,6 +101,20 @@ describe('PatientUtils', () => {
     test('should throw error when provided an invalid field to mask', () => {
       const bundle = _.cloneDeep(examplePatient);
       expect(() => maskPatientData(bundle, ['this is an invalid field', 'mrn'])).toThrowError();
+    });
+  });
+  describe('maskMRN', () => {
+    test('all occurances of the MRN as an id should be masked by a hashed version', () => {
+      const bundle = _.cloneDeep(exampleBundleWithMRN);
+      const hashedMRN = shajs('sha256').update(bundle.entry[0].resource.id).digest('hex');
+      maskMRN(bundle);
+      expect(bundle.entry[0].resource.id).toEqual(hashedMRN);
+      expect(bundle.entry[0].fullUrl).toEqual(`urn:uuid:${hashedMRN}`);
+      expect(bundle.entry[1].resource.subject.reference).toEqual(`urn:uuid:${hashedMRN}`);
+      expect(bundle.entry[2].resource.individual.reference).toEqual(`urn:uuid:${hashedMRN}`);
+    });
+    test('should throw error when there is no Patient resource in bundle', () => {
+      expect(() => maskMRN({})).toThrowError();
     });
   });
 });


### PR DESCRIPTION
# Summary
Since the MRN is used as an ID on the patient resource, it appears as a reference in other resources. Now when masking the MRN, all of those references will also be masked by replacing the MRN with a hash of the MRN after extraction is completed. 
## New behavior
If the MRN is specified as a field to be masked, in addition to masking the MRN in the Patient resource, there is an additional masking step after extraction is finished. All references to the MRN as an ID will be replaced by a hashed version of the MRN. Right now, the only places I found the MRN being used as an ID are in the `id` and `fullUrl` fields of the Patient resource and 'subject' and 'individual' objects in other resources.
## Code changes
- `patientUtils.js` now has a `maskMRN` function that takes a bundle as input, modifies the bundle to replace the MRN with a hashed version as the ID of the Patient resource, and then replaces every reference in other resources with the same hash 
- `app.js` will check the config to see if the MRN needs to be masked and will perform the masking after extraction is completed
- `patientUtils.test.js` now contains tests for the `maskMRN` function
# Testing guidance
- Run the program with `"mask": ["mrn"]` in the `constructorArgs` of the patient extractor
- Make sure that when MRN is specified to be masked, there are now no references to the MRN anywhere in the output bundle
- Check to see if the MRN is used in any locations that I missed
- Make sure all tests pass and the program runs as expected
