### PR TITLE
Added fn to find all invalid resources in a bundle

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -1,4 +1,4 @@
-const { isValidFHIR } = require('../helpers/fhirUtils');
+const { isValidFHIR, invalidResourcesFromBundle } = require('../helpers/fhirUtils');
 const logger = require('../helpers/logger');
 
 class BaseClient {
@@ -97,7 +97,7 @@ class BaseClient {
     }, Promise.resolve(contextBundle));
 
     if (!isValidFHIR(contextBundle)) {
-      logger.error('Extracted bundle is not valid FHIR.');
+      logger.error(`Extracted bundle is not valid FHIR, the following resources failed validation: ${invalidResourcesFromBundle(contextBundle).join(',')}`);
     }
 
     return { bundle: contextBundle, extractionErrors };

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -97,7 +97,7 @@ class BaseClient {
     }, Promise.resolve(contextBundle));
 
     if (!isValidFHIR(contextBundle)) {
-      logger.error(`Extracted bundle is not valid FHIR, the following resources failed validation: ${invalidResourcesFromBundle(contextBundle).join(',')}`);
+      logger.warn(`Extracted bundle is not valid FHIR, the following resources failed validation: ${invalidResourcesFromBundle(contextBundle).join(',')}`);
     }
 
     return { bundle: contextBundle, extractionErrors };

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -163,8 +163,22 @@ const logOperationOutcomeInfo = (operationOutcome) => {
   });
 };
 
-const isValidFHIR = (resource) => validator.validate('FHIR', resource);
-
+function isValidFHIR(resource) {
+  return validator.validate('FHIR', resource);
+}
+function invalidResourcesFromBundle(bundle) {
+  // Bundle is assumed to have all resources in bundle.entry[x].resource
+  const failingResources = [];
+  bundle.entry.forEach((e) => {
+    const { resource } = e;
+    const { id, resourceType } = resource;
+    if (!validator.validate('FHIR', resource)) {
+      const failureId = `${resourceType}-${id}`;
+      failingResources.push(failureId);
+    }
+  });
+  return failingResources;
+}
 
 module.exports = {
   allResourcesInBundle,
@@ -182,4 +196,5 @@ module.exports = {
   mapFHIRVersions,
   quantityCodeToUnitLookup,
   isValidFHIR,
+  invalidResourcesFromBundle,
 };

--- a/test/client/BaseClient.test.js
+++ b/test/client/BaseClient.test.js
@@ -76,8 +76,8 @@ describe('BaseClient', () => {
     });
     it('should iterate over all extractors gets, aggregating resultant entries in a bundle', async () => {
       const extractorClassesWithEntryGets = [
-        class Ext1 { get() { return { entry: [{ data: 'here' }] }; }},
-        class Ext2 { get() { return { entry: [{ data: 'alsoHere' }] }; }},
+        class Ext1 { get() { return { entry: [{ resource: 'here' }] }; }},
+        class Ext2 { get() { return { entry: [{ resource: 'alsoHere' }] }; }},
         class Ext3 { get() { throw new Error('Error'); }},
       ];
       engine.registerExtractors(...extractorClassesWithEntryGets);

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -144,12 +144,10 @@ describe('getResourceCountInBundle', () => {
 
 describe('isValidFHIR', () => {
   test('Should return true when provided valid FHIR resources', () => {
-    expect(isValidFHIR(bundleWithOneEntry)).toEqual(true);
+    expect(isValidFHIR(validResource)).toEqual(true);
   });
   test('Should return false when provided invalid FHIR resources', () => {
-    const invalidBundle = { ...bundleWithOneEntry };
-    invalidBundle.entry[0].resource = invalidResource;
-    expect(isValidFHIR(invalidBundle)).toEqual(false);
+    expect(isValidFHIR(invalidResource)).toEqual(false);
   });
 });
 

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -7,6 +7,8 @@ const {
   allResourcesInBundle,
   quantityCodeToUnitLookup,
   getResourceCountInBundle,
+  isValidFHIR,
+  invalidResourcesFromBundle,
 } = require('../../src/helpers/fhirUtils.js');
 const emptyBundle = require('./fixtures/emptyBundle.json');
 const bundleWithOneEntry = require('./fixtures/searchsetBundleWithOneEntry.json');
@@ -14,6 +16,8 @@ const bundleWithMultipleEntries = require('./fixtures/searchsetBundleWithMultipl
 const countBundle5Unique = require('./fixtures/count-bundle-5-unique.json');
 const countBundle5Same = require('./fixtures/count-bundle-5-same.json');
 const countBundle5Nested = require('./fixtures/count-bundle-5-nested.json');
+const validResource = require('./fixtures/valid-resource');
+const invalidResource = require('./fixtures/invalid-resource');
 
 describe('getQuantityUnit', () => {
   test('Should return unit text if provided in lookup table', () => {
@@ -135,5 +139,29 @@ describe('getResourceCountInBundle', () => {
       'Resource-1': [5],
     };
     expect(getResourceCountInBundle(countBundle5Nested)).toEqual(counts);
+  });
+});
+
+describe('isValidFHIR', () => {
+  test('Should return true when provided valid FHIR resources', () => {
+    expect(isValidFHIR(bundleWithOneEntry)).toEqual(true);
+  });
+  test('Should return false when provided invalid FHIR resources', () => {
+    const invalidBundle = { ...bundleWithOneEntry };
+    invalidBundle.entry[0].resource = invalidResource;
+    expect(isValidFHIR(invalidBundle)).toEqual(false);
+  });
+});
+
+describe('invalidResourcesFromBundle', () => {
+  test('Should return an empty array when all resources are valid', () => {
+    expect(invalidResourcesFromBundle(emptyBundle)).toEqual([]);
+  });
+  test('Should return an array of all invalid resources when they exist', () => {
+    const invalidBundle = { ...bundleWithOneEntry };
+    invalidBundle.entry[0].resource = invalidResource;
+    // This is dependent on implementation details intrinsic to invalidResourcesFromBundle
+    const invalidResourceId = `${invalidResource.resourceType}-${invalidResource.id}`;
+    expect(invalidResourcesFromBundle(invalidBundle)).toEqual([invalidResourceId]);
   });
 });

--- a/test/helpers/fixtures/invalid-resource.json
+++ b/test/helpers/fixtures/invalid-resource.json
@@ -3,9 +3,7 @@
   "id": "invalid-patient",
   "name": [
     {
-      "family": [
-        "Godel"
-      ],
+      "family": "Godel",
       "given": [
         "Kurt"
       ]

--- a/test/helpers/fixtures/invalid-resource.json
+++ b/test/helpers/fixtures/invalid-resource.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Patient",
+  "id": "invalid-patient",
+  "name": [
+    {
+      "family": [
+        "Godel"
+      ],
+      "given": [
+        "Kurt"
+      ]
+    }
+  ],
+  "gender": "invalid-enum-value",
+  "birthDate": "1906-04-28"
+}

--- a/test/helpers/fixtures/valid-resource.json
+++ b/test/helpers/fixtures/valid-resource.json
@@ -1,0 +1,16 @@
+{
+  "resourceType": "Patient",
+  "id": "valid-patient",
+  "name": [
+    {
+      "family": [
+        "Frege"
+      ],
+      "given": [
+        "Gottlob"
+      ]
+    }
+  ],
+  "gender": "male",
+  "birthDate": "1848-11-08"
+}

--- a/test/helpers/fixtures/valid-resource.json
+++ b/test/helpers/fixtures/valid-resource.json
@@ -3,9 +3,7 @@
   "id": "valid-patient",
   "name": [
     {
-      "family": [
-        "Frege"
-      ],
+      "family": "Frege",
       "given": [
         "Gottlob"
       ]


### PR DESCRIPTION
# Summary
Adds the `invalidResourcesFromBundle` function to be used by the baseClient and other utilities that desire resource-level information on invalid bundles. Updates the baseClient to use this new function. Adds some basic tests for this fn and for the general isValidFhir function. Updates all FHIR-validation related `logger.error` messages to `logger.warn`, since the clients shouldn't fail on account of invalid FHIR.

To test this, an easy change to templates that renders the resulting FHIR invalid is to fix the gender value in PatientTemplate to an unknown enum value – `gender: invalid-gender` would work, for example. This should render all patient resources invalid and you should see as much when you run the baseclient in the form of a warning. 