### PR TITLE
updated schema; added titles to each possible to format

### DIFF
--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -60,12 +60,12 @@
           "title": "To",
           "oneOf": [
             {
-              "title": "To, Comma Separated Emails",
+              "title": "To (comma separated list of emails)",
               "type": "string",
               "format": "comma-separated-emails"
             },
             {
-              "title": "To, Array of Emails",
+              "title": "To (list of emails)",
               "type": "array",
               "items": {
                 "type": "string",

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -58,12 +58,14 @@
         },
         "to": {
           "title": "To",
-          "anyOf": [
+          "oneOf": [
             {
+              "title": "To, Comma Separated Emails",
               "type": "string",
               "format": "comma-separated-emails"
             },
             {
+              "title": "To, Array of Emails",
               "type": "array",
               "items": {
                 "type": "string",


### PR DESCRIPTION
Minor updates to our config file schema. Updates the `.notificationInfo.to` property so that: 
1. The AnyOf is changed to OneOf, which is more in line with what we want. For detailed explanations on the difference between these, see [here](https://json-schema.org/understanding-json-schema/reference/combining.html).
2. Each of the OneOf options have a title associated with them. This improves the result of rendering these options by React JSON Schema Form, which is used by the extraction-ui. A companion PR exists there and also needs to be reviewed.

Testing here should ensure that everything works as it previously did. Additionally, before merging these changes, we should review the extraction-ui and ensure that the visual changes look as desired. 