### PR TITLE
Adding email with name custom schema format

### DIFF
--- a/src/helpers/configValidator.js
+++ b/src/helpers/configValidator.js
@@ -19,7 +19,7 @@ ajv.addFormat('email-with-name', {
   validate: (email) => {
     // this is Ajv's regex for email format (https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts#L106)
     const emailRegex = new RegExp(/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i);
-    return emailRegex.test(email.split(' ').pop());
+    return emailRegex.test(email.trim().split(' ').pop());
   },
 });
 

--- a/src/helpers/configValidator.js
+++ b/src/helpers/configValidator.js
@@ -14,6 +14,14 @@ ajv.addFormat('comma-separated-emails', {
     return emails.split(',').every((email) => emailRegex.test(email.trim()));
   },
 });
+ajv.addFormat('email-with-name', {
+  type: 'string',
+  validate: (email) => {
+    // this is Ajv's regex for email format (https://github.com/ajv-validator/ajv-formats/blob/master/src/formats.ts#L106)
+    const emailRegex = new RegExp(/^[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)*$/i);
+    return emailRegex.test(email.split(' ').pop());
+  },
+});
 
 const validator = ajv.addSchema(configSchema, 'config');
 

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -44,7 +44,8 @@
           "type": "integer"
         },
         "from": {
-          "type": "string"
+          "type": "string",
+          "format": "email-with-name"
         },
         "to": {
           "anyOf": [


### PR DESCRIPTION
# Summary
`notificationInfo.from` now uses a custom format for emails with a name in front of them. This format considers anything that ends with a valid email to be valid, for example: `Example Name example@demo.com`
## New behavior
Config validator has a new custom format that splits the input on spaces and checks that the last element is a valid email.
## Code changes
- `configValidator.js` now has new custom format `email-with-name` described above
- `config.schema.json` updated to use new format for `notificationInfo.from`
# Testing guidance
Cases to test:
- `Any number of words followed by anEmail@test.com` should be valid
- `justAnEmail@test.com` should be valid
- `Words with no email` should not be valid
- `emailFirst@test.com then some words` should not be valid