### PR TITLE
Allowing CSVs with no rows + adding trimming to CSV parsing

### DIFF
--- a/src/helpers/csvParsingUtils.js
+++ b/src/helpers/csvParsingUtils.js
@@ -44,6 +44,8 @@ const DEFAULT_OPTIONS = {
   columns: (header) => header.map((column) => stringNormalizer(column)),
   // https://csv.js.org/parse/options/bom/
   bom: true,
+  // https://csv.js.org/parse/options/trim/
+  trim: true,
   // https://csv.js.org/parse/options/skip_empty_lines/
   skip_empty_lines: true,
   // NOTE: This will skip any records with empty values, not just skip the empty values themselves
@@ -57,9 +59,17 @@ function csvParse(csvData, options = {}) {
   return parse(csvData, { ...DEFAULT_OPTIONS, ...options });
 }
 
+function getCSVHeader(csvData) {
+  return parse(csvData, {
+    bom: true,
+    trim: true,
+    to: 1,
+  })[0];
+}
 
 module.exports = {
   stringNormalizer,
   normalizeEmptyValues,
   csvParse,
+  getCSVHeader,
 };

--- a/src/helpers/csvParsingUtils.js
+++ b/src/helpers/csvParsingUtils.js
@@ -64,7 +64,7 @@ function getCSVHeader(csvData) {
     bom: true,
     trim: true,
     to: 1,
-  })[0];
+  })[0].map((h) => h.toLowerCase());
 }
 
 module.exports = {

--- a/src/helpers/csvValidator.js
+++ b/src/helpers/csvValidator.js
@@ -27,10 +27,6 @@ function validateCSV(csvFileIdentifier, csvSchema, csvData, header) {
     });
   }
 
-  if (csvData.length === 0) {
-    return true;
-  }
-
   // Check values
   csvData.forEach((row, i) => {
     Object.entries(row).forEach(([key, value], j) => {

--- a/src/helpers/csvValidator.js
+++ b/src/helpers/csvValidator.js
@@ -3,11 +3,10 @@ const logger = require('./logger');
 
 // Validates csvData against the csvSchema
 // Uses the csvFileIdentifier in logs for readability
-function validateCSV(csvFileIdentifier, csvSchema, csvData, header) {
+function validateCSV(csvFileIdentifier, csvSchema, csvData, headers) {
   let isValid = true;
 
   // Check headers
-  const headers = header.map((h) => h.toLowerCase());
   const schemaDiff = _.difference(csvSchema.headers.map((h) => h.name.toLowerCase()), headers);
   const fileDiff = _.difference(headers, csvSchema.headers.map((h) => h.name.toLowerCase()));
 

--- a/src/helpers/csvValidator.js
+++ b/src/helpers/csvValidator.js
@@ -3,11 +3,11 @@ const logger = require('./logger');
 
 // Validates csvData against the csvSchema
 // Uses the csvFileIdentifier in logs for readability
-function validateCSV(csvFileIdentifier, csvSchema, csvData) {
+function validateCSV(csvFileIdentifier, csvSchema, csvData, header) {
   let isValid = true;
 
   // Check headers
-  const headers = Object.keys(csvData[0]).map((h) => h.toLowerCase());
+  const headers = header.map((h) => h.toLowerCase());
   const schemaDiff = _.difference(csvSchema.headers.map((h) => h.name.toLowerCase()), headers);
   const fileDiff = _.difference(headers, csvSchema.headers.map((h) => h.name.toLowerCase()));
 
@@ -25,6 +25,10 @@ function validateCSV(csvFileIdentifier, csvSchema, csvData) {
         logger.warn(`Column ${sd} is missing in CSV ${csvFileIdentifier}`);
       }
     });
+  }
+
+  if (csvData.length === 0) {
+    return true;
   }
 
   // Check values

--- a/src/modules/CSVFileModule.js
+++ b/src/modules/CSVFileModule.js
@@ -2,14 +2,16 @@ const fs = require('fs');
 const moment = require('moment');
 const logger = require('../helpers/logger');
 const { validateCSV } = require('../helpers/csvValidator');
-const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
+const { csvParse, stringNormalizer, normalizeEmptyValues, getCSVHeader } = require('../helpers/csvParsingUtils');
 
 class CSVFileModule {
   constructor(csvFilePath, unalterableColumns, parserOptions) {
     // Parse then normalize the data
-    const parsedData = csvParse(fs.readFileSync(csvFilePath), parserOptions);
+    const csvData = fs.readFileSync(csvFilePath);
+    const parsedData = csvParse(csvData, parserOptions);
     this.filePath = csvFilePath;
     this.data = normalizeEmptyValues(parsedData, unalterableColumns);
+    this.header = getCSVHeader(csvData);
   }
 
   async get(key, value, fromDate, toDate) {
@@ -32,7 +34,7 @@ class CSVFileModule {
   async validate(csvSchema) {
     if (csvSchema) {
       logger.info(`Validating CSV file for ${this.filePath}`);
-      return validateCSV(this.filePath, csvSchema, this.data);
+      return validateCSV(this.filePath, csvSchema, this.data, this.header);
     }
     logger.warn(`No CSV schema provided for ${this.filePath}`);
     return true;

--- a/src/modules/CSVURLModule.js
+++ b/src/modules/CSVURLModule.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const moment = require('moment');
 const logger = require('../helpers/logger');
 const { validateCSV } = require('../helpers/csvValidator');
-const { csvParse, stringNormalizer, normalizeEmptyValues } = require('../helpers/csvParsingUtils');
+const { csvParse, stringNormalizer, normalizeEmptyValues, getCSVHeader } = require('../helpers/csvParsingUtils');
 
 class CSVURLModule {
   constructor(url, unalterableColumns, parserOptions) {
@@ -28,6 +28,7 @@ class CSVURLModule {
       const parsedData = csvParse(csvData, this.parserOptions);
       logger.debug('CSV Data parsing successful');
       this.data = normalizeEmptyValues(parsedData, this.unalterableColumns);
+      this.header = getCSVHeader(csvData);
     }
   }
 
@@ -55,7 +56,7 @@ class CSVURLModule {
 
     if (csvSchema) {
       this.data = normalizeEmptyValues(this.data, this.unalterableColumns);
-      return validateCSV(this.url, csvSchema, this.data);
+      return validateCSV(this.url, csvSchema, this.data, this.header);
     }
     logger.warn(`No CSV schema provided for data found at ${this.url}`);
     return true;

--- a/test/helpers/csvValidator.test.js
+++ b/test/helpers/csvValidator.test.js
@@ -83,26 +83,30 @@ const schema = {
 
 describe('csvValidator', () => {
   test('simple data validates', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA)).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA, Object.keys(SIMPLE_DATA[0]))).toBe(true);
   });
 
   test('data missing required value does not validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_REQUIRED_VALUE)).toBe(false);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_REQUIRED_VALUE, Object.keys(SIMPLE_DATA_MISSING_REQUIRED_VALUE[0]))).toBe(false);
   });
 
   test('data missing required header does not validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_HEADER)).toBe(false);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_HEADER, Object.keys(SIMPLE_DATA_MISSING_HEADER[0]))).toBe(false);
   });
 
   test('data with erroneous column should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_EXTRA_COLUMNS)).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_EXTRA_COLUMNS, Object.keys(SIMPLE_DATA_EXTRA_COLUMNS[0]))).toBe(true);
   });
 
   test('data missing an optional column should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_OPTIONAL_COLUMN)).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_OPTIONAL_COLUMN, Object.keys(SIMPLE_DATA_MISSING_OPTIONAL_COLUMN[0]))).toBe(true);
   });
 
   test('data with different casing in the column header should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_DIFFERENT_CASING)).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_DIFFERENT_CASING, Object.keys(SIMPLE_DATA_DIFFERENT_CASING[0]))).toBe(true);
+  });
+
+  test('data with only the header but no rows should still validate', () => {
+    expect(validateCSV('', schema, [], ['header1', 'header2', 'header3'])).toBe(true);
   });
 });

--- a/test/helpers/csvValidator.test.js
+++ b/test/helpers/csvValidator.test.js
@@ -87,23 +87,23 @@ describe('csvValidator', () => {
   });
 
   test('data missing required value does not validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_REQUIRED_VALUE, Object.keys(SIMPLE_DATA_MISSING_REQUIRED_VALUE[0]))).toBe(false);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_REQUIRED_VALUE, Object.keys(SIMPLE_DATA_MISSING_REQUIRED_VALUE[0]).map((h) => h.toLowerCase()))).toBe(false);
   });
 
   test('data missing required header does not validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_HEADER, Object.keys(SIMPLE_DATA_MISSING_HEADER[0]))).toBe(false);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_HEADER, Object.keys(SIMPLE_DATA_MISSING_HEADER[0]).map((h) => h.toLowerCase()))).toBe(false);
   });
 
   test('data with erroneous column should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_EXTRA_COLUMNS, Object.keys(SIMPLE_DATA_EXTRA_COLUMNS[0]))).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_EXTRA_COLUMNS, Object.keys(SIMPLE_DATA_EXTRA_COLUMNS[0]).map((h) => h.toLowerCase()))).toBe(true);
   });
 
   test('data missing an optional column should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_OPTIONAL_COLUMN, Object.keys(SIMPLE_DATA_MISSING_OPTIONAL_COLUMN[0]))).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_MISSING_OPTIONAL_COLUMN, Object.keys(SIMPLE_DATA_MISSING_OPTIONAL_COLUMN[0]).map((h) => h.toLowerCase()))).toBe(true);
   });
 
   test('data with different casing in the column header should still validate', () => {
-    expect(validateCSV('', schema, SIMPLE_DATA_DIFFERENT_CASING, Object.keys(SIMPLE_DATA_DIFFERENT_CASING[0]))).toBe(true);
+    expect(validateCSV('', schema, SIMPLE_DATA_DIFFERENT_CASING, Object.keys(SIMPLE_DATA_DIFFERENT_CASING[0]).map((h) => h.toLowerCase()))).toBe(true);
   });
 
   test('data with only the header but no rows should still validate', () => {


### PR DESCRIPTION
# Summary
This PR modifies the CSV validator function to allow CSVs with the proper header row, but no data to be considered valid. This PR also adds trimming to CSV parsing so excess whitespace in the CSV should be removed on parsing

## New behavior
When a CSV with no data is parsed, the parser returns an empty array, which meant the headers were not passed into the validator and so it would fail. This PR stores the headers separately to be passed into the validator so that even CSVs with no data will be properly validated.

Additionally, the `trim: true` option was added to the default options of the csv parse function, which should allow CSVs with extra whitespace to still work properly (`mrn         ,    familyName...` for example)

## Code changes
- New `getCSVHeader()` function added to `csvParsingUtils.js`, which returns an array of the headers from a CSV file
- `trim: true` added to `DEFAULT_OPTIONS` in `csvParsingUtils.js`
- `validateCSV()` in `csvValidator.js` modified to take headers as an input rather than infer them from `csvData`
- `CSVFileModule.js` and `CSVURLModule.js` modified to save the headers of CSVs they read and passthem as an input to `validateCSV()`
- Tests updated to reflect the above changes

# Testing guidance
- Ensure that extraction still works as expected with unaltered test data
- Add extra whitespace to CSVs and see that it is properly trimmed
- Remove data from CSVs and see that they pass as valid and extraction runs
- Modify CSV to have no data and improper headers and see that it is still properly caught as invalid
