### PR TITLE
Adding dose related fields to medication request extractor

### DIFF
--- a/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
+++ b/src/extractors/CSVCancerRelatedMedicationRequestExtractor.js
@@ -23,6 +23,11 @@ function formatData(medicationData, patientId) {
       intent,
       authoredon: authoredOn,
       requesterid: requesterId,
+      dosageroute: dosageRoute,
+      asneededcode: asNeededCode,
+      doseratetype: doseRateType,
+      dosequantityvalue: doseQuantityValue,
+      dosequantityunit: doseQuantityUnit,
     } = medication;
 
     if (!(code && codeSystem && status && intent && requesterId)) {
@@ -43,6 +48,11 @@ function formatData(medicationData, patientId) {
       intent,
       authoredOn,
       requesterId,
+      dosageRoute,
+      asNeededCode,
+      doseRateType,
+      doseQuantityValue,
+      doseQuantityUnit,
     };
   });
 }

--- a/src/helpers/schemas/csv.js
+++ b/src/helpers/schemas/csv.js
@@ -117,6 +117,11 @@ const CSVCancerRelatedMedicationRequestSchema = {
     { name: 'intent', required: true },
     { name: 'authoredOn' },
     { name: 'requesterId', required: true },
+    { name: 'dosageRoute' },
+    { name: 'asNeededCode' },
+    { name: 'doseRateType' },
+    { name: 'doseQuantityValue' },
+    { name: 'doseQuantityUnit' },
   ],
 };
 

--- a/test/extractors/fixtures/csv-medication-request-bundle.json
+++ b/test/extractors/fixtures/csv-medication-request-bundle.json
@@ -36,6 +36,42 @@
             }
           ]
         },
+        "dosageInstruction": [
+          {
+            "route": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "example-route"
+                }
+              ]
+            },
+            "asNeededCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://snomed.info/sct",
+                  "code": "example-asneeded"
+                }
+              ]
+            },
+            "doseAndRate": [
+              {
+                "type": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                      "code": "example-type"
+                    }
+                  ]
+                },
+                "doseQuantity": {
+                  "value": 111,
+                  "unit": "example-unit"
+                }
+              }
+            ]
+          }
+        ],
         "subject": {
           "reference": "urn:uuid:mrn-1",
           "type": "Patient"

--- a/test/extractors/fixtures/csv-medication-request-module-response.json
+++ b/test/extractors/fixtures/csv-medication-request-module-response.json
@@ -12,6 +12,11 @@
     "procedureintent": "example-code",
     "status": "example-status",
     "requesterid": "example-requester",
-    "intent": "example-intent"
+    "intent": "example-intent",
+    "dosageroute": "example-route",
+    "asneededcode": "example-asneeded",
+    "doseratetype": "example-type",
+    "dosequantityvalue": "111",
+    "dosequantityunit": "example-unit"
   }
 ]

--- a/test/sample-client-data/cancer-related-medication-request-information.csv
+++ b/test/sample-client-data/cancer-related-medication-request-information.csv
@@ -1,4 +1,4 @@
-mrn,requestId,code,codeSystem,displayText,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,procedureIntent,status,intent,authoredOn,requesterId
-123,requestId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,999000,http://snomed.info/sct,Mixed islet cell and exocrine adenocarcinoma,373808002,active,order,2020-01-01,requester-1
-456,requestId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,915007,http://snomed.info/sct,Malignant melanoma in junctional nevus,373808002,on-hold,proposal,2019-02-02,requester-2
-789,requestId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],900006,http://snomed.info/sct,Mucin-producing adenocarcinoma,363676003,cancelled,plan,,requester-3
+mrn,requestId,code,codeSystem,displayText,treatmentReasonCode,treatmentReasonCodeSystem,treatmentReasonDisplayText,procedureIntent,status,intent,authoredOn,requesterId,dosageRoute,asNeededCode,doseRateType,doseQuantityValue,doseQuantityUnit
+123,requestId-1,10760,http://www.nlm.nih.gov/research/umls/rxnorm,Triamcinolone Oral Paste,999000,http://snomed.info/sct,Mixed islet cell and exocrine adenocarcinoma,373808002,active,order,2020-01-01,requester-1,26643006,1152001,calculated,100,mg
+456,requestId-2,91318,http://www.nlm.nih.gov/research/umls/rxnorm,Coal Tar Topical Solution,915007,http://snomed.info/sct,Malignant melanoma in junctional nevus,373808002,on-hold,proposal,2019-02-02,requester-2,46713006,1140008,ordered,50,mg
+789,requestId-3,91833,http://www.nlm.nih.gov/research/umls/rxnorm,Vitamin K1 Injectable Solution [Aquamephyton],900006,http://snomed.info/sct,Mucin-producing adenocarcinoma,363676003,cancelled,plan,,requester-3,,,,,

--- a/test/templates/fixtures/maximal-medication-request.json
+++ b/test/templates/fixtures/maximal-medication-request.json
@@ -30,6 +30,42 @@
       }
     ]
   },
+  "dosageInstruction": [
+    {
+      "route": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "example-route"
+          }
+        ]
+      },
+      "asNeededCodeableConcept": {
+        "coding": [
+          {
+            "system": "http://snomed.info/sct",
+            "code": "example-asneeded"
+          }
+        ]
+      },
+      "doseAndRate": [
+        {
+          "type": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/dose-rate-type",
+                "code": "example-type"
+              }
+            ]
+          },
+          "doseQuantity": {
+            "value": 111,
+            "unit": "example-unit"
+          }
+        }
+      ]
+    }
+  ],
   "subject": {
     "reference": "urn:uuid:mrn-1",
     "type": "Patient"

--- a/test/templates/medicationRequest.test.js
+++ b/test/templates/medicationRequest.test.js
@@ -18,6 +18,11 @@ const REQUEST_VALID_DATA = {
   status: 'example-status',
   requesterId: 'example-requester',
   intent: 'example-intent',
+  dosageRoute: 'example-route',
+  asNeededCode: 'example-asneeded',
+  doseRateType: 'example-type',
+  doseQuantityValue: '111',
+  doseQuantityUnit: 'example-unit',
 };
 
 const REQUEST_MINIMAL_DATA = {
@@ -33,6 +38,11 @@ const REQUEST_MINIMAL_DATA = {
   status: 'example-status',
   requesterId: 'example-requester',
   intent: 'example-intent',
+  dosageRoute: null,
+  asNeededCode: null,
+  doseRateType: null,
+  doseQuantityValue: null,
+  doseQuantityUnit: null,
 };
 
 
@@ -50,6 +60,11 @@ const REQUEST_INVALID_DATA = {
   status: null,
   requesterId: 'example-requester',
   intent: 'example-intent',
+  dosageRoute: 'example-route',
+  asNeededCode: 'example-asneeded',
+  doseRateType: 'example-type',
+  doseQuantityValue: '111',
+  doseQuantityUnit: 'example-unit',
 };
 
 describe('test Medication Request template', () => {
@@ -76,6 +91,11 @@ describe('test Medication Request template', () => {
       treatmentReasonCodeSystem: 'example-code-system',
       treatmentReasonDisplayText: 'Example Text',
       procedureIntent: 'example-code',
+      dosageRoute: 'example-route',
+      asNeededCode: 'example-asneeded',
+      doseRateType: 'example-type',
+      doseQuantityValue: '111',
+      doseQuantityUnit: 'example-unit',
     };
 
     const NECESSARY_DATA = {


### PR DESCRIPTION
# Summary
This PR adds necessary CSV fields to the Cancer Related Medication Request Extractor to support the parts of `dosageInstruction` we need, route, dose quantity, type and as needed code. Timing is not included in this PR as we still need to check how we want to implement that field.

# Testing guidance
Run the extractor with the `CSVCancerRelatedMedicationRequestExtractor` and ensure that extraction still runs as expected and the new fields are properly generated