### PR TITLE
dateTimeStamp now localizes to UTC

### DIFF
--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -3,10 +3,10 @@ const logger = require('./logger');
 
 moment.suppressDeprecationWarnings = true; // We handle invalid date formats
 const dateFormat = 'YYYY-MM-DD';
-const dateTimeFormat = 'YYYY-MM-DDThh:mm:ssZ';
+const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ssZ';
 
 function formatDate(date) {
-  const parsedDate = moment.parseZone(date);
+  const parsedDate = moment.utc(date);
   if (!parsedDate.isValid()) {
     logger.warn(`Invalid date provided: ${date}. Provided value will be used.`);
     return date; // Use the provided date rather than 'Invalid date'
@@ -16,13 +16,14 @@ function formatDate(date) {
 }
 
 function formatDateTime(date) {
-  const parsedDate = moment.parseZone(date);
+  const parsedDate = moment.utc(date);
   if (!parsedDate.isValid()) {
     logger.warn(`Invalid date provided: ${date}. Provided value will be used.`);
     return date; // Use the provided date rather than 'Invalid date'
   }
 
-  if (parsedDate.hour()) {
+  // HACKY: If there is a minute, second, or hour, then we should treat this as a datetimestamp
+  if (parsedDate.hour() || parsedDate.minute() || parsedDate.second()) {
     return parsedDate.format(dateTimeFormat);
   }
   return parsedDate.format(dateFormat);
@@ -31,4 +32,6 @@ function formatDateTime(date) {
 module.exports = {
   formatDate,
   formatDateTime,
+  dateFormat,
+  dateTimeFormat,
 };

--- a/src/helpers/dateUtils.js
+++ b/src/helpers/dateUtils.js
@@ -6,7 +6,7 @@ const dateFormat = 'YYYY-MM-DD';
 const dateTimeFormat = 'YYYY-MM-DDThh:mm:ssZ';
 
 function formatDate(date) {
-  const parsedDate = moment(date);
+  const parsedDate = moment.parseZone(date);
   if (!parsedDate.isValid()) {
     logger.warn(`Invalid date provided: ${date}. Provided value will be used.`);
     return date; // Use the provided date rather than 'Invalid date'
@@ -16,7 +16,7 @@ function formatDate(date) {
 }
 
 function formatDateTime(date) {
-  const parsedDate = moment(date);
+  const parsedDate = moment.parseZone(date);
   if (!parsedDate.isValid()) {
     logger.warn(`Invalid date provided: ${date}. Provided value will be used.`);
     return date; // Use the provided date rather than 'Invalid date'

--- a/test/helpers/dateUtils.test.js
+++ b/test/helpers/dateUtils.test.js
@@ -1,4 +1,3 @@
-const moment = require('moment');
 const { formatDate, formatDateTime } = require('../../src/helpers/dateUtils');
 
 test('formatDate reformats date', () => {
@@ -11,9 +10,16 @@ test('formatDate does not reformat invalid date', () => {
 });
 
 test('formatDateTime reformats date with a time if provided', () => {
-  const currentTimeZone = moment('04/12/19').format('Z');
   expect(formatDateTime('04/12/19')).toEqual('2019-04-12');
-  expect(formatDateTime('2019-04-12T08:00:00')).toEqual(`2019-04-12T08:00:00${currentTimeZone}`);
+  expect(formatDateTime('2019-04-12T08:00:00')).toEqual('2019-04-12T08:00:00+00:00');
+  expect(formatDateTime('2019-04-12T08:00:00+01:00')).toEqual('2019-04-12T07:00:00+00:00');
+});
+
+test('formatDateTime respects timeZone information if provided', () => {
+  const dateTimeWithZone = '2020-05-08T18:00:00+00:00';
+  expect(formatDateTime(dateTimeWithZone)).toEqual('2020-05-08T18:00:00+00:00');
+  const secondDate = '2020-05-08T18:00:00Z';
+  expect(formatDateTime(secondDate)).toEqual('2020-05-08T18:00:00+00:00');
 });
 
 test('formatDateTime does not reformat invalid date', () => {

--- a/test/helpers/dateUtils.test.js
+++ b/test/helpers/dateUtils.test.js
@@ -12,7 +12,6 @@ test('formatDate does not reformat invalid date', () => {
 test('formatDateTime reformats date with a time if provided', () => {
   expect(formatDateTime('04/12/19')).toEqual('2019-04-12');
   expect(formatDateTime('2019-04-12T08:00:00')).toEqual('2019-04-12T08:00:00+00:00');
-  expect(formatDateTime('2019-04-12T08:00:00+01:00')).toEqual('2019-04-12T07:00:00+00:00');
 });
 
 test('formatDateTime respects timeZone information if provided', () => {
@@ -20,6 +19,8 @@ test('formatDateTime respects timeZone information if provided', () => {
   expect(formatDateTime(dateTimeWithZone)).toEqual('2020-05-08T18:00:00+00:00');
   const secondDate = '2020-05-08T18:00:00Z';
   expect(formatDateTime(secondDate)).toEqual('2020-05-08T18:00:00+00:00');
+  const thirdDate = '2019-04-12T08:00:00+01:00';
+  expect(formatDateTime(thirdDate)).toEqual('2019-04-12T07:00:00+00:00');
 });
 
 test('formatDateTime does not reformat invalid date', () => {


### PR DESCRIPTION
In addressing the root cause of broken E-MEF PerformanceStatus tests, we realized that the failing tests were due to the fact that our formatDateTime function was always interpretting timestamps according to the local timezone. This is according to the `moment()` constructor specification [found here](https://momentjs.com/docs/#/parsing/). Also found in the moment parsing documentation is guidance on the `moment.parseZone()` function, which will maintain the provided timezone in the parsing of a string and default to UTC if none is provided. 

This PR updates our use of moment in our formatDate functions to use this newly discovered method, leading to more robust testing fixtures on the E-MEF that don't depend on a testing machine running in the Eastern Time Zone 