### PR TITLE
Use ResearchStudy id from context in AdverseEvent search

### DIFF
--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -62,9 +62,20 @@ function getEncountersFromContext(context) {
   return encounterResourcesInContext;
 }
 
+function getResearchStudiesFromContext(context) {
+  logger.debug('Getting ResearchStudy resources from context');
+  const researchStudyResourcesInContext = getBundleResourcesByType(context, 'ResearchStudy', {}, false);
+  if (researchStudyResourcesInContext.length === 0) {
+    throw Error('Could not find any ResearchStudy resources in context; ensure that a ClinicalTrialInformationExtractor or ResearchStudyExtractor is used earlier in your extraction configuration');
+  }
+  logger.debug(`ResearchStudy resources found in context. Found ${researchStudyResourcesInContext.length} ResearchStudy resources.`);
+  return researchStudyResourcesInContext;
+}
+
 module.exports = {
   getConditionEntriesFromContext,
   getConditionsFromContext,
   getEncountersFromContext,
   getPatientFromContext,
+  getResearchStudiesFromContext,
 };

--- a/test/helpers/contextUtils.test.js
+++ b/test/helpers/contextUtils.test.js
@@ -1,6 +1,10 @@
-const { getConditionEntriesFromContext, getConditionsFromContext, getEncountersFromContext, getPatientFromContext } = require('../../src/helpers/contextUtils');
-
-const MOCK_PATIENT_MRN = '123';
+const {
+  getConditionEntriesFromContext,
+  getConditionsFromContext,
+  getEncountersFromContext,
+  getPatientFromContext,
+  getResearchStudiesFromContext,
+} = require('../../src/helpers/contextUtils');
 
 describe('getPatientFromContext', () => {
   const patientResource = {
@@ -124,7 +128,39 @@ describe('getEncountersFromContext', () => {
   });
 
   test('Should throw an error if there are no encounters in context', () => {
-    expect(() => getEncountersFromContext(MOCK_PATIENT_MRN, {}))
+    expect(() => getEncountersFromContext({}))
       .toThrow('Could not find any encounter resources in context; ensure that an EncounterExtractor is used earlier in your extraction configuration');
+  });
+});
+
+describe('getResearchStudyFromContext', () => {
+  const researchStudyResource = {
+    resourceType: 'ResearchStudy',
+    id: 'ResearchStudyExample01',
+  };
+  const researchStudyContext = {
+    resourceType: 'Bundle',
+    type: 'collection',
+    entry: [
+      {
+        fullUrl: 'context-url-1',
+        resource: researchStudyResource,
+      },
+      {
+        fullUrl: 'context-url-2',
+        resource: { ...researchStudyResource, id: 'ResearchStudyExample02' },
+      },
+    ],
+  };
+
+  test('Should return all ResearchStudy resources in context', () => {
+    const researchStudyResources = getResearchStudiesFromContext(researchStudyContext);
+    expect(researchStudyResources).toHaveLength(2);
+    expect(researchStudyResources[0]).toEqual(researchStudyResource);
+  });
+
+  test('Should throw an error if there are no research studies in context', () => {
+    expect(() => getResearchStudiesFromContext({}))
+      .toThrow('Could not find any ResearchStudy resources in context; ensure that a ClinicalTrialInformationExtractor or ResearchStudyExtractor is used earlier in your extraction configuration');
   });
 });


### PR DESCRIPTION
# Summary
This PR uses context to find any ResearchStudy ids to be included in the FHIR Adverse Event search.

## New behavior
The `FHIRAdverseEventExtractor` now looks in context for any `ResearchStudy` resources. If it finds research study resources, it includes the study ids from all research studies in the `this.study` list of studies to be used when searching for AdverseEvents. If no research study resources are found, the AdverseEvent extractor still proceeds trying to search for AdverseEvents, but does not add any studies beyond the ones that were set in the constructor.

It also adds a new context util function for ResearchStudy resources.
## Code changes
This includes the new context util function and associated test. It also updates the (string) list of studies that is added in `parametrizeArgsForFHIRModule` in the `FHIRAdverseEventExtractor`. Searching for AdverseEvents using the `study` query parameter supports searching for multiple study ids in a comma separated list, like `study=study1,study2`.

# Testing guidance
Ensure that the tests cover the expected behavior. The actual extractor can't really be tested in this repo.