### PR TITLE
Adding CSV schemas to remaining CSV extractors

### DIFF
--- a/src/extractors/CSVAdverseEventExtractor.js
+++ b/src/extractors/CSVAdverseEventExtractor.js
@@ -4,6 +4,7 @@ const { getEmptyBundle } = require('../helpers/fhirUtils');
 const { getPatientFromContext } = require('../helpers/contextUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVAdverseEventSchema } = require('../helpers/schemas/csv');
 
 // Formats data to be passed into template-friendly format
 function formatData(adverseEventData, patientId) {
@@ -72,7 +73,7 @@ class CSVAdverseEventExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVAdverseEventSchema, csvParse });
   }
 
   async getAdverseEventData(mrn) {

--- a/src/extractors/CSVCTCAdverseEventExtractor.js
+++ b/src/extractors/CSVCTCAdverseEventExtractor.js
@@ -7,6 +7,7 @@ const { formatDateTime } = require('../helpers/dateUtils');
 const { getDisplayFromConcept } = require('../helpers/valueSetUtils');
 const { ctcAEGradeCodeToTextLookup } = require('../helpers/lookups/ctcAdverseEventLookup');
 const logger = require('../helpers/logger');
+const { CSVCTCAdverseEventSchema } = require('../helpers/schemas/csv');
 
 // Formats data to be passed into template-friendly format
 function formatData(adverseEventData, patientId) {
@@ -112,7 +113,7 @@ class CSVCTCAdverseEventExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCTCAdverseEventSchema, csvParse });
   }
 
   async getAdverseEventData(mrn) {

--- a/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationAdministrationExtractor.js
@@ -4,6 +4,7 @@ const { getPatientFromContext } = require('../helpers/contextUtils');
 const { getEmptyBundle } = require('../helpers/fhirUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVCancerRelatedMedicationAdministrationSchema } = require('../helpers/schemas/csv');
 
 
 function formatData(medicationData, patientId) {
@@ -49,7 +50,7 @@ class CSVCancerRelatedMedicationAdministrationExtractor extends BaseCSVExtractor
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCancerRelatedMedicationAdministrationSchema, csvParse });
   }
 
   async getMedicationData(mrn) {

--- a/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
@@ -4,6 +4,7 @@ const { getPatientFromContext } = require('../helpers/contextUtils');
 const { getEmptyBundle } = require('../helpers/fhirUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVCancerRelatedMedicationRequestSchema } = require('../helpers/schemas/csv');
 
 
 function formatData(medicationData, patientId) {
@@ -51,7 +52,7 @@ class CSVCancerRelatedMedicationRequestExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVCancerRelatedMedicationRequestSchema, csvParse });
   }
 
   async getMedicationData(mrn) {

--- a/src/extractors/CSVObservationExtractor.js
+++ b/src/extractors/CSVObservationExtractor.js
@@ -4,6 +4,7 @@ const { getPatientFromContext } = require('../helpers/contextUtils');
 const { getEmptyBundle } = require('../helpers/fhirUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVObservationSchema } = require('../helpers/schemas/csv');
 
 function formatData(observationData, patientId) {
   logger.debug('Reformatting observation data from CSV into template format');
@@ -45,7 +46,7 @@ class CSVObservationExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVObservationSchema, csvParse });
   }
 
   async getObservationData(mrn) {

--- a/src/extractors/CSVProcedureExtractor.js
+++ b/src/extractors/CSVProcedureExtractor.js
@@ -4,6 +4,7 @@ const { getPatientFromContext } = require('../helpers/contextUtils');
 const { getEmptyBundle } = require('../helpers/fhirUtils');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVProcedureSchema } = require('../helpers/schemas/csv');
 
 // Formats data to be passed into template-friendly format
 function formatData(procedureData, patientId) {
@@ -51,7 +52,7 @@ class CSVProcedureExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVProcedureSchema, csvParse });
   }
 
   async getProcedureData(mrn) {

--- a/src/extractors/CSVStagingExtractor.js
+++ b/src/extractors/CSVStagingExtractor.js
@@ -4,6 +4,7 @@ const { getPatientFromContext } = require('../helpers/contextUtils');
 const { generateMcodeResources } = require('../templates');
 const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
+const { CSVStagingSchema } = require('../helpers/schemas/csv');
 
 function formatTNMCategoryData(stagingData, patientId) {
   logger.debug('Reformatting TNM Category data into template format');
@@ -66,7 +67,7 @@ class CSVStagingExtractor extends BaseCSVExtractor {
   constructor({
     filePath, url, fileName, dataDirectory, csvParse,
   }) {
-    super({ filePath, url, fileName, dataDirectory, csvParse });
+    super({ filePath, url, fileName, dataDirectory, csvSchema: CSVStagingSchema, csvParse });
   }
 
   async getStagingData(mrn) {

--- a/src/helpers/schemas/csv.js
+++ b/src/helpers/schemas/csv.js
@@ -68,4 +68,154 @@ const CSVTreatmentPlanChangeSchema = {
   ],
 };
 
-module.exports = { CSVCancerDiseaseStatusSchema, CSVConditionSchema, CSVPatientSchema, CSVClinicalTrialInformationSchema, CSVTreatmentPlanChangeSchema };
+const CSVStagingSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'conditionId', required: true },
+    { name: 'stageGroup', required: true },
+    { name: 't' },
+    { name: 'n' },
+    { name: 'm' },
+    { name: 'type', required: true },
+    { name: 'stagingSystem' },
+    { name: 'stagingCodeSystem' },
+    { name: 'effectiveDate', required: true },
+  ],
+};
+
+const CSVCancerRelatedMedicationAdministrationSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'medicationId' },
+    { name: 'code', required: true },
+    { name: 'codeSystem', required: true },
+    { name: 'displayText' },
+    { name: 'startDate' },
+    { name: 'endDate' },
+    { name: 'treatmentReasonCode' },
+    { name: 'treatmentReasonCodeSystem' },
+    { name: 'treatmentReasonDisplayText' },
+    { name: 'treatmentIntent' },
+    { name: 'status', required: true },
+  ],
+};
+
+const CSVCancerRelatedMedicationRequestSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'requestId' },
+    { name: 'code', required: true },
+    { name: 'codeSystem', required: true },
+    { name: 'displayText' },
+    { name: 'treatmentReasonCode' },
+    { name: 'treatmentReasonCodeSystem' },
+    { name: 'treatmentReasonDisplayText' },
+    { name: 'procedureIntent' },
+    { name: 'status', required: true },
+    { name: 'intent', required: true },
+    { name: 'authoredOn', required: true },
+    { name: 'requesterId', required: true },
+  ],
+};
+
+const CSVProcedureSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'procedureId', required: true },
+    { name: 'conditionId' },
+    { name: 'status', required: true },
+    { name: 'code', required: true },
+    { name: 'codeSystem', required: true },
+    { name: 'displayName' },
+    { name: 'reasonCode' },
+    { name: 'reasonCodeSystem' },
+    { name: 'reasonDisplayName' },
+    { name: 'effectiveDate', required: true },
+    { name: 'bodySite' },
+    { name: 'laterality' },
+    { name: 'treatmentIntent' },
+  ],
+};
+
+const CSVObservationSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'observationId', required: true },
+    { name: 'status', required: true },
+    { name: 'code', required: true },
+    { name: 'codeSystem', required: true },
+    { name: 'displayName' },
+    { name: 'value', required: true },
+    { name: 'valueCodeSystem' },
+    { name: 'effectiveDate', required: true },
+    { name: 'bodySite' },
+    { name: 'laterality' },
+  ],
+};
+
+const CSVAdverseEventSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'adverseEventId' },
+    { name: 'adverseEventCode', required: true },
+    { name: 'adverseEventCodeSystem' },
+    { name: 'adverseEventDisplayText' },
+    { name: 'suspectedCauseId' },
+    { name: 'suspectedCauseType' },
+    { name: 'seriousness' },
+    { name: 'seriousnessCodeSystem' },
+    { name: 'seriousnessDisplayText' },
+    { name: 'category' },
+    { name: 'categoryCodeSystem' },
+    { name: 'categoryDisplayText' },
+    { name: 'severity' },
+    { name: 'actuality' },
+    { name: 'studyId' },
+    { name: 'effectiveDate', required: true },
+    { name: 'recordedDate' },
+  ],
+};
+
+const CSVCTCAdverseEventSchema = {
+  headers: [
+    { name: 'mrn', required: true },
+    { name: 'adverseEventId' },
+    { name: 'adverseEventCode', required: true },
+    { name: 'adverseEventCodeSystem', required: true },
+    { name: 'adverseEventCodeVersion' },
+    { name: 'adverseEventDisplayText' },
+    { name: 'adverseEventText' },
+    { name: 'suspectedCauseId' },
+    { name: 'suspectedCauseType' },
+    { name: 'seriousness' },
+    { name: 'seriousnessCodeSystem' },
+    { name: 'seriousnessDisplayText' },
+    { name: 'category' },
+    { name: 'categoryCodeSystem' },
+    { name: 'categoryDisplayText' },
+    { name: 'studyId' },
+    { name: 'effectiveDate', required: true },
+    { name: 'recordedDate' },
+    { name: 'grade', required: true },
+    { name: 'expectation' },
+    { name: 'resolvedDate' },
+    { name: 'seriousnessOutcome' },
+    { name: 'actor' },
+    { name: 'functionCode' },
+  ],
+};
+
+module.exports = {
+  CSVCancerDiseaseStatusSchema,
+  CSVConditionSchema,
+  CSVPatientSchema,
+  CSVClinicalTrialInformationSchema,
+  CSVTreatmentPlanChangeSchema,
+  CSVStagingSchema,
+  CSVCancerRelatedMedicationAdministrationSchema,
+  CSVCancerRelatedMedicationRequestSchema,
+  CSVProcedureSchema,
+  CSVObservationSchema,
+  CSVAdverseEventSchema,
+  CSVCTCAdverseEventSchema,
+};


### PR DESCRIPTION
# Summary
Not every extractor had a CSV schema, so this PR adds schemas to those that did not. 

## New behavior
Missing CSV values would previously throw an error during extraction, now all our bases should be covered and we should be able to catch missing required fields in the validation stage and throw an error before extraction.

## Code changes
- `helper/schemas/csv.js` has new schemas for: `CSVStagingExtractor`, `CSVAdverseEventExtractor`, `CSVCTCAdverseEventExtractor`, `CSVCancerRelatedMedicationAdministrationExtractor`, `CSVCancerRelatedMedicationRequestExtractor`, `CSVObservationExtractor`, `CSVProcedureExtractor `
- The above listed extractors now add the proper schema during construction

# Testing guidance
- Make sure that the new schemas properly list all fields and mark the appropriate fields as required
- Make sure extraction still works as expected and missing fields are properly caught during the validation stage