### PR TITLE
Replaced shajs with crypto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9539,15 +9539,6 @@
         }
       }
     },
-    "sha.js": {
-      "version": "2.4.11",
-      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
-      "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
-      "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
-    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash": "^4.17.21",
     "moment": "^2.26.0",
     "nodemailer": "^6.4.16",
-    "sha.js": "^2.4.9",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 const fhirpath = require('fhirpath');
-const shajs = require('sha.js');
+const crypto = require('crypto');
 const { extensionArr, dataAbsentReasonExtension } = require('../templates/snippets/extension.js');
 
 // Based on the OMB Ethnicity table found here:http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-ethnicity-category.html
@@ -104,7 +104,9 @@ function maskPatientData(bundle, mask) {
       patient._gender = masked;
     } else if (field === 'mrn' && 'identifier' in patient) {
       // id and fullURL still need valid values, so we use a hashed version of MRN instead of dataAbsentReason
-      const maskedMRN = shajs('sha256').update(patient.id).digest('hex');
+      const hash = crypto.createHash('sha256');
+      const maskedMRN = hash.update(patient.id).digest('hex');
+
       patient.id = maskedMRN;
       const patientEntry = fhirpath.evaluate(
         bundle,

--- a/src/templates/ResourceGenerator.js
+++ b/src/templates/ResourceGenerator.js
@@ -1,5 +1,5 @@
 const _ = require('lodash');
-const shajs = require('sha.js');
+const crypto = require('crypto');
 const logger = require('../helpers/logger');
 
 const { adverseEventTemplate } = require('./AdverseEventTemplate');
@@ -36,7 +36,8 @@ function loadFhirTemplate(mcodeProfileID) {
 
 // Hash a data object to get a unique, deterministic ID for it
 function generateResourceId(data) {
-  return shajs('sha256').update(JSON.stringify(data)).digest('hex');
+  const hash = crypto.createHash('sha256');
+  return hash.update(JSON.stringify(data)).digest('hex');
 }
 
 // Ensures that empty data in the resource object carries a null value, rather than being undefined or an empty string


### PR DESCRIPTION
# Summary

Removes the shajs dependency and uses the Node-native Crypto library. 

## New behavior

Ideally none.

## Code changes

Replaces all instances of the sha library with the crypto library. 

# Testing guidance

Ensure all tests pass. 