### PR TITLE
Adverse Event context additions

### DIFF
--- a/src/extractors/FHIRAdverseEventExtractor.js
+++ b/src/extractors/FHIRAdverseEventExtractor.js
@@ -18,8 +18,12 @@ class FHIRAdverseEventExtractor extends BaseFHIRExtractor {
     try {
       allResearchStudyResources = getResearchStudiesFromContext(context);
     } catch (e) {
-      logger.error(e.message);
+      logger.debug(e.message);
       logger.debug(e.stack);
+      if (!this.study) {
+        logger.error('There is no ResearchStudy id to complete a request for Adverse Event resources; please include a ClinicalTrialInformationExtractor,'
+        + ' ResearchStudyExtractor, or "study" constructorArg in your extraction configuration.');
+      }
     }
 
     // The patient is referenced in the 'subject' field of an AdverseEvent

--- a/src/helpers/contextUtils.js
+++ b/src/helpers/contextUtils.js
@@ -48,6 +48,36 @@ function getConditionsFromContext(context) {
 }
 
 /**
+* Parses context for AdverseEvent resources
+* @param {Object} context - Context object consisting of a FHIR Bundle
+* @return {Array} All the AdverseEvent resources found in context
+*/
+function getAdverseEventsFromContext(context) {
+  logger.debug('Getting adverse event resources from context');
+  const adverseEventResourcesInContext = getBundleResourcesByType(context, 'AdverseEvent', {}, false);
+  if (_.isEmpty(adverseEventResourcesInContext)) {
+    throw Error('Could not find any adverse events in context; ensure that an AdverseEventExtractor is used earlier in your extraction configuration');
+  }
+  logger.debug(`AdverseEvent resources found in context. Found ${adverseEventResourcesInContext.length} adverse event resources.`);
+  return adverseEventResourcesInContext;
+}
+
+/**
+* Parses context for AdverseEvent entries, which themselves contain resources
+* @param {Object} context - Context object consisting of a FHIR Bundle
+* @return {Array} All the AdverseEvents entries found in context
+*/
+function getAdverseEventEntriesFromContext(context) {
+  logger.debug('Getting adverse event entries from context');
+  const adverseEventEntriesInContext = getBundleEntriesByResourceType(context, 'AdverseEvent', {}, false);
+  if (adverseEventEntriesInContext.length === 0) {
+    throw Error('Could not find any adverse events in context; ensure that an AdverseEventExtractor is used earlier in your extraction configuration');
+  }
+  logger.debug(`AdverseEvent entries found in context. Found ${adverseEventEntriesInContext.length} adverse event resources.`);
+  return adverseEventEntriesInContext;
+}
+
+/**
 * Parses context for Encounter resources
 * @param {Object} context - Context object consisting of a FHIR Bundle
 * @return {Array} All the encounter resources found in context
@@ -78,4 +108,6 @@ module.exports = {
   getEncountersFromContext,
   getPatientFromContext,
   getResearchStudiesFromContext,
+  getAdverseEventEntriesFromContext,
+  getAdverseEventsFromContext,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -65,7 +65,14 @@ const {
 const { getDiseaseStatusCode, getDiseaseStatusEvidenceCode, mEpochToDate } = require('./helpers/diseaseStatusUtils');
 const { formatDate, formatDateTime } = require('./helpers/dateUtils');
 const { lowercaseLookupQuery, createLowercaseLookup, createInvertedLookup } = require('./helpers/lookupUtils');
-const { getConditionEntriesFromContext, getConditionsFromContext, getEncountersFromContext, getPatientFromContext } = require('./helpers/contextUtils');
+const {
+  getConditionEntriesFromContext,
+  getConditionsFromContext,
+  getEncountersFromContext,
+  getPatientFromContext,
+  getAdverseEventsFromContext,
+  getAdverseEventEntriesFromContext,
+} = require('./helpers/contextUtils');
 const { parsePatientIds } = require('./helpers/appUtils');
 const { getConfig, validateConfig } = require('./helpers/configUtils');
 const configSchema = require('./helpers/schemas/config.schema.json');
@@ -150,6 +157,8 @@ module.exports = {
   getConditionsFromContext,
   getEncountersFromContext,
   getPatientFromContext,
+  getAdverseEventEntriesFromContext,
+  getAdverseEventsFromContext,
   // Configuration file schema
   configSchema,
 };


### PR DESCRIPTION
# Summary
Adds two new utility functions, `getAdverseEventsFromContext` and `getAdverseEventEntriesFromContext`.
## New behavior
1. New additions to `contextUtils` make it possible to fetch AdverseEvent resources in the context bundle.
2. The `FHIRAdverseEventExtractor` will now only throw an error if a `study` is not included in its contructorArgs. Previously, an error would be thrown whenever there were no `ResearchStudy` resources found in context, even though it's not exactly necessary if a `study` is included.
## Code changes
1. Two utility functions added to `contextUtils.js`.
2. Any errors thrown by `getResearchStudiesFromContext` are now logged as debug messages in `FHIRAdverseEventExtractor.js`, which a custom error being thrown by that Extractor if the `study` contructorArg isn't included either.
# Testing guidance
Testing guidance will be included in the corresponding E-MEF PR. 