### PR TITLE
Modified app.js to return object instead of writing to file; moved code to write to file to cli.js

### DIFF
--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -129,22 +129,6 @@ async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     }
   }
 
-
-
-
-  // Finally, save the data to disk
-  // const outputPath = './output';
-  // if (!fs.existsSync(outputPath)) {
-  //   logger.info(`Creating directory ${outputPath}`);
-  //   fs.mkdirSync(outputPath);
-  // }
-  // // For each bundle in our extractedData, write it to our output directory
-  // extractedData.forEach((bundle, i) => {
-  //   const outputFile = path.join(outputPath, `mcode-extraction-patient-${i + 1}.json`);
-  //   logger.debug(`Logging mCODE output to ${outputFile}`);
-  //   fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
-  // });
-  // logger.info(`Successfully logged ${extractedData.length} mCODE bundle(s) to ${outputPath}`);
   return extractedData;
 }
 

--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -129,19 +129,23 @@ async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, d
     }
   }
 
+
+
+
   // Finally, save the data to disk
-  const outputPath = './output';
-  if (!fs.existsSync(outputPath)) {
-    logger.info(`Creating directory ${outputPath}`);
-    fs.mkdirSync(outputPath);
-  }
-  // For each bundle in our extractedData, write it to our output directory
-  extractedData.forEach((bundle, i) => {
-    const outputFile = path.join(outputPath, `mcode-extraction-patient-${i + 1}.json`);
-    logger.debug(`Logging mCODE output to ${outputFile}`);
-    fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
-  });
-  logger.info(`Successfully logged ${extractedData.length} mCODE bundle(s) to ${outputPath}`);
+  // const outputPath = './output';
+  // if (!fs.existsSync(outputPath)) {
+  //   logger.info(`Creating directory ${outputPath}`);
+  //   fs.mkdirSync(outputPath);
+  // }
+  // // For each bundle in our extractedData, write it to our output directory
+  // extractedData.forEach((bundle, i) => {
+  //   const outputFile = path.join(outputPath, `mcode-extraction-patient-${i + 1}.json`);
+  //   logger.debug(`Logging mCODE output to ${outputFile}`);
+  //   fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
+  // });
+  // logger.info(`Successfully logged ${extractedData.length} mCODE bundle(s) to ${outputPath}`);
+  return extractedData;
 }
 
 module.exports = {

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -27,8 +27,7 @@ const allEntries = !entriesFilter;
 
 async function runApp() {
   try {
-    extractedData = await mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
-
+    const extractedData = await mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
 
     // Finally, save the data to disk
     const outputPath = './output';
@@ -43,8 +42,7 @@ async function runApp() {
       fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
     });
     logger.info(`Successfully logged ${extractedData.length} mCODE bundle(s) to ${outputPath}`);
-
-    } catch (e) {
+  } catch (e) {
     if (debug) logger.level = 'debug';
     logger.error(e.message);
     logger.debug(e.stack);

--- a/src/cli/cli.js
+++ b/src/cli/cli.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const path = require('path');
 const program = require('commander');
 const { MCODEClient } = require('../client/MCODEClient');
@@ -26,8 +27,24 @@ const allEntries = !entriesFilter;
 
 async function runApp() {
   try {
-    await mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
-  } catch (e) {
+    extractedData = await mcodeApp(MCODEClient, fromDate, toDate, configFilepath, runLogFilepath, debug, allEntries);
+
+
+    // Finally, save the data to disk
+    const outputPath = './output';
+    if (!fs.existsSync(outputPath)) {
+      logger.info(`Creating directory ${outputPath}`);
+      fs.mkdirSync(outputPath);
+    }
+    // For each bundle in our extractedData, write it to our output directory
+    extractedData.forEach((bundle, i) => {
+      const outputFile = path.join(outputPath, `mcode-extraction-patient-${i + 1}.json`);
+      logger.debug(`Logging mCODE output to ${outputFile}`);
+      fs.writeFileSync(outputFile, JSON.stringify(bundle), 'utf8');
+    });
+    logger.info(`Successfully logged ${extractedData.length} mCODE bundle(s) to ${outputPath}`);
+
+    } catch (e) {
     if (debug) logger.level = 'debug';
     logger.error(e.message);
     logger.debug(e.stack);


### PR DESCRIPTION
# Summary
The function mcodeApp in src/cli/app.js was modified to return the extractedData object instead of writing the results to a file. src/cli/cli.js was modified to write the results of calling mocdeApp to a file.

## New behavior
cli.js writes the results of extraction to a file instead of app.js.

## Code changes
The code to write to a file was moved from app.js to cli.js and replaced with a return statement.

# Testing guidance
Use 'npm start' to run extraction.
