### PR TITLE
CSV Module now ignores BOMs

### DIFF
--- a/src/modules/CSVModule.js
+++ b/src/modules/CSVModule.js
@@ -5,7 +5,7 @@ const logger = require('../helpers/logger');
 
 class CSVModule {
   constructor(csvFilePath) {
-    this.data = parse(fs.readFileSync(csvFilePath), { columns: true });
+    this.data = parse(fs.readFileSync(csvFilePath), { columns: true, bom: true });
   }
 
   async get(key, value, fromDate, toDate) {

--- a/test/modules/CSVModule.test.js
+++ b/test/modules/CSVModule.test.js
@@ -4,9 +4,15 @@ const exampleResponse = require('./fixtures/csv-response.json');
 
 const INVALID_MRN = 'INVALID MRN';
 const csvModule = new CSVModule(path.join(__dirname, './fixtures/example-csv.csv'));
+const csvModuleWithBOMs = new CSVModule(path.join(__dirname, './fixtures/example-csv-bom.csv'));
 
 test('Reads data from CSV', async () => {
   const data = await csvModule.get('mrn', 'example-mrn-1');
+  expect(data).toEqual(exampleResponse);
+});
+
+test('Reads data from CSV with a Byte Order Mark', async () => {
+  const data = await csvModuleWithBOMs.get('mrn', 'example-mrn-1');
   expect(data).toEqual(exampleResponse);
 });
 

--- a/test/modules/fixtures/example-csv-bom.csv
+++ b/test/modules/fixtures/example-csv-bom.csv
@@ -1,0 +1,4 @@
+﻿mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,dateRecorded
+example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1,2020-01-10
+example-mrn-2,subjectId-2,status-2,researchId-2,trialStatus-2,2020-01-10
+example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3,2020-06-10


### PR DESCRIPTION
# Summary
This PR enables the CSV Module to read csvs with invisible Byte Order Marks at the beginning of a file.
## New behavior
The extractor now runs as expected when csvs containing a client's data include Byte Order Marks at the beginning of the file.
## Code changes
1. The `parse` function that's run in the CSVModule's contractor now has the `bom` flag set to true, causing any BOMs at the beginning of the csv to be ignored.
2. A new `example-csv-bom.csv` file has been added as a test fixture. It's identical to the preexisting `example-csv.csv` file, except it include a BOM at the beginning of the file.
3. A test case verifying that the CSV module ignores BOMs has been added to `CSVModule.test.js`
# Testing guidance
Commit `3dd1055` adds both an example csv with a BOM as well as a unit test that attempts to parse this CSV. The `bom` flag has __not__ been added in this commit though, so you should see this unit test fail as the CSVModule fails to recognize the `mrn` column. In commit `0e3d63a`, that same unit test should pass as that commit enables the `bom` flag.