### PR TITLE
Double checking schemas and un-requiring unnecessary required fields

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @julianxcarter @dmendelowitz @dtphelan1
+*   @dmendelowitz

--- a/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
@@ -2,7 +2,6 @@ const { BaseCSVExtractor } = require('./BaseCSVExtractor');
 const { generateMcodeResources } = require('../templates');
 const { getPatientFromContext } = require('../helpers/contextUtils');
 const { getEmptyBundle } = require('../helpers/fhirUtils');
-const { formatDateTime } = require('../helpers/dateUtils');
 const logger = require('../helpers/logger');
 const { CSVCancerRelatedMedicationRequestSchema } = require('../helpers/schemas/csv');
 
@@ -26,8 +25,8 @@ function formatData(medicationData, patientId) {
       requesterid: requesterId,
     } = medication;
 
-    if (!(code && codeSystem && status && intent && requesterId && authoredOn)) {
-      throw new Error('The cancer-related medication request is missing an expected element; code, code system, status, authoredOn, requesterId, and intent are all required values.');
+    if (!(code && codeSystem && status && intent && requesterId)) {
+      throw new Error('The cancer-related medication request is missing an expected element; code, code system, status, requesterId, and intent are all required values.');
     }
 
     return {
@@ -42,7 +41,7 @@ function formatData(medicationData, patientId) {
       procedureIntent,
       status,
       intent,
-      authoredOn: formatDateTime(authoredOn),
+      authoredOn,
       requesterId,
     };
   });

--- a/src/helpers/schemas/csv.js
+++ b/src/helpers/schemas/csv.js
@@ -113,7 +113,7 @@ const CSVCancerRelatedMedicationRequestSchema = {
     { name: 'procedureIntent' },
     { name: 'status', required: true },
     { name: 'intent', required: true },
-    { name: 'authoredOn', required: true },
+    { name: 'authoredOn' },
     { name: 'requesterId', required: true },
   ],
 };

--- a/src/templates/CancerRelatedMedicationRequestTemplate.js
+++ b/src/templates/CancerRelatedMedicationRequestTemplate.js
@@ -7,6 +7,7 @@ const {
   treatmentReasonTemplate,
 } = require('./snippets');
 const { ifAllArgsObj } = require('../helpers/templateUtils');
+const { formatDateTime } = require('../helpers/dateUtils');
 
 function procedureIntentTemplate({ procedureIntent }) {
   return {
@@ -36,9 +37,9 @@ function cancerRelatedMedicationRequestTemplate({
   authoredOn,
   requesterId,
 }) {
-  if (!(subjectId && code && codeSystem && status && intent && requesterId && authoredOn)) {
+  if (!(subjectId && code && codeSystem && status && intent && requesterId)) {
     const e1 = 'Trying to render a CancerRelatedMedicationRequestTemplate, but a required argument is missing; ';
-    const e2 = 'ensure that subjectId, code, codeSystem, intent, requesterId, authoredOn, and status are all present';
+    const e2 = 'ensure that subjectId, code, codeSystem, intent, requesterId, and status are all present';
     throw Error(e1 + e2);
   }
 
@@ -55,7 +56,7 @@ function cancerRelatedMedicationRequestTemplate({
     intent,
     ...medicationTemplate({ code, codeSystem, displayText }),
     ...ifAllArgsObj(subjectTemplate)({ id: subjectId }),
-    authoredOn,
+    ...(authoredOn && { authoredOn: formatDateTime(authoredOn) }),
     ...ifAllArgsObj(requesterTemplate)({ id: requesterId }),
     ...ifAllArgsObj(treatmentReasonTemplate)({ treatmentReasonCode, treatmentReasonCodeSystem, treatmentReasonDisplayText }),
   };

--- a/test/extractors/CSVCancerRelatedMedicationRequestExtractor.test.js
+++ b/test/extractors/CSVCancerRelatedMedicationRequestExtractor.test.js
@@ -35,7 +35,7 @@ expandedExampleBundle.entry.push(exampleCSVMedicationBundle.entry[0]);
 describe('CSVCancerRelatedMedicationRequestExtractor', () => {
   describe('formatData', () => {
     test('should join data appropriately and throw errors when missing required properties', () => {
-      const expectedErrorString = 'The cancer-related medication request is missing an expected element; code, code system, status, authoredOn, requesterId, and intent are all required values.';
+      const expectedErrorString = 'The cancer-related medication request is missing an expected element; code, code system, status, requesterId, and intent are all required values.';
       const localData = _.cloneDeep(exampleCSVMedicationModuleResponse);
       const patientId = getPatientFromContext(MOCK_CONTEXT).id;
 

--- a/test/sample-client-data/cancer-related-medication-request-information.csv
+++ b/test/sample-client-data/cancer-related-medication-request-information.csv
@@ -1,4 +1,4 @@
 mrn,requestId,code,codeSystem,displayText,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,procedureIntent,status,intent,authoredOn,requesterId
 123,requestId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,999000,http://snomed.info/sct,Mixed islet cell and exocrine adenocarcinoma,373808002,active,order,2020-01-01,requester-1
 456,requestId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,915007,http://snomed.info/sct,Malignant melanoma in junctional nevus,373808002,on-hold,proposal,2019-02-02,requester-2
-789,requestId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],900006,http://snomed.info/sct,Mucin-producing adenocarcinoma,363676003,cancelled,plan,2021-06-12,requester-3
+789,requestId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],900006,http://snomed.info/sct,Mucin-producing adenocarcinoma,363676003,cancelled,plan,,requester-3

--- a/test/templates/fixtures/minimal-medication-request.json
+++ b/test/templates/fixtures/minimal-medication-request.json
@@ -19,7 +19,6 @@
     "reference": "urn:uuid:mrn-1",
     "type": "Patient"
   },
-  "authoredOn": "2020-01-01",
   "requester": {
     "reference": "urn:uuid:example-requester"
   }

--- a/test/templates/medicationRequest.test.js
+++ b/test/templates/medicationRequest.test.js
@@ -25,7 +25,7 @@ const REQUEST_MINIMAL_DATA = {
   code: 'example-code',
   codeSystem: 'example-code-system',
   displayText: null,
-  authoredOn: '2020-01-01',
+  authoredOn: null,
   treatmentReasonCode: null,
   treatmentReasonCodeSystem: null,
   treatmentReasonDisplayText: null,


### PR DESCRIPTION
I went through and checked each CSV schema to double check required fields. In the end the only erroneously required field is `authoredOn` in the `CSVCancerRelatedMedicationRequestExtractor`, so I made the necessary changes to make it optional.

As we discussed before there are a number of extractors with `effectiveDate` as a required field, which isn't strictly required by the IG, but we decided was good to have required. I did also consider looking into if we can set them to trigger a soft warning in the validation stage instead of making them totally required, let me know what you think is the best thing to do.

There are also a few fields that we don't require in the schema even though they are required in the IG, but in all of these cases we insert a default value or a data absent reason extension (`actuality` in the `CSVAdverseEventExtractor` for example), so I left those as is.