### PR TITLE
Stu2/utils updates

### DIFF
--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -1,6 +1,6 @@
 const { createInvertedLookup, createLowercaseLookup } = require('../lookupUtils');
 
-// Code mapping is based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
+// Code mapping is based on current values at https://www.hl7.org/fhir/us/mcode/2021May/ValueSet-mcode-condition-status-trend-vs.html
 const mcodeDiseaseStatusTextToCodeLookup = {
   'No abnormality detected (finding)': '281900007',
   'Patient condition improved (finding)': '268910001',
@@ -12,6 +12,7 @@ const mcodeDiseaseStatusCodeToTextLookup = createInvertedLookup(mcodeDiseaseStat
 
 // Code mapping is based on initial values still in use by icare implementors
 // specifically using lowercase versions of the text specified by ICARE for status
+// based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 const icareDiseaseStatusTextToCodeLookup = {
   'no evidence of disease': '260415000',
   responding: '268910001',

--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -2,7 +2,7 @@ const { createInvertedLookup, createLowercaseLookup } = require('../lookupUtils'
 
 // Code mapping is based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
 const mcodeDiseaseStatusTextToCodeLookup = {
-  'Not detected (qualifier)': '260415000',
+  'No abnormality detected (finding)': '281900007',
   'Patient condition improved (finding)': '268910001',
   'Patient\'s condition stable (finding)': '359746009',
   'Patient\'s condition worsened (finding)': '271299001',

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -7,8 +7,8 @@ const {
 } = require('../../src/helpers/diseaseStatusUtils.js');
 
 // Code mapping is based on current values at http://standardhealthrecord.org/guides/icare/mapping_guidance.html
-const currentDiseaseStatusTextToCodeLookup = {
-  'Not detected (qualifier)': '260415000',
+const mcodeDiseaseStatusTextToCodeLookup = {
+  'No abnormality detected (finding)': '281900007',
   'Patient condition improved (finding)': '268910001',
   'Patient\'s condition stable (finding)': '359746009',
   'Patient\'s condition worsened (finding)': '271299001',
@@ -38,8 +38,8 @@ const evidenceTextToCodeLookup = {
 
 describe('diseaseStatusUtils', () => {
   test('getMcodeDiseaseStatusCode,', () => {
-    Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
-      const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
+    Object.keys(mcodeDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = mcodeDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusCode(dsText, 'mcode')).toEqual(dsCode);
       expect(getDiseaseStatusCode(dsText)).toEqual(dsCode);
     });
@@ -51,8 +51,8 @@ describe('diseaseStatusUtils', () => {
     });
   });
   test('getMcodeDiseaseStatusDisplay,', () => {
-    Object.keys(currentDiseaseStatusTextToCodeLookup).forEach((dsText) => {
-      const dsCode = currentDiseaseStatusTextToCodeLookup[dsText];
+    Object.keys(mcodeDiseaseStatusTextToCodeLookup).forEach((dsText) => {
+      const dsCode = mcodeDiseaseStatusTextToCodeLookup[dsText];
       expect(getDiseaseStatusDisplay(dsCode, 'mcode')).toEqual(dsText);
       expect(getDiseaseStatusDisplay(dsCode)).toEqual(dsText);
     });


### PR DESCRIPTION
# Summary

Below are all the major utils-related concepts checked for changes across STU1 to STU2. These lists of questions are based on the responsibilities of the utils files (listed below) identified by the task. Conclusions are based on the May2021 STU2 specification described here: http://hl7.org/fhir/us/mcode/2021May/index.html

Files checked:
- src/helpers/cancerStagingUtils.js
- src/helpers/conditionUtils.js
- src/helpers/diseaseStatusUtils.js
- src/helpers/observationUtils.js
- src/helpers/patientUtils.js

Key concepts checked, along with their change/no change status:
- **No Change** Was the vital sign VS updated?
  - Handled by FHIR R4, hasn't changed – http://hl7.org/fhir/R4/observation-vitalsigns.html 
- **No Change**  Was Karnofsky code changed? – `89243-0`
  - Hasn't changed – http://hl7.org/fhir/us/mcode/2021May/StructureDefinition-mcode-karnofsky-performance-status.html 
- **No Change** Did the ECOG code change – `89247-1`
  - Hasn't changed – http://hl7.org/fhir/us/mcode/2021May/StructureDefinition-mcode-ecog-performance-status.html
- **No Change** Do we need to update ethnicityCodeToDisplay?   `'2135-2': 'Hispanic or Latino',  '2186-5': 'Non Hispanic or Latino',`
  - No change – US Core Ethnicity leverages the CDC's Ethnicity codeset, based on Office of Management and Budget's ethnicity modelling. See http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-ethnicity-category.html, http://hl7.org/fhir/us/core/STU3.1/CodeSystem-cdcrec.html, and https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf  (p. 8) 
- **No Change** Do we need to update race code to codesystem lookup? – http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html
  - No change – US Core Race leverages the CDC's Race codeset the Office of Management and Budget's race modelling, as well as a few HL7 codes that communicate some NULL-adj concept. See http://hl7.org/fhir/us/core/STU3.1/ValueSet-omb-race-category.html, http://hl7.org/fhir/us/core/STU3.1/CodeSystem-cdcrec.html, and https://www.govinfo.gov/content/pkg/FR-1997-10-30/pdf/97-28653.pdf (p. 8)
- **Change needed**  Do we need to update any of our Cancer Disease Status lookups? 
  - **Change needed** - `mcodeDiseaseStatusCodeToTextLookup`
    - While not reflected in the ChangeLog, there is a change in this VS; null-ish values were once modelled with `  260415000 -> 'Not detected (qualifier)' `, but STU2 updates this null-ish value to be `281900007 -> 'No abnormality detected (finding)'`. This change will be applied
    - http://hl7.org/fhir/us/mcode/2021May/ValueSet-mcode-condition-status-trend-vs.html vs. http://hl7.org/fhir/us/mcode/STU1/ValueSet-mcode-condition-status-trend-vs.html 
  - **No Change**`icareDiseaseStatusCodeToTextLookup`
    - These are isolated and should not be changed because of updates to the mCODE STU2
  - **No Change; Task Made** `evidenceTextToCodeLookup`
    - Observed that while we only have one evidence lookup, technically we should have one for mCODE and ICARE, since the values today refelect only the ICARE mapping guidance, not the CancerDiseaseStatusEvidenceTypeVS. 
    - Since this is unrelated to the STU1->STU2 migration, I've created a task to address this
    - http://hl7.org/fhir/us/mcode/2021May/ValueSet-mcode-cancer-disease-status-evidence-type-vs.html
- **No Change** Do we need to update the Condition ICD system  URN:oid in our condition lookup? `urn:oid:2.16.840.1.113883.6.90`
  - No change to the URN OID; this is an OID registered by HL7 and is still up to date – see http://hl7.org/fhir/2017jan/terminologies-systems.html and  https://oidref.com/2.16.840.1.113883.6 
- **No Change** Do we need to update the name of our primary and secondary VS? 
  - While technically the shift from `PrimaryCancerConditionVS` to `PrimaryOrUncertainBehaviorCancerDisorderVS` happened as a part of the shift from STU1 to STU2, we already referenced the latter VS in our tools. A happy coninscidence 😊

# Testing guidance
- Ensure that tests still pass and changes align with the new VS values
- Ensure that I didn't miss any areas of these files in my review. If I did, let me know what other aspects of the identified `utils` files I should inspect 😄 