### PR TITLE
Better logging in the CSVURLModule 

### DIFF
--- a/src/client/BaseClient.js
+++ b/src/client/BaseClient.js
@@ -54,7 +54,7 @@ class BaseClient {
           }
           return ((await curExtractorsValid) && isExtractorValid);
         } catch (e) {
-          logger.warn(`Extractor ${name} FAILED CSV validation`);
+          logger.warn(`Extractor ${name} could not validate. Encountered the following error: ${e.message}`);
           return false;
         }
       }

--- a/src/helpers/csvParsingUtils.js
+++ b/src/helpers/csvParsingUtils.js
@@ -7,6 +7,7 @@ function stringNormalizer(str) {
 
 // For translating null/nil-like values into empty strings
 function normalizeEmptyValues(data, unalterableColumns = []) {
+  logger.debug('Checking for empty CSV values to normalize');
   const EMPTY_VALUES = ['null', 'nil'].map(stringNormalizer);
   const normalizedUnalterableColumns = unalterableColumns.map(stringNormalizer);
   // Flag tracking if empty values were normalized or not.

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -20,7 +20,7 @@ class CSVURLModule {
       const csvData = await axios.get(this.url)
         .then((res) => res.data)
         .catch((e) => {
-          logger.error('Error occurred when getting CSV data using url');
+          logger.error('Error occurred when making a connection to this url');
           throw e;
         });
       logger.debug('Web request successful');
@@ -29,7 +29,7 @@ class CSVURLModule {
         columns: (header) => header.map((column) => stringNormalizer(column)),
         bom: true,
       });
-      logger.debug('Data parsing successful');
+      logger.debug('CSV Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
     }
   }

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -16,13 +16,22 @@ class CSVURLModule {
   // If data is already cached, this function does nothing
   async fillDataCache() {
     if (!this.data) {
-      const csvData = await axios.get(this.url).then((res) => res.data);
+      logger.debug('Filling the data cache of CSVURLModule');
+      const csvData = await axios.get(this.url)
+        .then((res) => res.data)
+        .catch((e) => {
+          logger.error('Error occurred when getting CSV data using url');
+          throw e;
+        });
+      logger.debug('Web request successful');
       // Parse then normalize the data
       const parsedData = parse(csvData, {
         columns: (header) => header.map((column) => stringNormalizer(column)),
         bom: true,
       });
+      logger.debug('Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
+      logger.debug('Normalization of empty values successful');
     }
   }
 

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -31,7 +31,6 @@ class CSVURLModule {
       });
       logger.debug('Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
-      logger.debug('Normalization of empty values successful');
     }
   }
 


### PR DESCRIPTION
# Summary

This PR addresses STEAM-670: 'CSVURLModule should validate the the URL it receives is a valid URL'. Upon closer inspection, it doesn't look like we do the level of validation we expected in the CSVFileModule. Accordingly, all this task takes up is better logging in fillDataCache logic. 

## New behavior

When a URL is provided that cannot be used successfully in CSV extraction, error messages are logged to the console. Additionally, debug messages have been added throughout the `fillDataCache` routine. 

## Code changes
- Logs added throughout the `fillDataCache` function.

# Testing guidance
- With a URL-enabled csv extractor, run the tool with a valid URL and ensure that extraction works. 
- With a URL-enabled csv extractor, run the tool with an invalid URL and ensure that the error message logs as expected. 

Below is an example (courtesy of @julianxcarter ) of a valid URL extractor config
```json
{
      "label": "cancerDiseaseStatus",
      "type": "CSVCancerDiseaseStatusExtractor",
      "constructorArgs": {
        "url": "https://raw.githubusercontent.com/mcode/mcode-extraction-framework/main/test/sample-client-data/cancer-disease-status-information.csv"
      }
    }
```