### PR TITLE
Support CSVs with blank lines and empty values

### DIFF
--- a/src/helpers/appUtils.js
+++ b/src/helpers/appUtils.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const parse = require('csv-parse/lib/sync');
+const { csvParse } = require('./csvParsingUtils');
 
 /**
  * Parses a provided CSV with MRN column into string array of IDs
@@ -11,10 +11,7 @@ const parse = require('csv-parse/lib/sync');
 function parsePatientIds(pathToCSV) {
   // Parse CSV for list of patient IDs
   const patientIdsCsvPath = path.resolve(pathToCSV);
-  const patientIds = parse(fs.readFileSync(patientIdsCsvPath, 'utf8'), {
-    columns: (header) => header.map((column) => column.toLowerCase()),
-    bom: true,
-  }).map((row) => {
+  const patientIds = csvParse(fs.readFileSync(patientIdsCsvPath, 'utf8')).map((row) => {
     if (!row.mrn) {
       throw new Error(`${pathToCSV} has no "mrn" column`);
     }

--- a/src/helpers/csvParsingUtils.js
+++ b/src/helpers/csvParsingUtils.js
@@ -1,3 +1,4 @@
+const parse = require('csv-parse/lib/sync');
 const logger = require('./logger');
 
 // The standard string normalizer function
@@ -38,7 +39,27 @@ function normalizeEmptyValues(data, unalterableColumns = []) {
   return newData;
 }
 
+// Default options for CSV parsing
+const DEFAULT_OPTIONS = {
+  columns: (header) => header.map((column) => stringNormalizer(column)),
+  // https://csv.js.org/parse/options/bom/
+  bom: true,
+  // https://csv.js.org/parse/options/skip_empty_lines/
+  skip_empty_lines: true,
+  // NOTE: This will skip any records with empty values, not just skip the empty values themselves
+  // NOTE-2: The name of the flag changed from v4 (what we use) to v5 (what is documented)
+  // https://csv.js.org/parse/options/skip_records_with_empty_values/
+  skip_lines_with_empty_values: true,
+};
+
+// Common utility for parsing CSV files
+function csvParse(csvData, options = {}) {
+  return parse(csvData, { ...DEFAULT_OPTIONS, ...options });
+}
+
+
 module.exports = {
   stringNormalizer,
   normalizeEmptyValues,
+  csvParse,
 };

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -1,25 +1,13 @@
 const fs = require('fs');
 const moment = require('moment');
-const parse = require('csv-parse/lib/sync');
 const logger = require('../helpers/logger');
 const { validateCSV } = require('../helpers/csvValidator');
-const { stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
+const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
 
 class CSVFileModule {
   constructor(csvFilePath, unalterableColumns) {
     // Parse then normalize the data
-    const parsedData = parse(fs.readFileSync(csvFilePath), {
-      columns: (header) => header.map((column) => stringNormalizer(column)),
-      // https://csv.js.org/parse/options/bom/
-      bom: true,
-      // https://csv.js.org/parse/options/skip_empty_lines/
-      skip_empty_lines: true,
-      // NOTE: This will skip any records with empty values, not just skip the empty values themselves
-      // NOTE-2: The name of the flag changed from v4 (what we use) to v5 (what is documented)
-      // https://csv.js.org/parse/options/skip_records_with_empty_values/
-      skip_lines_with_empty_values: true,
-    });
-
+    const parsedData = csvParse(fs.readFileSync(csvFilePath));
     this.filePath = csvFilePath;
     this.data = normalizeEmptyValues(parsedData, unalterableColumns);
   }

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -15,9 +15,11 @@ class CSVFileModule {
       // https://csv.js.org/parse/options/skip_empty_lines/
       skip_empty_lines: true,
       // NOTE: This will skip any records with empty values, not just skip the empty values themselves
+      // NOTE-2: The name of the flag changed from v4 (what we use) to v5 (what is documented)
       // https://csv.js.org/parse/options/skip_records_with_empty_values/
-      skip_records_with_empty_values: true,
+      skip_lines_with_empty_values: true,
     });
+
     this.filePath = csvFilePath;
     this.data = normalizeEmptyValues(parsedData, unalterableColumns);
   }

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -10,12 +10,15 @@ class CSVFileModule {
     // Parse then normalize the data
     const parsedData = parse(fs.readFileSync(csvFilePath), {
       columns: (header) => header.map((column) => stringNormalizer(column)),
+      // https://csv.js.org/parse/options/bom/
       bom: true,
+      // https://csv.js.org/parse/options/skip_empty_lines/
       skip_empty_lines: true,
+      // NOTE: This will skip any records with empty values, not just skip the empty values themselves
+      // https://csv.js.org/parse/options/skip_records_with_empty_values/
       skip_records_with_empty_values: true,
     });
     this.filePath = csvFilePath;
-
     this.data = normalizeEmptyValues(parsedData, unalterableColumns);
   }
 

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -11,6 +11,8 @@ class CSVFileModule {
     const parsedData = parse(fs.readFileSync(csvFilePath), {
       columns: (header) => header.map((column) => stringNormalizer(column)),
       bom: true,
+      skip_empty_lines: true,
+      skip_records_with_empty_values: true,
     });
     this.filePath = csvFilePath;
 

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -1,9 +1,8 @@
 const axios = require('axios');
 const moment = require('moment');
-const parse = require('csv-parse/lib/sync');
 const logger = require('../helpers/logger');
 const { validateCSV } = require('../helpers/csvValidator');
-const { stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
+const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
 
 class CSVURLModule {
   constructor(url, unalterableColumns) {
@@ -25,10 +24,7 @@ class CSVURLModule {
         });
       logger.debug('Web request successful');
       // Parse then normalize the data
-      const parsedData = parse(csvData, {
-        columns: (header) => header.map((column) => stringNormalizer(column)),
-        bom: true,
-      });
+      const parsedData = csvParse(csvData);
       logger.debug('CSV Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
     }

--- a/test/modules/CSVFileModule.test.js
+++ b/test/modules/CSVFileModule.test.js
@@ -4,7 +4,6 @@ const exampleResponse = require('./fixtures/csv-response.json');
 
 const INVALID_MRN = 'INVALID MRN';
 const csvFileModule = new CSVFileModule(path.join(__dirname, './fixtures/example-csv.csv'));
-const csvFileModuleWithBOMs = new CSVFileModule(path.join(__dirname, './fixtures/example-csv-bom.csv'));
 
 
 describe('CSVFileModule', () => {
@@ -15,7 +14,27 @@ describe('CSVFileModule', () => {
     });
 
     test('Reads data from CSV with a Byte Order Mark', async () => {
+      const csvFileModuleWithBOMs = new CSVFileModule(
+        path.join(__dirname, './fixtures/example-csv-empty-values.csv'),
+      );
+
       const data = await csvFileModuleWithBOMs.get('mrn', 'example-mrn-1');
+      expect(data).toEqual(exampleResponse);
+    });
+
+    test('Reads data from CSV with Empty Values', async () => {
+      const csvFileModuleWithEmptyValues = new CSVFileModule(
+        path.join(__dirname, './fixtures/example-csv-empty-values.csv'),
+      );
+      const data = await csvFileModuleWithEmptyValues.get('mrn', 'example-mrn-1');
+      expect(data).toEqual(exampleResponse);
+    });
+
+    test('Reads data from CSV with Empty Lines', async () => {
+      const csvFileModuleWithEmptyLines = new CSVFileModule(
+        path.join(__dirname, './fixtures/example-csv-empty-line.csv'),
+      );
+      const data = await csvFileModuleWithEmptyLines.get('mrn', 'example-mrn-1');
       expect(data).toEqual(exampleResponse);
     });
 

--- a/test/modules/CSVFileModule.test.js
+++ b/test/modules/CSVFileModule.test.js
@@ -23,11 +23,17 @@ describe('CSVFileModule', () => {
     });
 
     test('Reads data from CSV with Empty Values', async () => {
+      // Five row file, with three rows of empty values
+      // Should be just two rows of data after ingestion
       const csvFileModuleWithEmptyValues = new CSVFileModule(
         path.join(__dirname, './fixtures/example-csv-empty-values.csv'),
       );
       const data = await csvFileModuleWithEmptyValues.get('mrn', 'example-mrn-1');
       expect(data).toEqual(exampleResponse);
+      const data2 = await csvFileModuleWithEmptyValues.get('mrn', 'example-mrn-not-ignored');
+      expect(data2).toHaveLength(1);
+      // Should be just two rows of data after ingestion
+      expect(csvFileModuleWithEmptyValues.data).toHaveLength(2);
     });
 
     test('Reads data from CSV with Empty Lines', async () => {

--- a/test/modules/CSVFileModule.test.js
+++ b/test/modules/CSVFileModule.test.js
@@ -15,7 +15,7 @@ describe('CSVFileModule', () => {
 
     test('Reads data from CSV with a Byte Order Mark', async () => {
       const csvFileModuleWithBOMs = new CSVFileModule(
-        path.join(__dirname, './fixtures/example-csv-empty-values.csv'),
+        path.join(__dirname, './fixtures/example-csv-bom.csv'),
       );
 
       const data = await csvFileModuleWithBOMs.get('mrn', 'example-mrn-1');

--- a/test/modules/fixtures/example-csv-empty-line.csv
+++ b/test/modules/fixtures/example-csv-empty-line.csv
@@ -1,0 +1,4 @@
+﻿mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,dateRecorded
+example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1,2020-01-10
+
+example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3,2020-06-10

--- a/test/modules/fixtures/example-csv-empty-values.csv
+++ b/test/modules/fixtures/example-csv-empty-values.csv
@@ -1,0 +1,4 @@
+﻿mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,dateRecorded
+example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1,2020-01-10
+, ,    , \t\t\t,,\t
+example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3,2020-06-10

--- a/test/modules/fixtures/example-csv-empty-values.csv
+++ b/test/modules/fixtures/example-csv-empty-values.csv
@@ -1,4 +1,6 @@
 ﻿mrn,trialSubjectID,enrollmentStatus,trialResearchID,trialStatus,dateRecorded
 example-mrn-1,subjectId-1,status-1,researchId-1,trialStatus-1,2020-01-10
-, ,    , \t\t\t,,\t
-example-mrn-2,subjectId-3,status-3,researchId-3,trialStatus-3,2020-06-10
+, , , , , 
+,    ,   ,    ,,
+,,,		,	,
+example-mrn-not-ignored,,,,,


### PR DESCRIPTION
# Summary

Supports ingestion of CSV's with either totally blank rows of data or rows with nothing by empty-values; in both cases those rows will be ignored. 

## New behavior

Now the CSVFileModule can ingest files with rows that meet the above criteria.

## Code changes

Some new tests

# Testing guidance

Make sure the tool still works.
