### PR TITLE
Loosen required fields for Patient CSV and mark missing required fields

### DIFF
--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -14,8 +14,8 @@ function joinAndReformatData(patientData) {
     mrn, familyName, givenName, gender, birthsex, dateOfBirth, race, ethnicity, language, addressLine, city, state, zip,
   } = patientData;
 
-  if (!mrn || !familyName || !givenName || !gender) {
-    throw Error('Missing required field for Patient CSV Extraction. Required values include: mrn, familyName, givenName, gender');
+  if (!mrn) {
+    throw Error('Missing required field for Patient CSV Extraction: mrn');
   }
 
   return {

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -99,6 +99,9 @@ function maskPatientData(bundle, mask) {
       delete patient.gender;
       // an underscore is added when a primitive type is being replaced by an object (extension)
       patient._gender = masked;
+    } else if (field === 'gender' && '_gender' in patient) {
+      delete patient._gender; // gender may have a dataAbsentReason on it for 'unknown' data, but we'll still want to mask it
+      patient._gender = masked;
     } else if (field === 'mrn' && 'identifier' in patient) {
       patient.identifier = [masked];
     } else if (field === 'name' && 'name' in patient) {
@@ -120,7 +123,7 @@ function maskPatientData(bundle, mask) {
       );
       // fhirpath.evaluate will return [] if there is no extension with the given URL
       // so checking if the result is [] checks if the field exists to be masked
-      if (birthsex !== []) {
+      if (birthsex.length > 0) {
         delete birthsex[0].valueCode;
         birthsex[0]._valueCode = masked;
       }
@@ -129,7 +132,7 @@ function maskPatientData(bundle, mask) {
         patient,
         'Patient.extension.where(url=\'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race\')',
       );
-      if (race !== []) {
+      if (race.length > 0) {
         race[0].extension[0].valueCoding = masked;
         delete race[0].extension[1].valueString;
         race[0].extension[1]._valueString = masked;
@@ -139,7 +142,7 @@ function maskPatientData(bundle, mask) {
         patient,
         'Patient.extension.where(url=\'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity\')',
       );
-      if (ethnicity !== []) {
+      if (ethnicity.length > 0) {
         ethnicity[0].extension[0].valueCoding = masked;
         delete ethnicity[0].extension[1].valueString;
         ethnicity[0].extension[1]._valueString = masked;

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -122,7 +122,7 @@ function maskPatientData(bundle, mask) {
         'Patient.extension.where(url=\'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex\')',
       );
       // fhirpath.evaluate will return [] if there is no extension with the given URL
-      // so checking if the result is [] checks if the field exists to be masked
+      // so checking if the result is an array with anything in it checks if the field exists to be masked
       if (birthsex.length > 0) {
         delete birthsex[0].valueCode;
         birthsex[0]._valueCode = masked;

--- a/src/helpers/schemas/csv.js
+++ b/src/helpers/schemas/csv.js
@@ -31,9 +31,9 @@ const CSVConditionSchema = {
 const CSVPatientSchema = {
   headers: [
     { name: 'mrn', required: true },
-    { name: 'familyName', required: true },
-    { name: 'givenName', required: true },
-    { name: 'gender', required: true },
+    { name: 'familyName' },
+    { name: 'givenName' },
+    { name: 'gender' },
     { name: 'birthsex' },
     { name: 'dateOfBirth' },
     { name: 'race' },

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -98,6 +98,22 @@ describe('PatientUtils', () => {
       expect(bundle).toEqual(exampleMaskedPatient);
     });
 
+    test('should mask gender even if it only had an extension', () => {
+      const bundle = _.cloneDeep(examplePatient);
+      delete bundle.entry[0].resource.gender;
+      // eslint-disable-next-line no-underscore-dangle
+      bundle.entry[0].resource._gender = {
+        extension: [
+          {
+            url: 'http://hl7.org/fhir/StructureDefinition/data-absent-reason',
+            valueCode: 'unknown',
+          },
+        ],
+      };
+      maskPatientData(bundle, ['gender', 'mrn', 'name', 'address', 'birthDate', 'language', 'ethnicity', 'birthsex', 'race']);
+      expect(bundle).toEqual(exampleMaskedPatient);
+    });
+
     test('should throw error when provided an invalid field to mask', () => {
       const bundle = _.cloneDeep(examplePatient);
       expect(() => maskPatientData(bundle, ['this is an invalid field', 'mrn'])).toThrowError();

--- a/test/templates/fixtures/patient-resource.json
+++ b/test/templates/fixtures/patient-resource.json
@@ -18,11 +18,21 @@
     }
   ],
   "name": [
-      {
-          "text": "Test Patient",
-          "family": "Patient",
-          "given": [ "Test" ]
-      }
+    {
+      "extension": [
+        {
+          "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+          "valueCode": "unknown"
+        }
+      ]
+    }
   ],
-  "gender": "female"
+  "_gender": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  }
 }

--- a/test/templates/patient.test.js
+++ b/test/templates/patient.test.js
@@ -9,9 +9,9 @@ describe('JavaScript Render Patient', () => {
     const PATIENT_VALID_DATA = {
       id: 'SomeId',
       mrn: '1234',
-      familyName: 'Patient',
-      givenName: 'Test',
-      gender: 'female',
+      familyName: null,
+      givenName: null,
+      gender: null,
       birthsex: null,
       dateOfBirth: null,
       language: null,


### PR DESCRIPTION
# Summary
This PR makes it so that `familyName`, `givenName`, and `gender` are not required fields in CSVs. Because they are still required in the [mCODE Cancer Patient profile](http://hl7.org/fhir/us/mcode/StructureDefinition-mcode-cancer-patient.html), they are marked with `dataAbsentReason` extensions with a code `'unknown'`.

## New behavior
If `familyName`, `givenName`, or `gender` is not provided in the patient information CSV, no errors/warnings are logged and no data extracted. Further, if they are missing, the template will add a `dataAbsentReason` for `name` and `gender` in the patient resource because they have a `1..*` cardinality in mCODE. I thought about adding a warning or debug message to say those fields are recommended, but decided against it. If anyone likes the idea of that message, I can definitely be convinced to add it back.

If `name` or `gender` is not provided but configuration says to mask it, it will get a `dataAbsentReason` for `'masked'` instead. I thought this made sense because we'd want to mask any data we had, including the extension saying that we had no data (when I type it out, it sounds more confusing than I thought).

None of the other fields in the patient CSV are affected by this PR because they are not required in the profiled Patient resource, and if values are not provided in the CSV, we already do not include them in the extracted resource. Any field that we say to mask but was never in the resource is not masked, which I believe is still correct.

## Code changes
- Updates the requirements in the CSV validation schemas
- Updates when we throw an error from the `CSVPatientExtractor` to only throw if the `mrn` is missing
- Adds the `dataAbsentReason` extensions if applicable to `name` and `gender`

# Testing guidance
- Ensure the tests test this code appropriately.
- Try running the CSV Patient extractor with only mrn and with a combination of the non-required data and ensure both approaches extract a Patient resource properly. Also try masking properties, including `gender`, `name`, `mrn`, and any other non-required, `0..*` property.
- Ensure this PR covers both [STEAM-507](https://jira.mitre.org/browse/STEAM-507) and [STEAM-508](https://jira.mitre.org/browse/STEAM-508)
