### PR TITLE
Adding implementation of extractor dependencies

### DIFF
--- a/src/client/MCODEClient.js
+++ b/src/client/MCODEClient.js
@@ -22,6 +22,7 @@ const {
   FHIRPatientExtractor,
   FHIRProcedureExtractor,
 } = require('../extractors');
+const { sortExtractors } = require('../helpers/dependencyUtils.js');
 
 class MCODEClient extends BaseClient {
   constructor({ extractors, commonExtractorArgs, webServiceAuthConfig }) {
@@ -51,6 +52,21 @@ class MCODEClient extends BaseClient {
     );
     // Store the extractors defined by the configuration file as local state
     this.extractorConfig = extractors;
+    // Define information about the order and dependencies of extractors
+    const dependencyInfo = [
+      { type: 'CSVPatientExtractor', dependencies: [] },
+      { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVCancerDiseaseStatusExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVClinicalTrialInformationExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVTreatmentPlanChangeExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVStagingExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVCancerRelatedMedicationExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVProcedureExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVObservationExtractor', dependencies: ['CSVPatientExtractor'] },
+      { type: 'CSVAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
+    ];
+    // Sort extractors based on order and dependencies
+    sortExtractors(this.extractorConfig, dependencyInfo);
     // Store webServiceAuthConfig if provided`
     this.authConfig = webServiceAuthConfig;
     this.commonExtractorArgs = {

--- a/src/client/MCODEClient.js
+++ b/src/client/MCODEClient.js
@@ -66,7 +66,7 @@ class MCODEClient extends BaseClient {
       { type: 'CSVAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
     ];
     // Sort extractors based on order and dependencies
-    sortExtractors(this.extractorConfig, dependencyInfo);
+    this.extractorConfig = sortExtractors(this.extractorConfig, dependencyInfo);
     // Store webServiceAuthConfig if provided`
     this.authConfig = webServiceAuthConfig;
     this.commonExtractorArgs = {

--- a/src/helpers/dependencyUtils.js
+++ b/src/helpers/dependencyUtils.js
@@ -14,7 +14,7 @@ const logger = require('./logger');
  */
 function sortExtractors(extractors, dependencyInfo) {
   const missing = {};
-  // Filter dependency info to onlly extractors in the config
+  // Filter dependency info to only extractors in the config
   dependencyInfo.filter((e) => extractors.map((x) => x.type).includes(e.type)).forEach((extractor) => {
     // For each extractor, check if its dependencies are present
     extractor.dependencies.forEach((dependency) => {
@@ -35,8 +35,10 @@ function sortExtractors(extractors, dependencyInfo) {
     throw new Error('Some extractors are missing dependencies, see above for details.');
   }
   // If no missing dependencies, sort extractors into correct order
+  const sortedExtractors = [...extractors];
   const order = dependencyInfo.map((x) => x.type);
-  extractors.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type));
+  sortedExtractors.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type));
+  return sortedExtractors;
 }
 
 module.exports = {

--- a/src/helpers/dependencyUtils.js
+++ b/src/helpers/dependencyUtils.js
@@ -1,0 +1,44 @@
+const logger = require('./logger');
+
+/**
+ * Checks if any dependencies of extractors are missing.
+ * If no depedencies are missing, sorts extractors into the correct order.
+ * @param {Array} extractors array of extractors from the config file, this function will modify the order of this array
+ * @param {Array} dependencyInfo array of objects dictacting order of extractors and their dependencies
+ * Example of dependencyInfo:
+ * [
+ *  { type: 'CSVPatientExtractor', dependencies: [] },
+ *  { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
+ *  ...
+ * ]
+ */
+function sortExtractors(extractors, dependencyInfo) {
+  const missing = {};
+  // Filter dependency info to onlly extractors in the config
+  dependencyInfo.filter((e) => extractors.map((x) => x.type).includes(e.type)).forEach((extractor) => {
+    // For each extractor, check if its dependencies are present
+    extractor.dependencies.forEach((dependency) => {
+      if (extractors.filter((e) => e.type === dependency).length === 0) {
+        if (missing[dependency] === undefined) {
+          missing[dependency] = [extractor.type];
+        } else {
+          missing[dependency].push(extractor.type);
+        }
+      }
+    });
+  });
+  // If extractors are missing, alert user which are missing
+  if (Object.keys(missing).length > 0) {
+    Object.keys(missing).forEach((extractor) => {
+      logger.error(`Missing dependency: ${extractor} (required by: ${missing[extractor].join(', ')})`);
+    });
+    throw new Error('Some extractors are missing dependencies, see above for details.');
+  }
+  // If no missing dependencies, sort extractors into correct order
+  const order = dependencyInfo.map((x) => x.type);
+  extractors.sort((a, b) => order.indexOf(a.type) - order.indexOf(b.type));
+}
+
+module.exports = {
+  sortExtractors,
+};

--- a/src/helpers/dependencyUtils.js
+++ b/src/helpers/dependencyUtils.js
@@ -3,8 +3,9 @@ const logger = require('./logger');
 /**
  * Checks if any dependencies of extractors are missing.
  * If no depedencies are missing, sorts extractors into the correct order.
- * @param {Array} extractors array of extractors from the config file, this function will modify the order of this array
+ * @param {Array} extractors array of extractors from the config file
  * @param {Array} dependencyInfo array of objects dictacting order of extractors and their dependencies
+ * @returns {Array} array of extractors sorted into the order defined in dependency info
  * Example of dependencyInfo:
  * [
  *  { type: 'CSVPatientExtractor', dependencies: [] },

--- a/test/cli/mcodeExtraction.test.js
+++ b/test/cli/mcodeExtraction.test.js
@@ -115,7 +115,7 @@ describe('mcodeExtraction', () => {
     it('should throw error when initialized with missing dependencies', async () => {
       const testConfig = {
         extractors: [
-          // Should fail when this extractor is run without patient data in context
+          // Should fail when this extractor is run without patient in config becuase patient is required dependency
           {
             label: 'CTI',
             type: 'CSVClinicalTrialInformationExtractor',

--- a/test/cli/mcodeExtraction.test.js
+++ b/test/cli/mcodeExtraction.test.js
@@ -92,6 +92,13 @@ describe('mcodeExtraction', () => {
               filePath: path.join(__dirname, './fixtures/example-clinical-trial-info.csv'),
             },
           },
+          {
+            label: 'patient',
+            type: 'CSVPatientExtractor',
+            constructorArgs: {
+              filePath: path.join(__dirname, './fixtures/example-patient.csv'),
+            },
+          },
         ],
       };
 
@@ -104,6 +111,22 @@ describe('mcodeExtraction', () => {
       expect(extractedData).toHaveLength(3);
       const flatErrors = flattenErrorValues(totalExtractionErrors);
       expect(flatErrors).toHaveLength(3);
+    });
+    it('should throw error when initialized with missing dependencies', async () => {
+      const testConfig = {
+        extractors: [
+          // Should fail when this extractor is run without patient data in context
+          {
+            label: 'CTI',
+            type: 'CSVClinicalTrialInformationExtractor',
+            constructorArgs: {
+              filePath: path.join(__dirname, './fixtures/example-clinical-trial-info.csv'),
+            },
+          },
+        ],
+      };
+
+      expect(() => new MCODEClient(testConfig)).toThrow();
     });
   });
 });

--- a/test/helpers/dependencyUtils.test.js
+++ b/test/helpers/dependencyUtils.test.js
@@ -1,0 +1,44 @@
+const _ = require('lodash');
+const { sortExtractors } = require('../../src/helpers/dependencyUtils.js');
+
+const WRONG_ORDER = [
+  { type: 'Extractor3' },
+  { type: 'Extractor1' },
+  { type: 'Extractor2' },
+];
+
+const MISSING = [
+  { type: 'Extractor1' },
+  { type: 'Extractor3' },
+];
+
+const NO_CHANGE = [
+  { type: 'Extractor1' },
+  { type: 'Extractor2' },
+  { type: 'Extractor3' },
+];
+
+const DEPENDENCY_INFO = [
+  { type: 'Extractor1', dependencies: [] },
+  { type: 'Extractor2', dependencies: ['Extractor1'] },
+  { type: 'Extractor3', dependencies: ['Extractor1', 'Extractor2'] },
+];
+
+describe('sortExtractors', () => {
+  test('should put extractors in the correct order', () => {
+    sortExtractors(WRONG_ORDER, DEPENDENCY_INFO);
+    expect(WRONG_ORDER[0].type).toEqual('Extractor1');
+    expect(WRONG_ORDER[1].type).toEqual('Extractor2');
+    expect(WRONG_ORDER[2].type).toEqual('Extractor3');
+  });
+
+  test('should change nothing if all extractors are in order with all dependencies', () => {
+    const unchanged = _.cloneDeep(NO_CHANGE);
+    sortExtractors(unchanged, DEPENDENCY_INFO);
+    expect(unchanged).toEqual(NO_CHANGE);
+  });
+
+  test('should fail when missing dependencies', () => {
+    expect(() => sortExtractors(MISSING, DEPENDENCY_INFO)).toThrow();
+  });
+});

--- a/test/helpers/dependencyUtils.test.js
+++ b/test/helpers/dependencyUtils.test.js
@@ -1,4 +1,3 @@
-const _ = require('lodash');
 const { sortExtractors } = require('../../src/helpers/dependencyUtils.js');
 
 const WRONG_ORDER = [
@@ -26,15 +25,14 @@ const DEPENDENCY_INFO = [
 
 describe('sortExtractors', () => {
   test('should put extractors in the correct order', () => {
-    sortExtractors(WRONG_ORDER, DEPENDENCY_INFO);
-    expect(WRONG_ORDER[0].type).toEqual('Extractor1');
-    expect(WRONG_ORDER[1].type).toEqual('Extractor2');
-    expect(WRONG_ORDER[2].type).toEqual('Extractor3');
+    const sorted = sortExtractors(WRONG_ORDER, DEPENDENCY_INFO);
+    expect(sorted[0].type).toEqual('Extractor1');
+    expect(sorted[1].type).toEqual('Extractor2');
+    expect(sorted[2].type).toEqual('Extractor3');
   });
 
   test('should change nothing if all extractors are in order with all dependencies', () => {
-    const unchanged = _.cloneDeep(NO_CHANGE);
-    sortExtractors(unchanged, DEPENDENCY_INFO);
+    const unchanged = sortExtractors(NO_CHANGE, DEPENDENCY_INFO);
     expect(unchanged).toEqual(NO_CHANGE);
   });
 


### PR DESCRIPTION
# Summary
Adds new `sortExtractors()` function called within `MCODEClient` which sorts extractors based on a predefined order (defined in `MCODEClient.js`) and will throw an error detailing any missing dependencies. Since there was some uncertainty over which method of implementing extractor dependencies was best, I would appreciate people's further thoughts after seeing this method in action and I wouldn't be against going back and trying another method if people think this isn't quite what we wanted.

Also, This new functionality makes a previous test fail (in `mcodeExtraction.test.js`). I didn't want to just remove it because I feel like we could modify the test to work a different way, I just wasn't sure how, so I would appreciate some help with that
## New behavior
If extractors are put out of order in the config file (e.g. Patient is put after extractors that require Patient), they will be reordered automatically before running the client and if any extractor's dependencies are missing an error will be thrown.
## Code changes
- `dependencyUtils.js` is a new file containing the `sortExtractors()` function that sorts extractors and checks for missing dependencies
- `dependencyUtils.test.js` contains tests for this new function
- `MCODEClient.js` now contains information about the order and dependencies of extractors and calls the sortExtractors function to sort based on that order and check those dependencies
# Testing guidance
- Put the patient extractor somewhere other than the start of your config file and see that the client still runs properly
- Remove the patient extractor entirely and see that you receive an error telling you that it is missing and which extractors require it
- Ensure that all tests pass (see note in summary about the one that doesn't) and check that the new tests cover enough cases