### PR TITLE
Adding npm start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,19 +58,13 @@ const cancerDiseaseStatusExtractor = new CSVCancerDiseaseStatusExtractor('path-t
 The framework also contains the [MCODEClient](src/client/MCODEClient.js) which has registered all of the extractors in this repo. Once you have exported CSV data and updated your configuration file, use the mCODE Extraction client by running the following:
 
 ```bash
-node src/cli/cli.js [options]
+npm start -- [options]
 ```
 
 To see all the options that can be used with the mCODE client, run the following:
 
 ```bash
-node src/cli/cli.js --help
-```
-
-The client can also be run by npm script:
-
-```bash
-npm start -- [options]
+npm start -- --help
 ```
 
 ### First Time User Guide
@@ -131,7 +125,7 @@ Whenever the mCODE Extraction Client successfully runs with the `--entries-filte
 Users can specify a different location for the file by using the `--run-log-filepath <path>` CLI option. Users will need to create this file before running the mCODE Extraction Client with `--entries-filter` and a date range. Initially, this file's contents should be an empty array, `[]`. For example:
 
 ```bash
-node src/cli/cli.js --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --run-log-filepath path/to/file.json
+npm start -- --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --run-log-filepath path/to/file.json
 ```
 
 ### Masking Patient Data
@@ -164,7 +158,7 @@ If any filtering on data elements in CSV files is required, the `entries-filter`
 If a `from-date` is provided as an option when running the mCODE Extraction Client, it will be used to filter out any data elements that are recorded before that date based on the `dateRecorded` column in the CSV files. If a `to-date` is provided as an option, it will be used to filter out any data elements that are recorded after that date based on the `dateRecorded` column in the CSV files. If no `to-date` is provided, the default is today. If no `from-date` is provided, the mCODE Extraction Client will look to a run log file (details [above](#Logging-Successful-Extractions)) to find the most recent run and use the `to-date` of that run as the `from-date` for the current run, allowing users to only run the extraction on data elements that were not included in previous runs. If there are no previous run times logged, a `from-date` needs to be provided when running the extraction when the `entries-filter` option is provided. If the `entries-filter` option is not provided, any `from-date` and `to-date` options will be ignored, none of the data elements will be filtered by date, and a successful run will not be logged since there is no specified date range. An example running the client with the `from-date` and `to-date` is as follows:
 
 ```bash
-node src/cli/cli.js --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --config-filepath <path>
+npm start -- --entries-filter --from-date <YYYY-MM-DD> --to-date <YYYY-MM-DD> --config-filepath <path>
 ```
 
 ## Terminology and Architecture

--- a/README.md
+++ b/README.md
@@ -67,6 +67,12 @@ To see all the options that can be used with the mCODE client, run the following
 node src/cli/cli.js --help
 ```
 
+The client can also be run by npm script:
+
+```bash
+npm start -- [options]
+```
+
 ### First Time User Guide
 
 To run the mCODE Extraction Client you must have:

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   ],
   "main": "src/",
   "scripts": {
+    "start":"node src/cli/cli.js",
     "lint": "eslint \"./**/*.js\"",
     "lint-fix": "eslint \"./**/*.js\" --fix",
     "test": "cross-env LOGGING=none jest",


### PR DESCRIPTION
# Summary
You can now call `npm start -- [options]` to start the client instead of `node src/cli/cli.js [options]`
## New behavior
There is now a script in `package.json` called "start" that acts as a simpler way of calling the program from the command line. It is important to note that npm requires you to put "--" between your script name and command line arguments. If the double hyphen is left out, the arguments will be interpreted as npm flags, for example -d and -f will be interpreted as npm's debug and force flags, not our debug and from date flags.
## Code changes
- `package.json` now has a start script, which runs the client
- The README has been updated to include the new way of running the client
# Testing guidance
Make sure that you are able to use the client as usual when calling via the start script