### PR TITLE
Trimming whitespace and handling empty values for additional condition codes

### DIFF
--- a/src/extractors/CSVConditionExtractor.js
+++ b/src/extractors/CSVConditionExtractor.js
@@ -27,12 +27,16 @@ function formatData(conditionData, patientId) {
     if (!(conditionId && codeSystem && code && category)) {
       throw new Error('The condition is missing an expected attribute. Condition id, code system, code, and category are all required.');
     }
+    const codes = code.split('|').map((c) => c.trim()).filter((c) => c && c !== '');
+    if (codes.length < code.split('|').length) {
+      logger.warn('Delimiter (|) used to indicate multiple condition codes but no additional code provided');
+    }
     return {
       id: conditionId,
       subject: {
         id: patientId,
       },
-      code: code.split('|').map((c) => ({
+      code: codes.map((c) => ({
         code: c,
         system: codeSystem,
         display: displayName,


### PR DESCRIPTION
# Summary

Trims whitespace and better handles empty values when using the `|` delimiter to include multiple condition codes

## New behavior

Whitespace is now trimmed off the split codes so inputs like `123 | 456`, etc, should no longer cause an error. Empty code values resulting from inputs like `|123` or `456|` should now print a warning to the output but still generate a condition resource with the one available condition (previously this would have caused an error and stopped the resource from being generated)

# Testing guidance
- Make sure extraction still works as expected and all tests still pass
- Test that the type of inputs described above work as described and don't cause any errors