### PR TITLE
Exporting extractor list for use in other clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4060,7 +4060,7 @@
     },
     "fhir-mapper": {
       "version": "git+https://github.com/standardhealth/fhir-mapper.git#531dcdb9d4673b14aa4fafe8eccfcdeaa1dd370e",
-      "from": "git+https://github.com/standardhealth/fhir-mapper.git",
+      "from": "git+https://github.com/standardhealth/fhir-mapper.git#old-fhirpath",
       "requires": {
         "crypto": "^1.0.1",
         "fhirpath": "^0.10.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "commander": "^6.2.0",
     "csv-parse": "^4.8.8",
     "fhir-crud-client": "^1.2.2",
-    "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git",
+    "fhir-mapper": "git+https://github.com/standardhealth/fhir-mapper.git#old-fhirpath",
     "fhirpath": "2.1.5",
     "lodash": "^4.17.21",
     "moment": "^2.29.4",

--- a/src/client/MCODEClient.js
+++ b/src/client/MCODEClient.js
@@ -1,82 +1,13 @@
 const { BaseClient } = require('./BaseClient');
-const {
-  CSVAdverseEventExtractor,
-  CSVAppointmentExtractor,
-  CSVCancerDiseaseStatusExtractor,
-  CSVCancerRelatedMedicationAdministrationExtractor,
-  CSVCancerRelatedMedicationRequestExtractor,
-  CSVClinicalTrialInformationExtractor,
-  CSVConditionExtractor,
-  CSVCTCAdverseEventExtractor,
-  CSVEncounterExtractor,
-  CSVObservationExtractor,
-  CSVPatientExtractor,
-  CSVProcedureExtractor,
-  CSVStagingExtractor,
-  CSVTreatmentPlanChangeExtractor,
-  FHIRAdverseEventExtractor,
-  FHIRAllergyIntoleranceExtractor,
-  FHIRConditionExtractor,
-  FHIRDocumentReferenceExtractor,
-  FHIREncounterExtractor,
-  FHIRMedicationOrderExtractor,
-  FHIRMedicationRequestExtractor,
-  FHIRMedicationStatementExtractor,
-  FHIRObservationExtractor,
-  FHIRPatientExtractor,
-  FHIRProcedureExtractor,
-} = require('../extractors');
+const { allExtractors, dependencyInfo } = require('../extractors');
 const { sortExtractors } = require('../helpers/dependencyUtils.js');
 
 class MCODEClient extends BaseClient {
   constructor({ extractors, commonExtractorArgs, webServiceAuthConfig }) {
     super();
-    this.registerExtractors(
-      CSVAdverseEventExtractor,
-      CSVAppointmentExtractor,
-      CSVCancerDiseaseStatusExtractor,
-      CSVCancerRelatedMedicationAdministrationExtractor,
-      CSVCancerRelatedMedicationRequestExtractor,
-      CSVClinicalTrialInformationExtractor,
-      CSVConditionExtractor,
-      CSVCTCAdverseEventExtractor,
-      CSVEncounterExtractor,
-      CSVObservationExtractor,
-      CSVPatientExtractor,
-      CSVProcedureExtractor,
-      CSVStagingExtractor,
-      CSVTreatmentPlanChangeExtractor,
-      FHIRAdverseEventExtractor,
-      FHIRAllergyIntoleranceExtractor,
-      FHIRConditionExtractor,
-      FHIRDocumentReferenceExtractor,
-      FHIREncounterExtractor,
-      FHIRMedicationOrderExtractor,
-      FHIRMedicationRequestExtractor,
-      FHIRMedicationStatementExtractor,
-      FHIRObservationExtractor,
-      FHIRPatientExtractor,
-      FHIRProcedureExtractor,
-    );
+    this.registerExtractors(...allExtractors);
     // Store the extractors defined by the configuration file as local state
     this.extractorConfig = extractors;
-    // Define information about the order and dependencies of extractors
-    const dependencyInfo = [
-      { type: 'CSVPatientExtractor', dependencies: [] },
-      { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerDiseaseStatusExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVClinicalTrialInformationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVTreatmentPlanChangeExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVStagingExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerRelatedMedicationAdministrationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCancerRelatedMedicationRequestExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVProcedureExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVObservationExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVCTCAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVEncounterExtractor', dependencies: ['CSVPatientExtractor'] },
-      { type: 'CSVAppointmentExtractor', dependencies: ['CSVPatientExtractor'] },
-    ];
     // Sort extractors based on order and dependencies
     this.extractorConfig = sortExtractors(this.extractorConfig, dependencyInfo);
     // Store webServiceAuthConfig if provided`

--- a/src/extractors/index.js
+++ b/src/extractors/index.js
@@ -28,7 +28,73 @@ const { FHIRPatientExtractor } = require('./FHIRPatientExtractor');
 const { FHIRProcedureExtractor } = require('./FHIRProcedureExtractor');
 const { MCODESurgicalProcedureExtractor } = require('./MCODESurgicalProcedureExtractor');
 
+// Define information about the order and dependencies of extractors
+const dependencyInfo = [
+  { type: 'CSVPatientExtractor', dependencies: [] },
+  { type: 'CSVConditionExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVCancerDiseaseStatusExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVClinicalTrialInformationExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVTreatmentPlanChangeExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVStagingExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVCancerRelatedMedicationAdministrationExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVCancerRelatedMedicationRequestExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVProcedureExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVObservationExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVCTCAdverseEventExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVEncounterExtractor', dependencies: ['CSVPatientExtractor'] },
+  { type: 'CSVAppointmentExtractor', dependencies: ['CSVPatientExtractor'] },
+];
+
+const CSVExtractors = [
+  CSVAdverseEventExtractor,
+  CSVAppointmentExtractor,
+  CSVCancerDiseaseStatusExtractor,
+  CSVCancerRelatedMedicationAdministrationExtractor,
+  CSVCancerRelatedMedicationRequestExtractor,
+  CSVClinicalTrialInformationExtractor,
+  CSVConditionExtractor,
+  CSVCTCAdverseEventExtractor,
+  CSVEncounterExtractor,
+  CSVObservationExtractor,
+  CSVPatientExtractor,
+  CSVProcedureExtractor,
+  CSVStagingExtractor,
+  CSVTreatmentPlanChangeExtractor,
+];
+
+const allExtractors = [
+  CSVAdverseEventExtractor,
+  CSVAppointmentExtractor,
+  CSVCancerDiseaseStatusExtractor,
+  CSVCancerRelatedMedicationAdministrationExtractor,
+  CSVCancerRelatedMedicationRequestExtractor,
+  CSVClinicalTrialInformationExtractor,
+  CSVConditionExtractor,
+  CSVCTCAdverseEventExtractor,
+  CSVEncounterExtractor,
+  CSVObservationExtractor,
+  CSVPatientExtractor,
+  CSVProcedureExtractor,
+  CSVStagingExtractor,
+  CSVTreatmentPlanChangeExtractor,
+  FHIRAdverseEventExtractor,
+  FHIRAllergyIntoleranceExtractor,
+  FHIRConditionExtractor,
+  FHIRDocumentReferenceExtractor,
+  FHIREncounterExtractor,
+  FHIRMedicationOrderExtractor,
+  FHIRMedicationRequestExtractor,
+  FHIRMedicationStatementExtractor,
+  FHIRObservationExtractor,
+  FHIRPatientExtractor,
+  FHIRProcedureExtractor,
+];
+
 module.exports = {
+  allExtractors,
+  CSVExtractors,
+  dependencyInfo,
   BaseCSVExtractor,
   BaseFHIRExtractor,
   CSVAdverseEventExtractor,

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ const {
   zipErrors,
 } = require('./application');
 const {
+  allExtractors,
+  CSVExtractors,
+  dependencyInfo,
   BaseFHIRExtractor,
   CSVAdverseEventExtractor,
   CSVAppointmentExtractor,
@@ -92,6 +95,9 @@ module.exports = {
   getConfig,
   validateConfig,
   // Extractors and Clients
+  allExtractors,
+  CSVExtractors,
+  dependencyInfo,
   BaseClient,
   BaseFHIRExtractor,
   BaseFHIRModule,


### PR DESCRIPTION
# Summary
Exporting a list of extractors to be used in the base ICARE client. This should make it easier to keep the different clients in line when we add new extractors.