### PR TITLE
Debug flag bug

### DIFF
--- a/src/application/app.js
+++ b/src/application/app.js
@@ -39,7 +39,7 @@ function checkInputAndConfig(config, fromDate, toDate) {
 }
 
 async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries) {
-  logger.level = (debug ? 'debug' : 'info');
+  logger.level = debug ? 'debug' : 'info';
   const config = getConfig(pathToConfig);
   checkInputAndConfig(config, fromDate, toDate);
 

--- a/src/application/app.js
+++ b/src/application/app.js
@@ -39,7 +39,7 @@ function checkInputAndConfig(config, fromDate, toDate) {
 }
 
 async function mcodeApp(Client, fromDate, toDate, pathToConfig, pathToRunLogs, debug, allEntries) {
-  if (debug) logger.level = 'debug';
+  logger.level = (debug ? 'debug' : 'info');
   const config = getConfig(pathToConfig);
   checkInputAndConfig(config, fromDate, toDate);
 


### PR DESCRIPTION
# Summary
Originally, the mcodeApp function in src/application/app.js only changed the logger level if debug was true, and didn't change it back to 'info' if debug was false. Since the UI can run extraction multiple times in a row, this caused a bug.

## New behavior
The mcodeApp function now changes the logger level back to 'info' if the debug flag is false.

## Code changes
The if statement on line 42 of src/application/app.js was changed to a ternary operator.

# Testing guidance
In the root package.json file of code-extraction-ui, set the location of mcode-extraction-framework to "file:local_file_path_to_framework". Run npm install, then npm start. Click on "Extract New", check "Log output debugging information", and then click "Submit". Either look at the terminal to see the logs or, if on the logger-display branch, click on "Log File" in the sidebar of the result page. Click the "Exit" button on the result page, then run extraction again with "Log debugging information" unchecked. Regardless of the order in which you run extraction with and without debug-level logs, as well as the number of times you repeat this process, the proper logs should show up.
