### PR TITLE
CDS 2022 Value Set Updates

### DIFF
--- a/src/extractors/CSVCancerDiseaseStatusExtractor.js
+++ b/src/extractors/CSVCancerDiseaseStatusExtractor.js
@@ -36,7 +36,7 @@ class CSVCancerDiseaseStatusExtractor extends BaseCSVExtractor {
         status: observationStatus || 'final',
         value: {
           code: diseaseStatusCode,
-          system: 'http://snomed.info/sct',
+          system: diseaseStatusCode.includes('USCRS') ? 'http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs' : 'http://snomed.info/sct',
           display: diseaseStatusText || getDiseaseStatusDisplay(diseaseStatusCode, this.implementation),
         },
         subject: {

--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -1,12 +1,17 @@
 const { createInvertedLookup, createLowercaseLookup } = require('../lookupUtils');
 
-// Code mapping is based on current values at https://www.hl7.org/fhir/us/mcode/2021May/ValueSet-mcode-condition-status-trend-vs.html
+// Code mapping is based on current values at https://hl7.org/fhir/us/mcode/ValueSet-mcode-condition-status-trend-vs.html
+// along with legacy codes included at https://www.hl7.org/fhir/us/mcode/2021May/ValueSet-mcode-condition-status-trend-vs.html
 const mcodeDiseaseStatusTextToCodeLookup = {
-  'No abnormality detected (finding)': '281900007',
+  'No abnormality detected (finding)': '281900007', // No longer in the Vs, included for backwards compatibility
   'Patient condition improved (finding)': '268910001',
   'Patient\'s condition stable (finding)': '359746009',
   'Patient\'s condition worsened (finding)': '271299001',
   'Patient condition undetermined (finding)': '709137006',
+  // TODO: These are placeholder codes representing codes that are requested additions to the SNOMED vocabulary
+  // They will likely need to be updated in future versions of mCODE
+  'Cancer in complete remission(finding)': 'USCRS-352236',
+  'Cancer in partial remission (finding)': 'USCRS-352237'
 };
 const mcodeDiseaseStatusCodeToTextLookup = createInvertedLookup(mcodeDiseaseStatusTextToCodeLookup);
 

--- a/src/helpers/lookups/diseaseStatusLookup.js
+++ b/src/helpers/lookups/diseaseStatusLookup.js
@@ -11,7 +11,7 @@ const mcodeDiseaseStatusTextToCodeLookup = {
   // TODO: These are placeholder codes representing codes that are requested additions to the SNOMED vocabulary
   // They will likely need to be updated in future versions of mCODE
   'Cancer in complete remission(finding)': 'USCRS-352236',
-  'Cancer in partial remission (finding)': 'USCRS-352237'
+  'Cancer in partial remission (finding)': 'USCRS-352237',
 };
 const mcodeDiseaseStatusCodeToTextLookup = createInvertedLookup(mcodeDiseaseStatusTextToCodeLookup);
 

--- a/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-bundle.json
@@ -3,10 +3,10 @@
   "type": "collection",
   "entry": [
     {
-      "fullUrl": "urn:uuid:4b9e9b5a8db529782cd9e89b68c6a3fac408d2195f025691a3f2850cab18057f",
+      "fullUrl": "urn:uuid:e8293a0d18fb20d6b1749009032a26f2d34d8418369c87c8345f6c988fa0fc33",
       "resource": {
         "resourceType": "Observation",
-        "id": "4b9e9b5a8db529782cd9e89b68c6a3fac408d2195f025691a3f2850cab18057f",
+        "id": "e8293a0d18fb20d6b1749009032a26f2d34d8418369c87c8345f6c988fa0fc33",
         "meta": {
           "profile": [
             "http://hl7.org/fhir/us/mcode/StructureDefinition/mcode-cancer-disease-status"
@@ -47,9 +47,9 @@
         "valueCodeableConcept": {
           "coding": [
             {
-              "system": "http://snomed.info/sct",
-              "code": "268910001",
-              "display": "Patient condition improved (finding)"
+              "system": "http://hl7.org/fhir/us/mcode/CodeSystem/snomed-requested-cs",
+              "code": "USCRS-352236",
+              "display": "Cancer in complete remission(finding)"
             }
           ]
         },

--- a/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
+++ b/test/extractors/fixtures/csv-cancer-disease-status-module-response.json
@@ -2,7 +2,7 @@
   {
     "mrn": "mrn-1",
     "conditionid": "cond-1",
-    "diseasestatuscode": "268910001",
+    "diseasestatuscode": "USCRS-352236",
     "dateofobservation": "2019-12-02",
     "evidence": "363679005|252416005",
     "observationstatus": "amended"

--- a/test/helpers/diseaseStatusUtils.test.js
+++ b/test/helpers/diseaseStatusUtils.test.js
@@ -13,6 +13,8 @@ const mcodeDiseaseStatusTextToCodeLookup = {
   'Patient\'s condition stable (finding)': '359746009',
   'Patient\'s condition worsened (finding)': '271299001',
   'Patient condition undetermined (finding)': '709137006',
+  'Cancer in complete remission(finding)': 'USCRS-352236',
+  'Cancer in partial remission (finding)': 'USCRS-352237',
 };
 
 // Code mapping is based on initial values still in use by icare implementors


### PR DESCRIPTION
# Summary
Updates our Cancer Disease Status code lookups to include 2 new codes added in the [STU2 Condition Status Trend Value Set](https://hl7.org/fhir/us/mcode/ValueSet-mcode-condition-status-trend-vs.html).
## New behavior
The extractor now supports displayText mappings for the two new requested codes in the aforementioned VS. 
## Code changes
1. New codes added to the CDS lookup file. 
2. Code System check added to the CDSExtractor to ensure the proper system is used for the two additional codes. 
3. CDSExtractor test fixtures updated to test the new changes.   
# Testing guidance
1. Ensure unit tests pass. 
2. Run the extractor with the two new codes (`USCRS-352236` or `USCRS-352237`) in the `diseaseStatusCode` column of the `cancer-disease-status-information` csv and the `diseaseStatusText` column blank. The resulting JSON should include the new code, the corresponding display, and the corresponding system. 