### PR TITLE
Adding post-extraction filtering

### DIFF
--- a/src/application/app.js
+++ b/src/application/app.js
@@ -5,6 +5,7 @@ const { sendEmailNotification, zipErrors } = require('./tools/emailNotifications
 const { extractDataForPatients } = require('./tools/mcodeExtraction');
 const { parsePatientIds } = require('../helpers/appUtils');
 const { validateConfig } = require('../helpers/configUtils');
+const { postExtractionFilter } = require('../helpers/filterUtils');
 
 function checkInputAndConfig(config, fromDate, toDate) {
   // Check input args and needed config variables based on client being used
@@ -42,6 +43,12 @@ async function mcodeApp(Client, fromDate, toDate, config, pathToRunLogs, debug, 
   // Extract the data
   logger.info(`Extracting data for ${patientIds.length} patients`);
   const { extractedData, successfulExtraction, totalExtractionErrors } = await extractDataForPatients(patientIds, mcodeClient, effectiveFromDate, effectiveToDate);
+
+  // Perform post-extraction processes
+  if (config.postExtractionFilter) {
+    logger.info('Applying post-extraction filter to bundle');
+    postExtractionFilter(extractedData, config.postExtractionFilter);
+  }
 
   // If we have notification information, send an emailNotification
   const { notificationInfo } = config;

--- a/src/helpers/filterUtils.js
+++ b/src/helpers/filterUtils.js
@@ -1,0 +1,16 @@
+const fhirpath = require('fhirpath');
+
+function postExtractionFilter(extractedData, filter) {
+  extractedData.map((bundle) => {
+    const filteredBundle = bundle;
+    filteredBundle.entry = fhirpath.evaluate(
+      bundle,
+      `Bundle.entry.where(${filter})`,
+    );
+    return filteredBundle;
+  });
+}
+
+module.exports = {
+  postExtractionFilter,
+};

--- a/src/helpers/schemas/config.schema.json
+++ b/src/helpers/schemas/config.schema.json
@@ -8,6 +8,10 @@
       "title": "Patient ID CSV File",
       "type": "string"
     },
+    "postExtractionFilter": {
+      "title": "Post-Extraction Filter",
+      "type": "string"
+    },
     "commonExtractorArgs": {
       "$ref": "#/$defs/commonExtractorArgs"
     },

--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ const { parsePatientIds } = require('./helpers/appUtils');
 const { getConfig, validateConfig } = require('./helpers/configUtils');
 const configSchema = require('./helpers/schemas/config.schema.json');
 const { sortExtractors } = require('./helpers/dependencyUtils');
+const { postExtractionFilter } = require('./helpers/filterUtils');
 
 module.exports = {
   // CLI Related utilities
@@ -156,6 +157,7 @@ module.exports = {
   lowercaseLookupQuery,
   mEpochToDate,
   sortExtractors,
+  postExtractionFilter,
   // Context operations
   getConditionEntriesFromContext,
   getConditionsFromContext,


### PR DESCRIPTION
# Summary

This PR adds functionality for filtering the entries in the output bundle after the extraction process has run. This is done by adding a FHIRpath statement to the config file with the new config field: `postExtractionFilter`. For example, adding `resource.resourceType = 'Patient'` will filter the output bundles to just patients or adding something more complicated like `(resource.resourceType = 'Observation' and resource.code.coding.first().code = 'XXXXXX') or (resource.resourceType != 'Observation')` will filter out any observation that don't have the code `XXXXXX`

This is the most general purpose method for filtering I could think of. If we wanted to make it more convenient for users or specific use cases, we could easily add new wrapper functions around this to accomplish specific types of filtering in a way that's easier for users to add to their config files.

# Testing guidance
Add the following to the config file and see that they work as described above:
`"postExtractionFilter": "resource.resourceType = 'Patient'",`
`"postExtractionFilter": "(resource.resourceType = 'Observation' and resource.code.coding.first().code = '21907-1') or (resource.resourceType != 'Observation')",`