### PR TITLE
Add initial schema for one config property

### DIFF
--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -1,0 +1,26 @@
+{
+  "$id": "csv-config",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "Schema for CSV config files. TODO: Fill out the rest of this schema will all config properties",
+  "type": "object",
+  "properties": {
+    "extractors": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/extractor"
+      }
+    }
+  },
+  "$defs": {
+    "extractor": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        }
+      },
+      "required": ["type"]
+    }
+  },
+  "required": ["extractors"]
+}


### PR DESCRIPTION
# Summary

Add a basic schema for our csv config. **Note:** This schema is not complete. We just wanted a simple skeleton in here that we can expand on. This will allow us to parallelize some of the work of authoring the rest of the schema and using said schema in the app to report errors.

## New behavior

N/A

## Code changes

Added a schema file that will later be used for extractor config.

# Testing guidance

Head over to https://www.jsonschemavalidator.net/s/awUd23pG. This is an online playground that should have the schema from this PR and some sample content in the web. Try removing the "extractors" property which I've marked as required, or try removing the "type" property from an entry in the extractors array, which I've also marked required.

Just make sure the schema makes sense, can be built on, and works with some simple test cases in the online playground.