### PR TITLE
Add BOM flag to Patient ID CSV parsing

### DIFF
--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -84,7 +84,7 @@ async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
 
     // Parse CSV for list of patient mrns
     const patientIdsCsvPath = path.resolve(config.patientIdCsvPath);
-    const patientIds = parse(fs.readFileSync(patientIdsCsvPath, 'utf8'), { columns: true }).map((row) => row.mrn);
+    const patientIds = parse(fs.readFileSync(patientIdsCsvPath, 'utf8'), { columns: true, bom: true }).map((row) => row.mrn);
 
     // Get RunInstanceLogger for recording new runs and inferring dates from previous runs
     const runLogger = allEntries ? null : new RunInstanceLogger(pathToRunLogs);


### PR DESCRIPTION
# Summary
The patient IDs CSV is parsed in `app.js` rather than in `CSVModule.js` like the other CSVs and we forgot to add the BOM flag to that instance of the parse function being called
## New behavior
BOMs are now handled when parsing the Patient IDs CSV
## Code changes
The call to the CSV parse function in `app.js` now has the flag to properly handle BOMs
# Testing guidance
To test that this works, you can go and replace the `fs.readFileSync()` call on line 87 of `app.js` with the following `'\uFEFFmrn\n123\n456\n789\n1011'` (the same as the sample client data but with a BOM added at the start). The client should still run as expected.