### PR TITLE
Updating CancerDiseaseStatusTemplate to STU2

### DIFF
--- a/src/templates/CancerDiseaseStatusTemplate.js
+++ b/src/templates/CancerDiseaseStatusTemplate.js
@@ -74,8 +74,8 @@ function cancerDiseaseStatusTemplate({
       coding: [
         coding({
           system: 'http://loinc.org',
-          code: '88040-1',
-          display: 'Response to cancer treatment',
+          code: '97509-4',
+          display: 'Cancer Disease Progression',
         }),
       ],
     },

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -28,8 +28,8 @@
           "coding": [
             {
               "system": "http://loinc.org",
-              "code": "88040-1",
-              "display": "Response to cancer treatment"
+              "code": "97509-4",
+              "display": "Cancer Disease Progression"
             }
           ]
         },

--- a/test/templates/fixtures/disease-status-resource.json
+++ b/test/templates/fixtures/disease-status-resource.json
@@ -22,8 +22,8 @@
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "88040-1",
-        "display": "Response to cancer treatment"
+        "code": "97509-4",
+        "display": "Cancer Disease Progression"
       }
     ]
   },

--- a/test/templates/fixtures/minimal-disease-status-resource.json
+++ b/test/templates/fixtures/minimal-disease-status-resource.json
@@ -22,8 +22,8 @@
     "coding": [
       {
         "system": "http://loinc.org",
-        "code": "88040-1",
-        "display": "Response to cancer treatment"
+        "code": "97509-4",
+        "display": "Cancer Disease Progression"
       }
     ]
   },


### PR DESCRIPTION
# Summary
CancerDiseaseStatus profile now uses a newly-created LOINC code, 97509-4 “Cancer Disease Progression”. In STU 1, the LOINC code chosen to represent this observation (88040-1, “Response to cancer treatment”) did not precisely match the meaning of this profile because cancer disease status is observable regardless of whether the patient is under treatment
## New behavior
Cancer Disease Status template now uses the new LOINC code from STU2
## Code changes
- `CancerDiseaseStatusTemplate.js` now uses the new LOINC code
- Relevant test fixtures updated to match the new code
# Testing guidance
- Ensure that all tests pass
- Run the client with CancerDiseaseStatus and see that the output now contains the new LOINC code: `97509-4`
- Check if there are any updates from STU2 for the CancerDiseaseStatusTemplate that I missed
