### PR TITLE
Changing notificationInfo schema for easier use in UI

### DIFF
--- a/src/application/app.js
+++ b/src/application/app.js
@@ -43,7 +43,7 @@ async function mcodeApp(Client, fromDate, toDate, config, pathToRunLogs, debug, 
 
   // If we have notification information, send an emailNotification
   const { notificationInfo } = config;
-  if (notificationInfo) {
+  if (notificationInfo && Object.keys(notificationInfo).length > 0) {
     const notificationErrors = zipErrors(totalExtractionErrors);
     try {
       await sendEmailNotification(notificationInfo, notificationErrors, debug);

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -79,10 +79,13 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "host",
-        "to"
-      ]
+      "dependencies": {
+        "host": { "required": ["to"] },
+        "to": { "required": ["host"] },
+        "from": { "required": ["host", "to"] },
+        "port": { "required": ["host", "to"] },
+        "tlsRejectUnauthorized": { "required": ["host", "to"] }
+      }
     },
     "extractor": {
       "title": "Extractor",


### PR DESCRIPTION
# Summary
Allow notificationInfo to be empty and with the required fields only being required if any other field is present.
## New behavior
Required fields for notificationInfo are now dependencies in the schema, meaning they are only required if other fields are present. This allows for notificationInfo to be on the config editor page of the extraction UI but not have to be filled out.
## Code changes
- Required fields of `notificationInfo` in `config.schema.json` changed to be dependencies instead
- Since an empty notificationInfo is now valid, I also added a check in `app.js` to make sure the notificationInfo is not empty before trying to send a notification
# Testing guidance
- Make sure validation fails if notificationInfo has at least one field present but not all required fields
- Make sure empty notificationInfo passes validation and does not trigger a notification being sent
- Test on the extraction UI by changing the mcode-extraction-framework dependency to this branch
- Leaving all notificationInfo fields blank in the config editor should not cause an error, but adding a value for any one field should lead to the required fields now being required