### PR TITLE
New options for Patient masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ npm start -- --entries-filter --from-date YYYY-MM-DD --to-date YYY-MM-DD --run-l
 ### Masking Patient Data
 
 Patient data can be masked within the extracted `Patient` resource. When masked, the value of the field will be replaced with a [Data Absent Reason extension](https://www.hl7.org/fhir/extension-data-absent-reason.html) with the code `masked`.
-Patient properties that can be masked are: `gender`, `mrn`, `name`, `address`, `birthDate`, `language`, `ethnicity`, `birthsex`, and `race`.
+Patient properties that can be masked are: `gender`, `mrn`, `name`, `address`, `birthDate`, `language`, `ethnicity`, `birthsex`, `race`, `telecom`, `multipleBirth`, `photo`, `contact`, `generalPractitioner`, `managingOrganization`, and `link`.
 To mask a property, provide an array of the properties to mask in the `constructorArgs` of the Patient extractor. For example, the following configuration can be used to mask `address` and `birthDate`:
 
 ```bash

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -78,7 +78,9 @@ function getPatientName(name) {
  * dataAbsentReason extension with value 'masked'
  * @param {Object} bundle a FHIR bundle with a Patient resource
  * @param {Array} mask an array of fields to mask. Values can be:
- * ['gender','mrn','name','address','birthDate','language','ethnicity','birthsex','race']
+ * 'gender','mrn','name','address','birthDate','language','ethnicity','birthsex',
+ * 'race', 'telecom', 'multipleBirth', 'photo', 'contact', 'generalPractitioner',
+ * 'managingOrganization', and 'link'
  */
 function maskPatientData(bundle, mask) {
   // get Patient resource from bundle
@@ -87,7 +89,24 @@ function maskPatientData(bundle, mask) {
     'Bundle.entry.where(resource.resourceType=\'Patient\').resource,first()',
   )[0];
 
-  const validFields = ['gender', 'mrn', 'name', 'address', 'birthDate', 'language', 'ethnicity', 'birthsex', 'race'];
+  const validFields = [
+    'gender',
+    'mrn',
+    'name',
+    'address',
+    'birthDate',
+    'language',
+    'ethnicity',
+    'birthsex',
+    'race',
+    'telecom',
+    'multipleBirth',
+    'photo',
+    'contact',
+    'generalPractitioner',
+    'managingOrganization',
+    'link',
+  ];
   const masked = extensionArr(dataAbsentReasonExtension('masked'));
 
   mask.forEach((field) => {
@@ -157,6 +176,32 @@ function maskPatientData(bundle, mask) {
         delete ethnicity[0].extension[1].valueString;
         ethnicity[0].extension[1]._valueString = masked;
       }
+    } else if (field === 'telecom' && 'telecom' in patient) {
+      delete patient.telecom;
+      patient.telecom = [masked];
+    } else if (field === 'multipleBirth') {
+      if ('multipleBirthBoolean' in patient) {
+        delete patient.multipleBirthBoolean;
+        patient._multipleBirthBoolean = masked;
+      } else if ('multipleBirthInteger' in patient) {
+        delete patient.multipleBirthInteger;
+        patient._multipleBirthInteger = masked;
+      }
+    } else if (field === 'photo' && 'photo' in patient) {
+      delete patient.phoo;
+      patient.photo = [masked];
+    } else if (field === 'contact' && 'contact' in patient) {
+      delete patient.contact;
+      patient.contact = [masked];
+    } else if (field === 'generalPractitioner' && 'generalPractitioner' in patient) {
+      delete patient.generalPractitioner;
+      patient.generalPractitioner = [masked];
+    } else if (field === 'managingOrganization' && 'managingOrganization' in patient) {
+      delete patient.managingOrganization;
+      patient.managingOrganization = masked;
+    } else if (field === 'link' && 'link' in patient) {
+      delete patient.link;
+      patient.link = [masked];
     }
   });
 }

--- a/src/helpers/patientUtils.js
+++ b/src/helpers/patientUtils.js
@@ -188,7 +188,7 @@ function maskPatientData(bundle, mask) {
         patient._multipleBirthInteger = masked;
       }
     } else if (field === 'photo' && 'photo' in patient) {
-      delete patient.phoo;
+      delete patient.photo;
       patient.photo = [masked];
     } else if (field === 'contact' && 'contact' in patient) {
       delete patient.contact;

--- a/test/extractors/fixtures/extended-patient-bundle.json
+++ b/test/extractors/fixtures/extended-patient-bundle.json
@@ -1,0 +1,165 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "fullUrl": "urn:uuid:119147111821125",
+      "resource": {
+        "resourceType": "Patient",
+        "id": "119147111821125",
+        "identifier": [
+          {
+            "type": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/v2-0203",
+                  "code": "MR",
+                  "display": "Medical Record Number"
+                }
+              ],
+              "text": "Medical Record Number"
+            },
+            "system": "http://example.com/system/mrn",
+            "value": "119147111821125"
+          }
+        ],
+        "name": [
+          {
+            "text": "Archy Marshall",
+            "family": "Marshall",
+            "given": [
+              "Archy"
+            ]
+          }
+        ],
+        "gender": "male",
+        "birthDate": "1994-08-24",
+        "address": [
+          {
+            "line": [
+              "57 Adams St"
+            ],
+            "city": "New Rochelle",
+            "state": "NY",
+            "postalCode": "10801",
+            "country": "US"
+          }
+        ],
+        "telecom": [
+          {
+            "system" : "phone",
+            "value" : "555-555-5555",
+            "use" : "home"
+          },
+          {
+            "system" : "email",
+            "value" : "amy.shaw@example.com"
+          }
+        ],
+        "managingOrganization": {
+          "reference": "Organization/2.16.840.1.113883.19.5",
+          "display": "Good Health Clinic"
+        },
+        "generalPractitioner": [
+          {
+            "reference": "Practitioner/example",
+            "display": "Dr Adam Careful"
+          }
+        ],
+        "contact": [
+          {
+            "relationship": [
+              {
+                "coding": [
+                  {
+                    "system": "http://terminology.hl7.org/CodeSystem/v2-0131",
+                    "code": "C"
+                  }
+                ]
+              }
+            ],
+            "name": {
+              "family": "Chalmers",
+              "given": [
+                "Peter",
+                "James"
+              ]
+            },
+            "telecom": [
+              {
+                "system": "phone",
+                "value": "(03) 5555 6473",
+                "use": "work"
+              }
+            ]
+          }
+        ],
+        "photo": [
+          {
+            "contentType": "image/gif",
+            "data": "R0lGODlhEwARAPcAAAAAAAAA/+9aAO+1AP/WAP/eAP/eCP/eEP/eGP/nAP/nCP/nEP/nIf/nKf/nUv/nWv/vAP/vCP/vEP/vGP/vIf/vKf/vMf/vOf/vWv/vY//va//vjP/3c//3lP/3nP//tf//vf///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////yH5BAEAAAEALAAAAAATABEAAAi+AAMIDDCgYMGBCBMSvMCQ4QCFCQcwDBGCA4cLDyEGECDxAoAQHjxwyKhQAMeGIUOSJJjRpIAGDS5wCDly4AALFlYOgHlBwwOSNydM0AmzwYGjBi8IHWoTgQYORg8QIGDAwAKhESI8HIDgwQaRDI1WXXAhK9MBBzZ8/XDxQoUFZC9IiCBh6wEHGz6IbNuwQoSpWxEgyLCXL8O/gAnylNlW6AUEBRIL7Og3KwQIiCXb9HsZQoIEUzUjNEiaNMKAAAA7"
+          }
+        ],
+        "link": [
+          {
+            "other": {
+              "reference": "Patient/pat2"
+            },
+            "type": "seealso"
+          }
+        ],
+        "multipleBirthInteger": 2,
+        "communication": [
+          {
+            "language": {
+              "coding": [
+                {
+                  "system": "urn:ietf:bcp:47",
+                  "code": "en"
+                }
+              ]
+            }
+          }
+        ],
+        "extension": [
+          {
+          "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "1002-5",
+                  "system": "urn:oid:2.16.840.1.113883.6.238"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "American Indian or Alaska Native"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-race"
+          },
+          {
+            "extension": [
+              {
+                "url": "ombCategory",
+                "valueCoding": {
+                  "code": "2186-5",
+                  "system": "urn:oid:2.16.840.1.113883.6.238"
+                }
+              },
+              {
+                "url": "text",
+                "valueString": "Non Hispanic or Latino"
+              }
+            ],
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity"
+          },
+          {
+            "url": "http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex",
+            "valueCode": "male"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/test/helpers/fixtures/masked-patient-bundle.json
+++ b/test/helpers/fixtures/masked-patient-bundle.json
@@ -131,7 +131,73 @@
                             "valueCode": "masked"
                         }
                     ]
-                }
+                },
+                "telecom": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "masked"
+                      }
+                    ]
+                  }
+                ],
+                "_multipleBirthInteger": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "masked"
+                    }
+                  ]
+                },
+                "contact": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "masked"
+                      }
+                    ]
+                  }
+                ],
+                "generalPractitioner": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "masked"
+                      }
+                    ]
+                  }
+                ],
+                "managingOrganization": {
+                  "extension": [
+                    {
+                      "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                      "valueCode": "masked"
+                    }
+                  ]
+                },
+                "link": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "masked"
+                      }
+                    ]
+                  }
+                ],
+                "photo": [
+                  {
+                    "extension": [
+                      {
+                        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+                        "valueCode": "masked"
+                      }
+                    ]
+                  }
+                ]
             }
         }
     ]

--- a/test/helpers/patientUtils.test.js
+++ b/test/helpers/patientUtils.test.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const {
   getEthnicityDisplay, getRaceCodesystem, getRaceDisplay, getPatientName, maskPatientData,
 } = require('../../src/helpers/patientUtils');
-const examplePatient = require('../extractors/fixtures/csv-patient-bundle.json');
+const examplePatient = require('../extractors/fixtures/extended-patient-bundle.json');
 const exampleMaskedPatient = require('./fixtures/masked-patient-bundle.json');
 
 describe('PatientUtils', () => {
@@ -92,7 +92,24 @@ describe('PatientUtils', () => {
 
     test('bundle should be modified to have dataAbsentReason for all fields specified in mask', () => {
       const bundle = _.cloneDeep(examplePatient);
-      maskPatientData(bundle, ['gender', 'mrn', 'name', 'address', 'birthDate', 'language', 'ethnicity', 'birthsex', 'race']);
+      maskPatientData(bundle, [
+        'gender',
+        'mrn',
+        'name',
+        'address',
+        'birthDate',
+        'language',
+        'ethnicity',
+        'birthsex',
+        'race',
+        'telecom',
+        'multipleBirth',
+        'photo',
+        'contact',
+        'generalPractitioner',
+        'managingOrganization',
+        'link',
+      ]);
       expect(bundle).toEqual(exampleMaskedPatient);
     });
 
@@ -108,7 +125,24 @@ describe('PatientUtils', () => {
           },
         ],
       };
-      maskPatientData(bundle, ['gender', 'mrn', 'name', 'address', 'birthDate', 'language', 'ethnicity', 'birthsex', 'race']);
+      maskPatientData(bundle, [
+        'gender',
+        'mrn',
+        'name',
+        'address',
+        'birthDate',
+        'language',
+        'ethnicity',
+        'birthsex',
+        'race',
+        'telecom',
+        'multipleBirth',
+        'photo',
+        'contact',
+        'generalPractitioner',
+        'managingOrganization',
+        'link',
+      ]);
       expect(bundle).toEqual(exampleMaskedPatient);
     });
 


### PR DESCRIPTION
# Summary
Makes the following elements in the Patient resource maskable: `telecom`, `multipleBirth` (both `multipleBirthBoolean` and `multipleBirthInteger`), `photo`, `contact`, `generalPractitioner`, `managingOrganization`, and  `link`.
## New behavior
No changed behavior. The above elements are now supported as options within the `mask` array of the PatientExtractor config.
## Code changes
1. Support for new fields added to the `maskPatientData` function.
2. A new text fixture (`extended-patient-bundle.json`) was added to test masking, given that the newly supported fields are not supported by the CSVExtractors and will only ever occur in resources obtained via a FHIR search.
3. Updated readme to include the new masking fields.
# Testing guidance
1. Ensure that updated unit tests pass.
2. Ensure that the updated masking test fixture has elements consistent with what would be expected on the [CancerPatient resource](https://build.fhir.org/ig/HL7/fhir-mCODE-ig/StructureDefinition-mcode-cancer-patient.html) (namely that `_`s are placed before primitive elements, and that array elements have their dataAbsentReason extension contained within an array).
3. Ensure that the updated mask fixture is valid FHIR. This can be done using the [Inferno FHIR Validator](https://inferno.healthit.gov/validator/)