### PR TITLE
Passthrough csv-parse options supported in the config

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ The mCODE Extraction Framework uses the node `csv-parse` library to parse specif
   },
 ```
 
+**Note:** The mCODE Extraction Framework enables the `bom`, `skip_empty_lines`, and `skip_lines_with_empty_values` options by default, including these options in the configuration file will cause these default options to be overwritten.
+
 ## Terminology and Architecture
 
 This framework consists of three key components: Extractors, Modules and Templates. Below is, in order:

--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ cat -v <file.csv>
 
 If there is an unexpected symbol at the beginning of the file, then there may be a byte order marker that needs to be removed.
 
+#### Troubleshooting Additional Errors
+The mCODE Extraction Framework uses the node `csv-parse` library to parse specified CSV files. [Parsing options for the `csv-parse` library](https://csv.js.org/parse/options/) can be included in the configuration file within the `commonExtractorArgs.csvParse.options` section. For example, the following configuration will pass the `to` option to the `csv-parse` module, causing the mCODE Extraction Framework to only read CSV files up to the specified line number: 
+
+```
+"commonExtractorArgs": {
+    "dataDirectory": "/Users/*****/Documents/dataDirectory",
+    "csvParse": {
+      "options": {
+        "to": 3
+      }
+    }
+  },
+```
+
 ## Terminology and Architecture
 
 This framework consists of three key components: Extractors, Modules and Templates. Below is, in order:

--- a/config/csv.config.example.json
+++ b/config/csv.config.example.json
@@ -1,12 +1,7 @@
 {
   "patientIdCsvPath": "Users/YourAccount/absolute/path/to/patient-mrns.csv",
   "commonExtractorArgs": {
-    "dataDirectory": "Users/YourAccount/absolute/path/to/data/directory",
-    "csvParse": {
-      "options": {
-        "bom": true
-      }
-    }
+    "dataDirectory": "Users/YourAccount/absolute/path/to/data/directory"
   },
   "notificationInfo": {
     "host": "smtp.example.com",

--- a/config/csv.config.example.json
+++ b/config/csv.config.example.json
@@ -1,7 +1,12 @@
 {
   "patientIdCsvPath": "Users/YourAccount/absolute/path/to/patient-mrns.csv",
   "commonExtractorArgs": {
-    "dataDirectory": "Users/YourAccount/absolute/path/to/data/directory"
+    "dataDirectory": "Users/YourAccount/absolute/path/to/data/directory",
+    "csvParse": {
+      "options": {
+        "bom": true
+      }
+    }
   },
   "notificationInfo": {
     "host": "smtp.example.com",

--- a/src/application/app.js
+++ b/src/application/app.js
@@ -31,7 +31,8 @@ async function mcodeApp(Client, fromDate, toDate, config, pathToRunLogs, debug, 
 
   // Parse CSV for list of patient mrns
   const dataDirectory = config.commonExtractorArgs && config.commonExtractorArgs.dataDirectory;
-  const patientIds = parsePatientIds(config.patientIdCsvPath, dataDirectory);
+  const parserOptions = config.commonExtractorArgs && config.commonExtractorArgs.csvParse && config.commonExtractorArgs.csvParse.options ? config.commonExtractorArgs.csvParse.options : {};
+  const patientIds = parsePatientIds(config.patientIdCsvPath, dataDirectory, parserOptions);
 
   // Get RunInstanceLogger for recording new runs and inferring dates from previous runs
   const runLogger = allEntries ? null : new RunInstanceLogger(pathToRunLogs);

--- a/src/extractors/BaseCSVExtractor.js
+++ b/src/extractors/BaseCSVExtractor.js
@@ -6,7 +6,7 @@ const logger = require('../helpers/logger');
 
 class BaseCSVExtractor extends Extractor {
   constructor({
-    filePath, url, fileName, dataDirectory, csvSchema, unalterableColumns, csvParse
+    filePath, url, fileName, dataDirectory, csvSchema, unalterableColumns, csvParse,
   }) {
     super();
     this.unalterableColumns = unalterableColumns || [];

--- a/src/extractors/BaseCSVExtractor.js
+++ b/src/extractors/BaseCSVExtractor.js
@@ -6,26 +6,27 @@ const logger = require('../helpers/logger');
 
 class BaseCSVExtractor extends Extractor {
   constructor({
-    filePath, url, fileName, dataDirectory, csvSchema, unalterableColumns,
+    filePath, url, fileName, dataDirectory, csvSchema, unalterableColumns, csvParse
   }) {
     super();
     this.unalterableColumns = unalterableColumns || [];
     this.csvSchema = csvSchema;
+    this.parserOptions = csvParse && csvParse.options ? csvParse.options : {};
     if (url) {
       logger.debug('Found url argument; creating a CSVURLModule with the provided url');
       this.url = url;
-      this.csvModule = new CSVURLModule(this.url, this.unalterableColumns);
+      this.csvModule = new CSVURLModule(this.url, this.unalterableColumns, this.parserOptions);
     } else if (fileName && dataDirectory) {
       if (!path.isAbsolute(dataDirectory)) throw new Error('dataDirectory is not an absolutePath, it needs to be.');
       this.filePath = path.join(dataDirectory, fileName);
       logger.debug(
         'Found fileName and dataDirectory arguments; creating a CSVFileModule with the provided dataDirectory and fileName',
       );
-      this.csvModule = new CSVFileModule(this.filePath, this.unalterableColumns);
+      this.csvModule = new CSVFileModule(this.filePath, this.unalterableColumns, this.parserOptions);
     } else if (filePath) {
       logger.debug('Found filePath argument; creating a CSVFileModule with the provided filePath');
       this.filePath = filePath;
-      this.csvModule = new CSVFileModule(this.filePath, this.unalterableColumns);
+      this.csvModule = new CSVFileModule(this.filePath, this.unalterableColumns, this.parserOptions);
     } else {
       logger.debug(
         'Could not instantiate a CSVExtractor with the provided constructor args',

--- a/src/extractors/CSVAdverseEventExtractor.js
+++ b/src/extractors/CSVAdverseEventExtractor.js
@@ -69,8 +69,8 @@ function formatData(adverseEventData, patientId) {
 }
 
 class CSVAdverseEventExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getAdverseEventData(mrn) {

--- a/src/extractors/CSVAdverseEventExtractor.js
+++ b/src/extractors/CSVAdverseEventExtractor.js
@@ -69,7 +69,9 @@ function formatData(adverseEventData, patientId) {
 }
 
 class CSVAdverseEventExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVCTCAdverseEventExtractor.js
+++ b/src/extractors/CSVCTCAdverseEventExtractor.js
@@ -109,7 +109,9 @@ function formatData(adverseEventData, patientId) {
 }
 
 class CSVCTCAdverseEventExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVCTCAdverseEventExtractor.js
+++ b/src/extractors/CSVCTCAdverseEventExtractor.js
@@ -109,8 +109,8 @@ function formatData(adverseEventData, patientId) {
 }
 
 class CSVCTCAdverseEventExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getAdverseEventData(mrn) {

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -9,7 +9,7 @@ const { CSVCancerDiseaseStatusSchema } = require('../helpers/schemas/csv');
 
 class CSVCancerDiseaseStatusExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, csvParse, implementation
+    filePath, url, fileName, dataDirectory, csvParse, implementation,
   }) {
     super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCancerDiseaseStatusSchema, csvParse });
     this.implementation = implementation;

--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -9,9 +9,9 @@ const { CSVCancerDiseaseStatusSchema } = require('../helpers/schemas/csv');
 
 class CSVCancerDiseaseStatusExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, implementation,
+    filePath, url, fileName, dataDirectory, csvParse, implementation
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCancerDiseaseStatusSchema });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCancerDiseaseStatusSchema, csvParse });
     this.implementation = implementation;
   }
 

--- a/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
@@ -46,8 +46,8 @@ function formatData(medicationData, patientId) {
 }
 
 class CSVCancerRelatedMedicationAdministrationExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getMedicationData(mrn) {

--- a/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
@@ -46,7 +46,9 @@ function formatData(medicationData, patientId) {
 }
 
 class CSVCancerRelatedMedicationAdministrationExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
@@ -48,8 +48,8 @@ function formatData(medicationData, patientId) {
 }
 
 class CSVCancerRelatedMedicationRequestExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getMedicationData(mrn) {

--- a/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
@@ -48,7 +48,9 @@ function formatData(medicationData, patientId) {
 }
 
 class CSVCancerRelatedMedicationRequestExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -9,9 +9,9 @@ const { CSVClinicalTrialInformationSchema } = require('../helpers/schemas/csv');
 
 class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, csvParse, clinicalSiteID, clinicalSiteSystem
+    filePath, url, fileName, dataDirectory, csvParse, clinicalSiteID, clinicalSiteSystem,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVClinicalTrialInformationSchema });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVClinicalTrialInformationSchema, csvParse });
     if (!clinicalSiteID) logger.warn(`${this.constructor.name} expects a value for clinicalSiteID but got ${clinicalSiteID}`);
     this.clinicalSiteID = clinicalSiteID;
     this.clinicalSiteSystem = clinicalSiteSystem;

--- a/src/extractors/CSVClinicalTrialInformationExtractor.js
+++ b/src/extractors/CSVClinicalTrialInformationExtractor.js
@@ -9,7 +9,7 @@ const { CSVClinicalTrialInformationSchema } = require('../helpers/schemas/csv');
 
 class CSVClinicalTrialInformationExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, clinicalSiteID, clinicalSiteSystem,
+    filePath, url, fileName, dataDirectory, csvParse, clinicalSiteID, clinicalSiteSystem
   }) {
     super({ filePath, url, fileName, dataDirectory, csvSchema: CSVClinicalTrialInformationSchema });
     if (!clinicalSiteID) logger.warn(`${this.constructor.name} expects a value for clinicalSiteID but got ${clinicalSiteID}`);

--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -49,7 +49,9 @@ function formatData(conditionData, patientId) {
 }
 
 class CSVConditionExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvSchema: CSVConditionSchema, csvParse });
   }
 

--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -49,8 +49,8 @@ function formatData(conditionData, patientId) {
 }
 
 class CSVConditionExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVConditionSchema });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVConditionSchema, csvParse });
   }
 
   async getConditionData(mrn) {

--- a/src/extractors/CSVObservationExtractor.js
+++ b/src/extractors/CSVObservationExtractor.js
@@ -42,7 +42,9 @@ function formatData(observationData, patientId) {
 }
 
 class CSVObservationExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVObservationExtractor.js
+++ b/src/extractors/CSVObservationExtractor.js
@@ -42,8 +42,8 @@ function formatData(observationData, patientId) {
 }
 
 class CSVObservationExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getObservationData(mrn) {

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -55,7 +55,7 @@ function joinAndReformatData(patientData) {
 
 class CSVPatientExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, mask = [], csvParse
+    filePath, url, fileName, dataDirectory, mask = [], csvParse,
   }) {
     // Define CSV Columns whose values should never be altered
     const unalterableColumns = ['familyName', 'givenName'];
@@ -66,7 +66,7 @@ class CSVPatientExtractor extends BaseCSVExtractor {
       dataDirectory,
       csvSchema: CSVPatientSchema,
       unalterableColumns,
-      csvParse
+      csvParse,
     });
     this.mask = mask;
   }

--- a/src/extractors/CSVPatientExtractor.js
+++ b/src/extractors/CSVPatientExtractor.js
@@ -55,7 +55,7 @@ function joinAndReformatData(patientData) {
 
 class CSVPatientExtractor extends BaseCSVExtractor {
   constructor({
-    filePath, url, fileName, dataDirectory, mask = [],
+    filePath, url, fileName, dataDirectory, mask = [], csvParse
   }) {
     // Define CSV Columns whose values should never be altered
     const unalterableColumns = ['familyName', 'givenName'];
@@ -66,6 +66,7 @@ class CSVPatientExtractor extends BaseCSVExtractor {
       dataDirectory,
       csvSchema: CSVPatientSchema,
       unalterableColumns,
+      csvParse
     });
     this.mask = mask;
   }

--- a/src/extractors/CSVProcedureExtractor.js
+++ b/src/extractors/CSVProcedureExtractor.js
@@ -48,7 +48,9 @@ function formatData(procedureData, patientId) {
 }
 
 class CSVProcedureExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVProcedureExtractor.js
+++ b/src/extractors/CSVProcedureExtractor.js
@@ -48,8 +48,8 @@ function formatData(procedureData, patientId) {
 }
 
 class CSVProcedureExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getProcedureData(mrn) {

--- a/src/extractors/CSVStagingExtractor.js
+++ b/src/extractors/CSVStagingExtractor.js
@@ -63,8 +63,8 @@ function formatStagingData(stagingData, categoryIds, patientId) {
 }
 
 class CSVStagingExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 
   async getStagingData(mrn) {

--- a/src/extractors/CSVStagingExtractor.js
+++ b/src/extractors/CSVStagingExtractor.js
@@ -63,7 +63,9 @@ function formatStagingData(stagingData, categoryIds, patientId) {
 }
 
 class CSVStagingExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvParse });
   }
 

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -70,7 +70,9 @@ function formatData(tpcData, patientId) {
 }
 
 class CSVTreatmentPlanChangeExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+  constructor({
+    filePath, url, fileName, dataDirectory, csvParse,
+  }) {
     super({ filePath, url, fileName, dataDirectory, csvSchema: CSVTreatmentPlanChangeSchema, csvParse });
   }
 

--- a/src/extractors/CSVTreatmentPlanChangeExtractor.js
+++ b/src/extractors/CSVTreatmentPlanChangeExtractor.js
@@ -70,8 +70,8 @@ function formatData(tpcData, patientId) {
 }
 
 class CSVTreatmentPlanChangeExtractor extends BaseCSVExtractor {
-  constructor({ filePath, url, fileName, dataDirectory }) {
-    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVTreatmentPlanChangeSchema });
+  constructor({ filePath, url, fileName, dataDirectory, csvParse }) {
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVTreatmentPlanChangeSchema, csvParse });
   }
 
   async getTPCData(mrn, fromDate, toDate) {

--- a/src/helpers/appUtils.js
+++ b/src/helpers/appUtils.js
@@ -25,11 +25,12 @@ function getPatientIdCSVData(patientIdCsvPath, dataDirectory) {
  *
  * @param {string} patientIdCsvPath filePath to the CSV content to be parsed to get IDs
  * @param {string} dataDirectory optional argument for if a dataDirectory was specified by the config
+ * @param {object} parserOptions options for the csv-parse module
  * @returns array of parsed IDs from the CSV
  */
-function parsePatientIds(patientIdCsvPath, dataDirectory) {
+function parsePatientIds(patientIdCsvPath, dataDirectory, parserOptions) {
   const csvData = getPatientIdCSVData(patientIdCsvPath, dataDirectory);
-  return csvParse(csvData).map((row) => {
+  return csvParse(csvData, parserOptions).map((row) => {
     if (!row.mrn) {
       throw new Error(`${patientIdCsvPath} has no "mrn" column`);
     }

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -40,6 +40,17 @@
         "requestHeaders": {
           "title": "Request Headers",
           "type": "object"
+        },
+        "csvParse" : {
+          "title": "CSV Parse",
+          "type": "object",
+          "properties": {
+            "options": {
+              "titles": "Options",
+              "description": "Options to be passed to the \"CSV Parse\" module used for parsing CSV files.",
+              "type": "object"
+            }
+          }
         }
       }
     },

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -5,9 +5,9 @@ const { validateCSV } = require('../helpers/csvValidator');
 const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
 
 class CSVFileModule {
-  constructor(csvFilePath, unalterableColumns) {
+  constructor(csvFilePath, unalterableColumns, parserOptions) {
     // Parse then normalize the data
-    const parsedData = csvParse(fs.readFileSync(csvFilePath));
+    const parsedData = csvParse(fs.readFileSync(csvFilePath), parserOptions);
     this.filePath = csvFilePath;
     this.data = normalizeEmptyValues(parsedData, unalterableColumns);
   }

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -5,10 +5,11 @@ const { validateCSV } = require('../helpers/csvValidator');
 const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
 
 class CSVURLModule {
-  constructor(url, unalterableColumns) {
+  constructor(url, unalterableColumns, parserOptions) {
     this.unalterableColumns = unalterableColumns;
     this.url = url;
     this.data = undefined;
+    this.parserOptions = parserOptions;
   }
 
   // Ensures that this.data contains normalized CSV data fetched from the module's url
@@ -24,7 +25,7 @@ class CSVURLModule {
         });
       logger.debug('Web request successful');
       // Parse then normalize the data
-      const parsedData = csvParse(csvData);
+      const parsedData = csvParse(csvData, this.parserOptions);
       logger.debug('CSV Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
     }


### PR DESCRIPTION
# Summary
Adds support for a `csvParse` property within `commonExtractorArgs` of the config. Values included in the `options` property of this `csvParse` object will be passed to the `csv-parse` module as Extractors are initialized. Default options such as BOM removal and empty line skipping are still kept, but users can now override them (which is not recommended) or include their own in the event that they encounter errors while running the extractor. 
## New behavior
Properties included in the `commonExtractorArgs.csvParse.options` section of the config are passed to the `csv-parse` module to be used as the MEF reads CSV files. 
## Code changes
1. The `BaseCSVExtractor` (and each child Extractor class) now takes a `csvParse` argument in its constructor. The `BaseCSVExtractor` pulls the `options` property from this argument and passes it to the `CSVFileModule` and `CSVURLModule`.
2. References to this new config option are added to `csv.config.example.json`, `csv.schema.json`, and the README.
# Testing guidance
1. Ensure that extraction still works as expected when `commonExtractorArgs.csvParse` and `commonExtractorArgs.csvParse.options` are omitted from the config.
2. Ensure that options included in the config under `commonExtractorArgs.csvParse.options` are actually passed to the csv-parse module. This can be tested by including the following in your commonExtractorArgs:
```
"csvParse": {
   "options": {
      "to": 2
   }
 }
```
This instructs the `csv-parse` module to only parse CSV files up to the 2nd line, thus extracted bundles for any patients after patient 2 will be empty.