### PR TITLE
Adding custom schema format for comma separated emails

### DIFF
--- a/src/helpers/configValidator.js
+++ b/src/helpers/configValidator.js
@@ -5,6 +5,15 @@ const configSchema = require('./schemas/config.schema.json');
 
 const ajv = new Ajv({ logger: false, allErrors: true });
 ajv.addMetaSchema(metaSchema);
+
+ajv.addFormat('comma-separated-emails', {
+  type: 'string',
+  validate: (emails) => {
+    const emailRegex = new RegExp(/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i);
+    return emails.split(',').every((email) => emailRegex.test(email.trim()));
+  },
+});
+
 const validator = ajv.addSchema(configSchema, 'config');
 
 function validateConfig(config) {

--- a/src/helpers/configValidator.js
+++ b/src/helpers/configValidator.js
@@ -9,6 +9,7 @@ ajv.addMetaSchema(metaSchema);
 ajv.addFormat('comma-separated-emails', {
   type: 'string',
   validate: (emails) => {
+    // this is Ajv's regex for email format (https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts#L106)
     const emailRegex = new RegExp(/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i);
     return emails.split(',').every((email) => emailRegex.test(email.trim()));
   },

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -49,12 +49,14 @@
         "to": {
           "anyOf": [
             {
-              "type": "string"
+              "type": "string",
+              "format": "comma-separated-emails"
             },
             {
               "type": "array",
               "items": {
-                "type": "string"
+                "type": "string",
+                "format": "email"
               }
             }
           ]


### PR DESCRIPTION
# Summary
Adding a custom format to the config validator that checks if a string has the format of emails separated by commas, for example: `whoever@whatver.com,somone@wherever.com`. This new format is used to validate the `notificationInfo.to` field in the config
## New behavior
The config validator will now ensure that the `notificationInfo.to` field of the config is either an array of emails or a string of emails separated by commas
## Code changes
- Custom format, `comma-separated-emails`, added to `configValidator.js` which splits a string at any commas, strips excess whitespace and then validates the resulting strings against Ajv's email format regex
- `config.schema.json` updated to use `comma-separated-emails` for `notificationInfo.to`
# Testing guidance
Here are some variations to test:
- `test@example.com` a single email should still be valid
- `test#example.com` a single invalid email should not be valid
- `test@example.com,example@test.com` emails separated by comma should be valid
- `test@example.com,demo&example.com` should not be valid if any item is not a valid email
- Be sure to test any other cases you can think of in case I missed something