### PR TITLE
New validation logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ To mask a property, provide an array of the properties to mask in the `construct
 
 The mCODE Extraction Client will extract all data that is provided in the CSV files by default, regardless of any dates associated with each row of data. It is recommended that any required date filtering is performed outside of the scope of this client.
 
-If for any reason a user is required to specify a date range to be extracted through this client, users _must_ add a `dateRecorded` column in every data CSV file. This column will indicate when each row of data was added to the CSV file. Note that this date _does not_ correspond to any date associated with the data element.
+If for any reason a user is required to specify a date range to be extracted through this client, users _must_ add a `dateRecorded` column in every relevant data CSV file. This column will indicate when each row of data was added to the CSV file. Note that this date _does not_ correspond to any date associated with the data element.
+
+Note that some resources should always be included and should not be filtered out with a `dateRecorded` column and date. For example, every extraction should extract patient information to a Patient resource, so no `dateRecorded` column should be provided in a CSV that contains the Patient information.
 
 #### CLI From-Date and To-Date (NOT recommended use)
 

--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -104,7 +104,7 @@ class BaseClient {
       const warnMessages = [];
       const debugMessages = [];
       invalidResources.forEach(({ failureId, errors }) => {
-        warnMessages.push(`${failureId} at ${errors.map((e) => e.dataPath).join(',')}`);
+        warnMessages.push(`${failureId} at ${errors.map((e) => e.dataPath).join(', ')}`);
 
         errors.forEach((e) => {
           debugMessages.push(`${failureId} at ${e.dataPath} - ${e.message}`);

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -5,7 +5,7 @@ const metaSchema = require('ajv/lib/refs/json-schema-draft-06.json');
 const schema = require('./schemas/fhir.schema.json');
 const logger = require('./logger');
 
-const ajv = new Ajv({ logger: false });
+const ajv = new Ajv({ logger: false, allErrors: true });
 ajv.addMetaSchema(metaSchema);
 const validate = ajv.compile(schema);
 

--- a/src/helpers/fhirUtils.js
+++ b/src/helpers/fhirUtils.js
@@ -7,7 +7,7 @@ const logger = require('./logger');
 
 const ajv = new Ajv({ logger: false });
 ajv.addMetaSchema(metaSchema);
-const validator = ajv.addSchema(schema, 'FHIR');
+const validate = ajv.compile(schema);
 
 // Unit codes and display values fo Vital Signs values
 // Code mapping is based on http://hl7.org/fhir/R4/observation-vitalsigns.html
@@ -164,17 +164,29 @@ const logOperationOutcomeInfo = (operationOutcome) => {
 };
 
 function isValidFHIR(resource) {
-  return validator.validate('FHIR', resource);
+  return validate(resource);
 }
+
+function errorFilter(error) {
+  return error.message !== 'should NOT have additional properties' && error.keyword !== 'oneOf' && error.keyword !== 'const';
+}
+
 function invalidResourcesFromBundle(bundle) {
   // Bundle is assumed to have all resources in bundle.entry[x].resource
   const failingResources = [];
   bundle.entry.forEach((e) => {
     const { resource } = e;
     const { id, resourceType } = resource;
-    if (!validator.validate('FHIR', resource)) {
+
+    // Validate only this resource to get more scoped errors
+    const subSchema = schema;
+    subSchema.oneOf = [{ $ref: `#/definitions/${resourceType}` }];
+
+    const validateResource = ajv.compile(subSchema);
+
+    if (!validateResource(resource)) {
       const failureId = `${resourceType}-${id}`;
-      failingResources.push(failureId);
+      failingResources.push({ failureId, errors: validateResource.errors.filter(errorFilter) });
     }
   });
   return failingResources;

--- a/test/client/BaseClient.test.js
+++ b/test/client/BaseClient.test.js
@@ -76,8 +76,8 @@ describe('BaseClient', () => {
     });
     it('should iterate over all extractors gets, aggregating resultant entries in a bundle', async () => {
       const extractorClassesWithEntryGets = [
-        class Ext1 { get() { return { entry: [{ resource: 'here' }] }; }},
-        class Ext2 { get() { return { entry: [{ resource: 'alsoHere' }] }; }},
+        class Ext1 { get() { return { entry: [{ resource: { resourceType: 'Patient' } }] }; }},
+        class Ext2 { get() { return { entry: [{ resource: { resourceType: 'Patient' } }] }; }},
         class Ext3 { get() { throw new Error('Error'); }},
       ];
       engine.registerExtractors(...extractorClassesWithEntryGets);

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -160,6 +160,26 @@ describe('invalidResourcesFromBundle', () => {
     invalidBundle.entry[0].resource = invalidResource;
     // This is dependent on implementation details intrinsic to invalidResourcesFromBundle
     const invalidResourceId = `${invalidResource.resourceType}-${invalidResource.id}`;
-    expect(invalidResourcesFromBundle(invalidBundle)).toEqual([invalidResourceId]);
+    expect(invalidResourcesFromBundle(invalidBundle)).toEqual([
+      {
+        failureId: invalidResourceId,
+        errors: [
+          {
+            keyword: 'enum',
+            dataPath: '.gender',
+            schemaPath: '#/properties/gender/enum',
+            params: {
+              allowedValues: [
+                'male',
+                'female',
+                'other',
+                'unknown',
+              ],
+            },
+            message: 'should be equal to one of the allowed values',
+          },
+        ],
+      },
+    ]);
   });
 });

--- a/test/helpers/fhirUtils.test.js
+++ b/test/helpers/fhirUtils.test.js
@@ -146,6 +146,7 @@ describe('isValidFHIR', () => {
   test('Should return true when provided valid FHIR resources', () => {
     expect(isValidFHIR(validResource)).toEqual(true);
   });
+
   test('Should return false when provided invalid FHIR resources', () => {
     expect(isValidFHIR(invalidResource)).toEqual(false);
   });
@@ -155,7 +156,42 @@ describe('invalidResourcesFromBundle', () => {
   test('Should return an empty array when all resources are valid', () => {
     expect(invalidResourcesFromBundle(emptyBundle)).toEqual([]);
   });
-  test('Should return an array of all invalid resources when they exist', () => {
+
+  test('Should return an error for each invalid resource', () => {
+    const secondInvalidResource = {
+      ...invalidResource,
+      id: 'secondInvalidResource',
+    };
+
+    const invalidBundleWithTwoResources = {
+      resourceType: 'Bundle',
+      entry: [
+        {
+          resource: invalidResource,
+        },
+        {
+          resource: secondInvalidResource,
+        },
+      ],
+    };
+
+    const response = invalidResourcesFromBundle(invalidBundleWithTwoResources);
+
+    const invalidResourceId = `${invalidResource.resourceType}-${invalidResource.id}`;
+    const invalidResourceId2 = `${secondInvalidResource.resourceType}-${secondInvalidResource.id}`;
+
+    expect(response).toHaveLength(2);
+    expect(response).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        failureId: invalidResourceId,
+      }),
+      expect.objectContaining({
+        failureId: invalidResourceId2,
+      }),
+    ]));
+  });
+
+  test('Should return detailed error for invalid resource', () => {
     const invalidBundle = { ...bundleWithOneEntry };
     invalidBundle.entry[0].resource = invalidResource;
     // This is dependent on implementation details intrinsic to invalidResourcesFromBundle
@@ -181,5 +217,31 @@ describe('invalidResourcesFromBundle', () => {
         ],
       },
     ]);
+  });
+
+  test('Should return multiple errors if present within the same resource', () => {
+    // invalidResource already has an invalid gender enum value
+    const invalidResourceWithTwoProps = {
+      ...invalidResource,
+      birthDate: 'not-a-real-date',
+    };
+
+    const invalidBundle = {
+      resourceType: 'Bundle',
+      entry: [
+        {
+          resource: invalidResourceWithTwoProps,
+        },
+      ],
+    };
+
+    const response = invalidResourcesFromBundle(invalidBundle);
+
+    expect(response).toHaveLength(1);
+
+    const [invalidResponseObj] = response;
+
+    expect(invalidResponseObj.errors).toBeDefined();
+    expect(invalidResponseObj.errors).toHaveLength(2);
   });
 });


### PR DESCRIPTION
# Summary

This pull requests adds more detailed log information when a resource within the extracted bundle fails validation.

It introduces use of the `compile` function in AJV to generate a validator object that comes with `errors` we can filter and display in a more detailed manner.

We also now use the `subSchema` motif to pul off refs to specific resources in the schema that we wish to validate from within the loop, allowing us to collect all the error messages present for that resource rather than short circuit after one.

## New behavior

New log messages to the console when a resource fails validation. E.g.:

```
# Warning level
15:20:21.41 [warn]:     Extracted bundle is not valid FHIR, the following resources failed validation: Patient-789 at .gender
```

```
# Debug level
15:20:21.41 [warn]:     Extracted bundle is not valid FHIR, the following resources failed validation: Patient-789 at .gender
15:20:21.41 [debug]:    Patient-789 at .gender - should be equal to one of the allowed values
```

The default behavior now logs the resource ID and any attributes on that resource that failed validation. When debug is enabled, the specific error message will be displayed too for every error.

## Code changes

* Modify `fhirUtils` to use `ajv compile` and the sub schema
* Update `BaseClient` to join all errors and resources failing during log warn and debug statements
* Update some test fixtures to adhere to new validation behavior

# Testing guidance

To cause some validation errors, I would recommend making some changes in our templates. Some test cases that I tried included changing properties that were supposed to be dates and making them just strings or booleans or something, and also changing attributes that are enums (e.g. gender) to have a value that doesn't exist in that enum.

Feel free to experiment with other cases that you might expect to fail validation smartly.

Run without debug to see just the basic warning message that lists the resources that are failing and where they are failing. Run with debug to see the detailed error messages.
