### PR TITLE
Unique IDs added to several CSVs

### DIFF
--- a/docs/adverse-event.csv
+++ b/docs/adverse-event.csv
@@ -1,4 +1,4 @@
 mrn,adverseEventId,adverseEventCode,adverseEventCodeSystem,adverseEventDisplayText,suspectedCauseId,suspectedCauseType,seriousness,seriousnessCodeSystem,seriousnessDisplayText,category,categoryCodeSystem,categoryDisplayText,severity,actuality,studyId,effectiveDate,recordedDate
 mrn-full-example,example-id-1,event-code,code-system,code-display,cause-id,resourceType,seriousness-code,code-system,seriousness-display,category-code,code-system,category-dislpay,mild,actual,id,1994-12-09,1994-12-09
-mrn-two-category-example,example-id-1,event-code,code-system,code-display,cause-id,resourceType,seriousness-code,code-system,seriousness-display,category-code|category-code,code-system|code-system,category-display|category-display,mild,actual,id,1994-12-09,1994-12-09
+mrn-two-category-example,example-id-2,event-code,code-system,code-display,cause-id,resourceType,seriousness-code,code-system,seriousness-display,category-code|category-code,code-system|code-system,category-display|category-display,mild,actual,id,1994-12-09,1994-12-09
 mrn-minimal-example,,code-from-default-system,,,,,,,,,,,,,,1994-12-09,

--- a/docs/observation.csv
+++ b/docs/observation.csv
@@ -1,3 +1,3 @@
 mrn,observationId,status,code,codeSystem,displayName,value,valueCodeSystem,effectiveDate,bodySite,laterality
-mrn-1,example-id,example-status,example-code,example-system,example-name,example-value,example-system,YYYY-MM-DD,example-site,example-laterality
-mrn-2,example-id,example-status,example-code,example-system,example-name,example-value,example-system,YYYY-MM-DD,example-site,example-laterality
+mrn-1,example-id-1,example-status,example-code,example-system,example-name,example-value,example-system,YYYY-MM-DD,example-site,example-laterality
+mrn-2,example-id-2,example-status,example-code,example-system,example-name,example-value,example-system,YYYY-MM-DD,example-site,example-laterality

--- a/docs/procedure.csv
+++ b/docs/procedure.csv
@@ -1,3 +1,3 @@
 mrn,procedureId,conditionId,status,code,codeSystem,displayName,reasonCode,reasonCodeSystem,reasonDisplayName,effectiveDate,bodySite,laterality,treatmentIntent
-mrn-1,example-id,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
-mrn-2,example-id,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
+mrn-1,example-id-1,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
+mrn-2,example-id-2,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent

--- a/docs/procedure.csv
+++ b/docs/procedure.csv
@@ -1,3 +1,3 @@
 mrn,procedureId,conditionId,status,code,codeSystem,displayName,reasonCode,reasonCodeSystem,reasonDisplayName,effectiveDate,bodySite,laterality,treatmentIntent
-mrn-1,example-id-1,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
-mrn-2,example-id-2,example-condition-id,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
+mrn-1,example-id-1,example-condition-id-1,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent
+mrn-2,example-id-2,example-condition-id-2,example-status,example-code,example-system,example-name,example-reason-code,example-system,example-reason-display,YYYY-MM-DD,example-site,example-laterality,example-treatment-intent

--- a/test/sample-client-data/condition-information.csv
+++ b/test/sample-client-data/condition-information.csv
@@ -1,4 +1,4 @@
 mrn,conditionId,codeSystem,code,displayName,category,dateOfDiagnosis,clinicalStatus,verificationStatus,bodySite,laterality,histology
 123,conditionId-1,http://snomed.info/sct,363346000,Breast Cancer,encounter-diagnosis,2020-07-12,relapse,confirmed,251007,7771000,2424003
 456,conditionId-2,http://snomed.info/sct,363346000,Prostate Cancer,problem-list-item,2019-11-11,remission,confirmed,251007,24028007,2735009
-789,conditionId-2,http://snomed.info/sct,363346000,Lung Cancer,encounter-diagnosis,2020-02-14,resolved,confirmed,251007,66459002,2985005
+789,conditionId-3,http://snomed.info/sct,363346000,Lung Cancer,encounter-diagnosis,2020-02-14,resolved,confirmed,251007,66459002,2985005

--- a/test/sample-client-data/observation-information.csv
+++ b/test/sample-client-data/observation-information.csv
@@ -1,4 +1,4 @@
 mrn,observationId,status,code,codeSystem,displayName,value,valueCodeSystem,effectiveDate,bodySite,laterality
-123,observation-id,final,1695-6,http://loinc.org,,10828004,http://snomed.info/sct,2020-01-02,251007,66459002
-456,observation-id,final,8302-2,http://loinc.org,Body height,66.89 [in_i],,2020-01-02,251007,66459002
-789,observation-id,final,29463-7,http://loinc.org,Body Weight,185 [lb_av],,2020-01-02,251007,66459002
+123,observation-id-1,final,1695-6,http://loinc.org,,10828004,http://snomed.info/sct,2020-01-02,251007,66459002
+456,observation-id-2,final,8302-2,http://loinc.org,Body height,66.89 [in_i],,2020-01-02,251007,66459002
+789,observation-id-3,final,29463-7,http://loinc.org,Body Weight,185 [lb_av],,2020-01-02,251007,66459002

--- a/test/sample-client-data/procedure-information.csv
+++ b/test/sample-client-data/procedure-information.csv
@@ -1,4 +1,4 @@
 mrn,procedureId,conditionId,status,code,codeSystem,displayName,reasonCode,reasonCodeSystem,reasonDisplayName,effectiveDate,bodySite,laterality,treatmentIntent
-123,procedure-id,condition-id,completed,152198000,http://snomed.info/sct,Brachytherapy (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-01,41224006,51440002,373808002
-456,procedure-id,condition-id,in-progress,174337000,http://snomed.info/sct,Destruction of lesion,363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002
-789,procedure-id,condition-id,completed,172043006,http://snomed.info/sct,Total mastectomy,363346000,http://snomed.info/sct,Malignant tumor,2020-06-30,41224006,51440002,373808002
+123,procedure-id-1,condition-id,completed,152198000,http://snomed.info/sct,Brachytherapy (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-01,41224006,51440002,373808002
+456,procedure-id-2,condition-id,in-progress,174337000,http://snomed.info/sct,Destruction of lesion,363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002
+789,procedure-id-3,condition-id,completed,172043006,http://snomed.info/sct,Total mastectomy,363346000,http://snomed.info/sct,Malignant tumor,2020-06-30,41224006,51440002,373808002

--- a/test/sample-client-data/procedure-information.csv
+++ b/test/sample-client-data/procedure-information.csv
@@ -1,4 +1,4 @@
 mrn,procedureId,conditionId,status,code,codeSystem,displayName,reasonCode,reasonCodeSystem,reasonDisplayName,effectiveDate,bodySite,laterality,treatmentIntent
-123,procedure-id-1,condition-id,completed,152198000,http://snomed.info/sct,Brachytherapy (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-01,41224006,51440002,373808002
-456,procedure-id-2,condition-id,in-progress,174337000,http://snomed.info/sct,Destruction of lesion,363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002
-789,procedure-id-3,condition-id,completed,172043006,http://snomed.info/sct,Total mastectomy,363346000,http://snomed.info/sct,Malignant tumor,2020-06-30,41224006,51440002,373808002
+123,procedure-id-1,condition-id-1,completed,152198000,http://snomed.info/sct,Brachytherapy (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-01,41224006,51440002,373808002
+456,procedure-id-2,condition-id-2,in-progress,174337000,http://snomed.info/sct,Destruction of lesion,363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002
+789,procedure-id-3,condition-id-3,completed,172043006,http://snomed.info/sct,Total mastectomy,363346000,http://snomed.info/sct,Malignant tumor,2020-06-30,41224006,51440002,373808002

--- a/test/sample-client-data/procedure-information.csv
+++ b/test/sample-client-data/procedure-information.csv
@@ -2,3 +2,4 @@ mrn,procedureId,conditionId,status,code,codeSystem,displayName,reasonCode,reason
 123,procedure-id-1,condition-id-1,completed,152198000,http://snomed.info/sct,Brachytherapy (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-01,41224006,51440002,373808002
 456,procedure-id-2,condition-id-2,in-progress,174337000,http://snomed.info/sct,Destruction of lesion,363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002
 789,procedure-id-3,condition-id-3,completed,172043006,http://snomed.info/sct,Total mastectomy,363346000,http://snomed.info/sct,Malignant tumor,2020-06-30,41224006,51440002,373808002
+789,procedure-id-4,condition-id-3,in-progress,10611004,http://snomed.info/sct,Teleradiotherapy protons (procedure),363346000,http://snomed.info/sct,Malignant tumor,2020-01-12,41224006,51440002,373808002

--- a/test/sample-client-data/staging-information.csv
+++ b/test/sample-client-data/staging-information.csv
@@ -1,6 +1,6 @@
 mrn,conditionId,stageGroup,t,n,m,type,stagingSystem,stagingCodeSystem,effectiveDate
 123,conditionId-1,3C,cT3,cN3,cM0,Clinical,C146985,http://ncimeta.nci.nih.gov,2020-01-01
 456,conditionId-2,3C,cT3,cN3,cM0,Clinical,443830009,http://snomed.info/sct,2020-01-01
-789,conditionId-2,3C,,cN3,cM0,Clinical,444256004,http://snomed.info/sct,2020-01-02
-789,conditionId-2,3C,cT3,,cM0,Clinical,,,2020-01-03
-789,conditionId-2,3C,cT3,cN3,,Clinical,258235000,http://snomed.info/sct,2020-01-04
+789,conditionId-3,3C,,cN3,cM0,Clinical,444256004,http://snomed.info/sct,2020-01-02
+789,conditionId-3,3C,cT3,,cM0,Clinical,,,2020-01-03
+789,conditionId-3,3C,cT3,cN3,,Clinical,258235000,http://snomed.info/sct,2020-01-04


### PR DESCRIPTION
# Summary
This PR changes some of the example CSVs in the `docs` and `sample-client-data` directory to have values more representative of what the CSVModule is expecting. 
## New behavior
No new behavior.
## Code changes
* Unique sample Ids have been added to the condition, procedure, and observation CSVs within `test/sample-client-data`, and also to the adverse event, procedure, and observation CSVs within the `docs` folder. 
# Testing guidance
Ensure that I'm not missing anything that could potentially mislead users as they're creating their own CSVs. The only thing I saw that I thought required changing were some of the `id` fields not being unique when they should be in the context of FHIR, but I could be missing something. 