### PR TITLE
Updating Staging and TNM Category Templates to STU2

### DIFF
--- a/src/templates/StagingTemplate.js
+++ b/src/templates/StagingTemplate.js
@@ -6,7 +6,6 @@ function getTypeSpecificData(type) {
     return {
       categoryCode: 'survey',
       code: '21908-9',
-      profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group',
     };
   }
 
@@ -14,7 +13,6 @@ function getTypeSpecificData(type) {
     return {
       categoryCode: 'laboratory',
       code: '21902-2',
-      profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-stage-group',
     };
   }
 
@@ -46,13 +44,13 @@ function stagingTemplate({
   }
 
   const typeSpecificData = getTypeSpecificData(type);
-  const { categoryCode, code, profileUrl } = typeSpecificData;
+  const { categoryCode, code } = typeSpecificData;
 
   return {
     resourceType: 'Observation',
     id,
     meta: {
-      profile: [profileUrl],
+      profile: ['http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group'],
     },
     status: 'final',
     category: [

--- a/src/templates/TNMCategoryTemplate.js
+++ b/src/templates/TNMCategoryTemplate.js
@@ -7,21 +7,21 @@ function getCategorySpecificData(stageType, categoryType) {
     if (categoryType === 'Tumor') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-primary-tumor-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category',
         code: '21905-5',
       };
     }
     if (categoryType === 'Metastases') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-distant-metastases-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category',
         code: '21907-1',
       };
     }
     if (categoryType === 'Nodes') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-regional-nodes-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category',
         code: '21906-3',
       };
     }
@@ -30,21 +30,21 @@ function getCategorySpecificData(stageType, categoryType) {
     if (categoryType === 'Tumor') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-primary-tumor-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category',
         code: '21899-0',
       };
     }
     if (categoryType === 'Metastases') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-distant-metastases-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category',
         code: '21901-4',
       };
     }
     if (categoryType === 'Nodes') {
       return {
         categoryCode,
-        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-regional-nodes-category',
+        profileUrl: 'http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category',
         code: '21900-6',
       };
     }

--- a/test/extractors/fixtures/csv-staging-bundle.json
+++ b/test/extractors/fixtures/csv-staging-bundle.json
@@ -9,7 +9,7 @@
         "id": "626b61fd700d8ddc5a6a576a2e47944191b5f608e03083d00c49614f0158bb65",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-primary-tumor-category"
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category"
           ]
         },
         "status": "final",
@@ -67,7 +67,7 @@
         "id": "66e0e5f216bebeba287c3a3b0e220170bab88da95030e0c4bdba32f66628d00c",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-distant-metastases-category"
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category"
           ]
         },
         "status": "final",
@@ -125,7 +125,7 @@
         "id": "4469acab85a889d722f5b8b1cb786df8adbfc5f0b50ac23393ec42b8ecfd49e9",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-regional-nodes-category"
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category"
           ]
         },
         "status": "final",
@@ -183,7 +183,7 @@
         "id": "8fca0c2922335ea3c92022b4b2d4de17ba0645ce72d884b1e1c71a757c300a10",
         "meta": {
           "profile": [
-            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group"
+            "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group"
           ]
         },
         "status": "final",

--- a/test/templates/fixtures/maximal-staging-resource.json
+++ b/test/templates/fixtures/maximal-staging-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group"
     ]
   },
   "method": {

--- a/test/templates/fixtures/metastases-category-clinical-resource.json
+++ b/test/templates/fixtures/metastases-category-clinical-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-distant-metastases-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/metastases-category-pathologic-resource.json
+++ b/test/templates/fixtures/metastases-category-pathologic-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-distant-metastases-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-distant-metastases-category"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/minimal-staging-clinical-resource.json
+++ b/test/templates/fixtures/minimal-staging-clinical-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-stage-group"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/minimal-staging-pathologic-resource.json
+++ b/test/templates/fixtures/minimal-staging-pathologic-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-stage-group"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-stage-group"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/nodes-category-clinical-resource.json
+++ b/test/templates/fixtures/nodes-category-clinical-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-regional-nodes-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/nodes-category-pathologic-resource.json
+++ b/test/templates/fixtures/nodes-category-pathologic-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-regional-nodes-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-regional-nodes-category"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/tumor-category-clinical-resource.json
+++ b/test/templates/fixtures/tumor-category-clinical-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-clinical-primary-tumor-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category"
     ]
   },
   "status": "final",

--- a/test/templates/fixtures/tumor-category-pathologic-resource.json
+++ b/test/templates/fixtures/tumor-category-pathologic-resource.json
@@ -3,7 +3,7 @@
   "id": "example-id",
   "meta": {
     "profile": [
-      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-pathological-primary-tumor-category"
+      "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-tnm-primary-tumor-category"
     ]
   },
   "status": "final",


### PR DESCRIPTION
# Summary
stagingTemplate: The profile TNMStageGroup is now renamed CancerStageGroup in order to support non-TNM staging systems such as Rai, Binet, and Revised International Staging System (R-ISS)

tnmCategoryTemplate: In STU2, the separate sets of profiles for TNM Clinical and TNM Pathologic staging were combined into a single set of profiles: [CancerStageGroup](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/master/StructureDefinition-mcode-cancer-stage-group.html), [TNMPrimaryTumorCategory](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/master/ValueSet-mcode-observation-codes-primary-tumor-vs.html), [TNMRegionalNodesCategory](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/master/StructureDefinition-mcode-tnm-regional-nodes-category.html), and [TNMDistantMetastasesCategory](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/branches/master/StructureDefinition-mcode-tnm-distant-metastases-category.html).
## New behavior
All profiles that used to distinguish between Clinical and Pathologic have been consolidated to single profiles, but staging type is still necessary as an input because it is used to determine code and category within those profiles.
## Code changes
- `stagingTemplate.js` now uses the new Cancer Stage Group profile
- `TNMCategoryTemplate.js` now uses the new single set of profiles for Tumor, Nodes, and Metastases
- All relevant test fixtures have been updated to reflect changes
# Testing guidance
- Make sure all tests still pass
- Run the client with the Staging Extractor and see that the new profiles from STU2 are used
- Let me know if there are any changes from STU2 that I missed or implemented incorrectly
