### PR TITLE
process.exit moved to cli.js

### DIFF
--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const program = require('commander');
 const { MCODEClient } = require('../client/MCODEClient');
+const logger = require('../helpers/logger');
 const { mcodeApp } = require('./app');
 
 const defaultPathToConfig = path.join('config', 'csv.config.json');
@@ -23,4 +24,15 @@ const {
 // Flag to extract allEntries, or just to use to-from dates
 const allEntries = !entriesFilter;
 
-mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
+async function runApp() {
+  try {
+    await mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
+  } catch (e) {
+    if (debug) logger.level = 'debug';
+    logger.error(e.message);
+    logger.debug(e.stack);
+    process.exit(1);
+  }
+}
+
+runApp();


### PR DESCRIPTION
# Summary
Delegates fatal error handling to the cli, rather than the `mcodeApp`.
## New behavior
When a fatal error is encountered in the `mcodeApp`, the running process is now closed from the cli rather than from within  the app. The cli also handles any logging that will result from that error.
## Code changes
1. Within `cli.js`, a new `runApp()` function is introduced. This function calls the `mcodeApp()` function from within a `try` block. If an error is encountered, this function will log the error and exit the node process. The `runApp()` function was necessary due to `mcodeApp()` being an asynchronous function, as calling an `async` function within a `try..catch` block can only be done from within an `async` function.
2. Within `app.js`, all fatal error handling within `mcodeApp()` has been removed. Errors are now thrown straight to the `runApp()` function where they are logged and the process is exited.
# Testing guidance
1. Ensure all current tests pass and that the extraction runs as expected with a simple `npm start`.
2. Manually test extraction with arguments that will trigger a fatal error, ensuring that the process still exits as expected and the error is appropriately logged. An example would be `npm start --  --entries-filter --from-date 54849/382/3742`, as this will trigger an error due to the invalid date.