### PR TITLE
Support specifying clinicalSiteSystem in configuration file

### DIFF
--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -16,10 +16,11 @@ function getPatientId(context) {
 }
 
 class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
-  constructor({ filePath, clinicalSiteID }) {
+  constructor({ filePath, clinicalSiteID, clinicalSiteSystem }) {
     super({ filePath, csvSchema: CSVClinicalTrialInformationSchema });
     if (!clinicalSiteID) logger.warn(`${this.constructor.name} expects a value for clinicalSiteID but got ${clinicalSiteID}`);
     this.clinicalSiteID = clinicalSiteID;
+    this.clinicalSiteSystem = clinicalSiteSystem;
   }
 
   joinClinicalTrialData(patientId, clinicalTrialData) {
@@ -27,7 +28,7 @@ class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
     const {
       trialSubjectID, enrollmentStatus, trialResearchID, trialStatus, trialResearchSystem,
     } = clinicalTrialData;
-    const { clinicalSiteID } = this;
+    const { clinicalSiteID, clinicalSiteSystem } = this;
 
     if (!(patientId && clinicalSiteID && trialSubjectID && enrollmentStatus && trialResearchID && trialStatus)) {
       throw new Error('Clinical trial missing an expected property: patientId, clinicalSiteID, trialSubjectID, enrollmentStatus, trialResearchID, and trialStatus are required.');
@@ -46,6 +47,7 @@ class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
         trialStatus,
         trialResearchID,
         clinicalSiteID,
+        clinicalSiteSystem,
         trialResearchSystem,
       },
     };

--- a/src/templates/ResearchStudyTemplate.js
+++ b/src/templates/ResearchStudyTemplate.js
@@ -1,12 +1,12 @@
 const { identifierArr, identifier } = require('./snippets');
 
-function siteTemplate(clinicalSiteID) {
+function siteTemplate(clinicalSiteID, clinicalSiteSystem) {
   return {
     site: [
       {
         display: 'ID associated with Clinical Trial',
         ...identifier({
-          system: 'http://example.com/clinicalSiteIds',
+          system: clinicalSiteSystem,
           value: clinicalSiteID,
         }),
       },
@@ -27,7 +27,7 @@ function researchStudyIdentifierTemplate(trialResearchID, trialResearchSystem) {
 
 // Based on https://www.hl7.org/fhir/researchstudy.html
 function researchStudyTemplate({
-  id, trialStatus, trialResearchID, clinicalSiteID, trialResearchSystem,
+  id, trialStatus, trialResearchID, clinicalSiteID, clinicalSiteSystem, trialResearchSystem,
 }) {
   if (!(id && trialStatus && trialResearchID && clinicalSiteID)) {
     throw Error('Trying to render a ResearchStudyTemplate, but a required argument is missing; ensure that id, trialStatus, trialResearchID, clinicalSiteID are all present');
@@ -37,7 +37,7 @@ function researchStudyTemplate({
     resourceType: 'ResearchStudy',
     id,
     status: trialStatus,
-    ...siteTemplate(clinicalSiteID),
+    ...siteTemplate(clinicalSiteID, clinicalSiteSystem),
     ...researchStudyIdentifierTemplate(trialResearchID, trialResearchSystem),
   };
 }

--- a/test/extractors/CSVClinicalTrialInformationExtractor.test.js
+++ b/test/extractors/CSVClinicalTrialInformationExtractor.test.js
@@ -8,12 +8,14 @@ const exampleClinicalTrialInformationBundle = require('./fixtures/csv-clinical-t
 // Constants for mock tests
 const MOCK_CSV_PATH = path.join(__dirname, 'fixtures/example.csv'); // need a valid path/csv here to avoid parse error
 const MOCK_CLINICAL_SITE_ID = 'EXAMPLE-CLINICAL-SITE-ID';
+const MOCK_CLINICAL_SITE_SYSTEM = 'EXAMPLE-CLINICAL-SITE-SYSTEM';
 const MOCK_PATIENT_MRN = 'EXAMPLE-MRN';
 
 // Instantiate module with mock parameters
 const csvClinicalTrialInformationExtractor = new CSVClinicalTrialInformationExtractor({
   filePath: MOCK_CSV_PATH,
   clinicalSiteID: MOCK_CLINICAL_SITE_ID,
+  clinicalSiteSystem: MOCK_CLINICAL_SITE_SYSTEM,
 });
 
 // Destructure all modules
@@ -58,6 +60,7 @@ describe('CSVClinicalTrialInformationExtractor', () => {
           trialStatus: firstClinicalTrialInfoResponse.trialStatus,
           trialResearchID: firstClinicalTrialInfoResponse.trialResearchID,
           clinicalSiteID: MOCK_CLINICAL_SITE_ID,
+          clinicalSiteSystem: MOCK_CLINICAL_SITE_SYSTEM,
           trialResearchSystem: firstClinicalTrialInfoResponse.trialResearchSystem,
         },
       });

--- a/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
+++ b/test/extractors/fixtures/csv-clinical-trial-information-bundle.json
@@ -25,16 +25,16 @@
       }
     },
     {
-      "fullUrl": "urn:uuid:b245aa8a67b5f67263f5a688813c435ccfb364e0f7865885c512e3a5ca3c9093",
+      "fullUrl": "urn:uuid:28bd7a4890539dc60998a1b2d423e631a6d4373eb05001c45bd9f2bab3166506",
       "resource": {
         "resourceType": "ResearchStudy",
-        "id": "b245aa8a67b5f67263f5a688813c435ccfb364e0f7865885c512e3a5ca3c9093",
+        "id": "28bd7a4890539dc60998a1b2d423e631a6d4373eb05001c45bd9f2bab3166506",
         "status": "example-trialStatus",
         "site": [
           {
             "display": "ID associated with Clinical Trial",
             "identifier": {
-              "system": "http://example.com/clinicalSiteIds",
+              "system": "EXAMPLE-CLINICAL-SITE-SYSTEM",
               "value": "EXAMPLE-CLINICAL-SITE-ID"
             }
           }

--- a/test/templates/fixtures/research-study-resource.json
+++ b/test/templates/fixtures/research-study-resource.json
@@ -6,7 +6,7 @@
     {
       "display": "ID associated with Clinical Trial",
       "identifier": {
-        "system": "http://example.com/clinicalSiteIds",
+        "system": "EXAMPLE_SITE_SYSTEM",
         "value": "EXAMPLE_SITE_ID"
       }
     }

--- a/test/templates/researchStudy.test.js
+++ b/test/templates/researchStudy.test.js
@@ -7,6 +7,7 @@ const VALID_DATA = {
   trialStatus: 'active',
   trialResearchID: 'AFT1235',
   clinicalSiteID: 'EXAMPLE_SITE_ID',
+  clinicalSiteSystem: 'EXAMPLE_SITE_SYSTEM',
   trialResearchSystem: 'example-system',
 };
 


### PR DESCRIPTION
# Summary
clinicalSiteSystem can now be specified in the config file, similar to how clinicalSiteID is, except clinicalSiteSystem is optional
## New behavior
If a `clinicalSiteSystem` is added to the `constructorArgs` of `CSVClinicalTrialInformationExtractor` in the config file, that value will be used for the `system` field of the site object in the ResearchStudy resource. If no system is specified, the `system` field will be omitted in the output.
## Code changes
- `CSVClinicalTrialInformationExtractor.js` now takes an optional `clinicalSiteSystem` constructor argument and adds that to the formatted data for the Research Study
- `ResearchStudyTemplate.js` now takes an input for `clinicalSiteSystem` instead of just using an example.com value
- `CSVClinicalTrialInformationExtractor.test.js` and `researchStudy.test.js` have been updated to reflect the above changes
# Testing guidance
- Add a value for `clinicalSiteSystem` to the constructor arguments of the `CSVClinicalTrialInformationExtractor` and see that the correct value appears in the output and that there is no system in the output if the argument is removed from the config
- Make sure the new tests pass and accurately test the new functionality