### PR TITLE
Modifying conditions to allow  multiple codes

### DIFF
--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -32,11 +32,11 @@ function formatData(conditionData, patientId) {
       subject: {
         id: patientId,
       },
-      code: {
-        code,
+      code: code.split('|').map((c) => ({
+        code: c,
         system: codeSystem,
         display: displayName,
-      },
+      })),
       category: category.split('|'),
       dateOfDiagnosis: !dateOfDiagnosis ? null : formatDateTime(dateOfDiagnosis),
       clinicalStatus,

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -48,8 +48,7 @@ function categoryArrayTemplate(array) {
 function codingTemplate({ code }) {
   return {
     code: {
-      coding: [coding(code),
-      ],
+      coding: code.map((c) => coding(c)),
     },
   };
 }
@@ -100,7 +99,7 @@ function subjectTemplate({ subject }) {
 function conditionTemplate({
   subject, id, code, category, dateOfDiagnosis, clinicalStatus, verificationStatus, bodySite, laterality, histology,
 }) {
-  if (!(id && subject && code.system && code.code && category)) {
+  if (!(id && subject && code.every((c) => c.system) && code.every((c) => c.code) && category)) {
     throw Error('Trying to render a ConditionTemplate, but a required argument is missing; ensure that id, mrn, code, codesystem, and category are all present');
   }
 

--- a/src/templates/ConditionTemplate.js
+++ b/src/templates/ConditionTemplate.js
@@ -99,7 +99,7 @@ function subjectTemplate({ subject }) {
 function conditionTemplate({
   subject, id, code, category, dateOfDiagnosis, clinicalStatus, verificationStatus, bodySite, laterality, histology,
 }) {
-  if (!(id && subject && code.every((c) => c.system) && code.every((c) => c.code) && category)) {
+  if (!(id && subject && code.every((c) => c.system && c.code) && category)) {
     throw Error('Trying to render a ConditionTemplate, but a required argument is missing; ensure that id, mrn, code, codesystem, and category are all present');
   }
 

--- a/test/templates/condition.test.js
+++ b/test/templates/condition.test.js
@@ -9,11 +9,11 @@ const CONDITION_VALID_DATA = {
   subject: {
     id: 'example-subject-id',
   },
-  code: {
+  code: [{
     system: 'example-system',
     code: 'example-code',
     display: 'exampleDisplayName',
-  },
+  }],
   category: [
     'example-code',
   ],
@@ -33,10 +33,10 @@ const CONDITION_MINIMAL_DATA = {
   subject: {
     id: 'example-subject-id',
   },
-  code: {
+  code: [{
     system: 'example-system',
     code: 'example-code',
-  },
+  }],
   category: [
     'example-code',
   ],
@@ -97,11 +97,11 @@ describe('test Condition template', () => {
       subject: {
         id: 'example-subject-id',
       },
-      code: {
+      code: [{
         system: 'example-system',
         code: 'example-code',
         display: 'exampleDisplayName',
-      },
+      }],
       category: [
         'example-code',
       ],


### PR DESCRIPTION
# Summary
This PR modifies the `CSVConditionExtractor` to accept multiple codes by separating them with a `|` (e.g. `1234|5678`). Adding extra codes will result in extra entries in the coding array of the resulting condition resource.

## New behavior
Multiple condition codes in the csv file, separated by a `|` should result in extra codes in the coding array of the output, all with the same system and display name. This should work for any number of additional codes, but adding `|` without a code (e.g. `123|`) should result in an error

## Code changes
- `CSVConditionExtractor.js` now splits codes into an array and maps them to all have the same system and display
- `ConditionTemplate.js` now takes an array of codes in `codingTemplate()` and maps those to an array in the output
- Tests updated to reflect changes

# Testing guidance
- Ensure that tests pass and extraction still works as expected
- Add extra codes to `condition-information.csv` and see that the output reflects the behavior described above (one code still works as expected, multiple codes results in extra codes in the output, improper use of `|` results in error)
